### PR TITLE
feat: add `--ignore-file` command line flag

### DIFF
--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -100,6 +100,11 @@ pub struct LocalSourceFilterOptions {
     #[cfg_attr(feature = "merge", merge(strategy = merge::bool::overwrite_false))]
     pub no_require_git: bool,
 
+    /// Treat the provided filename like a .gitignore file (can be specified multiple times)
+    #[cfg_attr(feature = "clap", clap(long, value_name = "FILE"))]
+    #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    pub ignore_file: Vec<String>,
+
     /// Exclude contents of directories containing this filename (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long, value_name = "FILE"))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
@@ -184,6 +189,10 @@ impl LocalSource {
                     .add(line)
                     .map_err(IgnoreErrorKind::GenericError)?;
             }
+        }
+
+        for file in &filter_opts.ignore_file {
+            _ = walk_builder.add_custom_ignore_filename(file);
         }
 
         _ = walk_builder


### PR DESCRIPTION
This adds the `--ignore-file` command line option to treat each listed file like a `.gitignore`. This is distinct from the `--exclude-file` option, since it uses the walk builder and thus will match the filename even in subdirectories.

The name of the flag could be changed - as it stands, I don't think it's very clear from a glance what the difference between this flag and `--exclude-file` is - but this name seems like a good enough choice for now.

Closes rustic-rs/rustic#832.