### PR TITLE
backup: run size scanning parallel to backup; add no-scan option

### DIFF
--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -1,5 +1,4 @@
 //! Module for backend related functionality.
-
 pub(crate) mod cache;
 pub(crate) mod decrypt;
 pub(crate) mod dry_run;
@@ -371,7 +370,7 @@ pub struct ReadSourceEntry<O> {
 /// Trait for backends that can read and open sources.
 /// This trait is implemented by all backends that can read data and open from a source.
 pub trait ReadSourceOpen {
-    /// The type of the reader.
+    /// The Reader used for this source
     type Reader: Read + Send + 'static;
 
     /// Opens the source.
@@ -381,18 +380,17 @@ pub trait ReadSourceOpen {
 /// Trait for backends that can read from a source.
 ///
 /// This trait is implemented by all backends that can read data from a source.
-pub trait ReadSource {
-    /// The type of the open information.
+pub trait ReadSource: Sync + Send {
+    /// The type used to handle open source files
     type Open: ReadSourceOpen;
-
-    /// The type of the iterator over the entries.
+    /// The iterator we use to iterate over the source entries
     type Iter: Iterator<Item = RusticResult<ReadSourceEntry<Self::Open>>>;
 
     /// Returns the size of the source.
     fn size(&self) -> RusticResult<Option<u64>>;
 
     /// Returns an iterator over the entries of the source.
-    fn entries(self) -> Self::Iter;
+    fn entries(&self) -> Self::Iter;
 }
 
 /// Trait for backends that can write to a source.

--- a/crates/core/src/backend/stdin.rs
+++ b/crates/core/src/backend/stdin.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// The `StdinSource` is a `ReadSource` for stdin.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StdinSource {
     /// Whether we have already yielded the stdin entry.
     finished: bool,
@@ -53,8 +53,8 @@ impl ReadSource for StdinSource {
     }
 
     /// Returns an iterator over the source.
-    fn entries(self) -> Self::Iter {
-        self
+    fn entries(&self) -> Self::Iter {
+        self.clone()
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -173,7 +173,8 @@ pub use crate::{
         ignore::{LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions},
         local_destination::LocalDestination,
         node::last_modified_node,
-        FileType, ReadBackend, ReadSourceEntry, RepositoryBackends, WriteBackend, ALL_FILE_TYPES,
+        FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen, RepositoryBackends,
+        WriteBackend, ALL_FILE_TYPES,
     },
     blob::tree::TreeStreamerOptions as LsOptions,
     commands::{


### PR DESCRIPTION
Breaking change: This removes the `impl Iterator` from `LocalSource`. To still be able to iterate over its entries, the `ReadSource` trait (and its `entries()` method) is now public.

The neccessary change for rustic is in https://github.com/rustic-rs/rustic/pull/966

closes  https://github.com/rustic-rs/rustic/issues/689

This PR is based on #73 which should be merged first