### PR TITLE
backend: Add sftp backend

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -31,7 +31,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["opendal", "s3", "rest", "rclone"]
+default = ["opendal", "s3", "sftp", "rest", "rclone"]
 cli = ["merge", "clap"]
 merge = ["dep:merge"]
 clap = ["dep:clap"]
@@ -39,6 +39,8 @@ s3 = ["opendal"]
 opendal = ["dep:opendal", "dep:rayon", "dep:tokio", "tokio/rt-multi-thread"]
 rest = ["dep:reqwest", "dep:backoff"]
 rclone = ["rest", "dep:rand"]
+# Note: sftp is not yet supported on windows, see below
+sftp = ["opendal"]
 
 [dependencies]
 # core

--- a/crates/backend/src/choose.rs
+++ b/crates/backend/src/choose.rs
@@ -16,6 +16,9 @@ use crate::{
 #[cfg(feature = "s3")]
 use crate::opendal::s3::S3Backend;
 
+#[cfg(all(unix, feature = "sftp"))]
+use crate::opendal::sftp::SftpBackend;
+
 #[cfg(feature = "opendal")]
 use crate::opendal::OpenDALBackend;
 
@@ -159,6 +162,11 @@ pub enum SupportedBackend {
     /// An openDAL S3 backend
     #[strum(serialize = "s3", to_string = "S3 Backend")]
     S3,
+
+    #[cfg(all(unix, feature = "sftp"))]
+    /// An openDAL sftp backend
+    #[strum(serialize = "sftp", to_string = "sftp Backend")]
+    Sftp,
 }
 
 impl BackendChoice for SupportedBackend {
@@ -179,6 +187,8 @@ impl BackendChoice for SupportedBackend {
             Self::OpenDAL => Arc::new(OpenDALBackend::new(location, options)?),
             #[cfg(feature = "s3")]
             Self::S3 => Arc::new(S3Backend::new(location, options)?),
+            #[cfg(all(unix, feature = "sftp"))]
+            Self::Sftp => Arc::new(SftpBackend::new(location, options)?),
         })
     }
 }

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -15,6 +15,9 @@ pub use crate::{
     local::LocalBackend,
 };
 
+#[cfg(all(unix, feature = "sftp"))]
+pub use crate::opendal::sftp::SftpBackend;
+
 #[cfg(feature = "s3")]
 pub use crate::opendal::s3::S3Backend;
 

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "s3")]
 pub mod s3;
+#[cfg(all(unix, feature = "sftp"))]
+pub mod sftp;
 
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::OnceLock};
 

--- a/crates/backend/src/opendal/sftp.rs
+++ b/crates/backend/src/opendal/sftp.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use url::{self, Url};
+
+use crate::opendal::OpenDALBackend;
+use bytes::Bytes;
+use rustic_core::{FileType, Id, ReadBackend, WriteBackend};
+
+#[derive(Clone, Debug)]
+pub struct SftpBackend(OpenDALBackend);
+
+impl ReadBackend for SftpBackend {
+    fn location(&self) -> String {
+        self.0.location()
+    }
+
+    fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
+        self.0.list(tpe)
+    }
+
+    fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        self.0.list_with_size(tpe)
+    }
+
+    fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
+        self.0.read_full(tpe, id)
+    }
+
+    fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Bytes> {
+        self.0.read_partial(tpe, id, cacheable, offset, length)
+    }
+}
+
+impl WriteBackend for SftpBackend {
+    fn create(&self) -> Result<()> {
+        self.0.create()
+    }
+
+    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
+        self.0.write_bytes(tpe, id, cacheable, buf)
+    }
+
+    fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+        self.0.remove(tpe, id, cacheable)
+    }
+}
+
+impl SftpBackend {
+    /// Create a new S3 backend.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the s3 bucket
+    /// * `options` - Additional options for the s3 backend
+    ///
+    /// # Notes
+    ///
+    /// The path should be something like "`https://s3.amazonaws.com/bucket/my/repopath`"
+    pub fn new(path: impl AsRef<str>, mut options: HashMap<String, String>) -> Result<Self> {
+        let url = Url::parse(&("sftp://".to_string() + path.as_ref()))?;
+
+        let user = url.username();
+        if !user.is_empty() {
+            _ = options
+                .entry("user".to_string())
+                .or_insert_with(|| user.to_string());
+        }
+        if let Some(host) = url.host() {
+            _ = options
+                .entry("endpoint".to_string())
+                .or_insert_with(|| host.to_string());
+        }
+        _ = options
+            .entry("root".to_string())
+            .or_insert_with(|| url.path().to_string());
+
+        Ok(Self(OpenDALBackend::new("sftp", options)?))
+    }
+
+    pub fn to_inner(self) -> OpenDALBackend {
+        self.0
+    }
+}


### PR DESCRIPTION
Note that sftp in opendal is currently only supported on unix, see https://github.com/apache/incubator-opendal/issues/2963