### PR TITLE
use BTreeMap instead of HashMap to save memory

### DIFF
--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    collections::{BinaryHeap, HashSet},
+    collections::{BTreeSet, BinaryHeap},
     ffi::{OsStr, OsString},
     mem,
     path::{Component, Path, PathBuf, Prefix},
@@ -445,7 +445,7 @@ where
 #[derive(Debug)]
 pub struct TreeStreamerOnce<P> {
     /// The visited tree IDs
-    visited: HashSet<Id>,
+    visited: BTreeSet<Id>,
     /// The queue to send tree IDs to
     queue_in: Option<Sender<(PathBuf, Id, usize)>>,
     /// The queue to receive trees from
@@ -504,7 +504,7 @@ impl<P: Progress> TreeStreamerOnce<P> {
 
         let counter = vec![0; ids.len()];
         let mut streamer = Self {
-            visited: HashSet::new(),
+            visited: BTreeSet::new(),
             queue_in: Some(in_tx),
             queue_out: out_rx,
             p,

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -2,7 +2,7 @@
 use derive_setters::Setters;
 use log::{info, warn};
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     backend::{
@@ -67,8 +67,8 @@ enum Changed {
 
 #[derive(Default)]
 struct RepairState {
-    replaced: HashMap<Id, (Changed, Id)>,
-    seen: HashSet<Id>,
+    replaced: BTreeMap<Id, (Changed, Id)>,
+    seen: BTreeSet<Id>,
     delete: Vec<Id>,
 }
 

--- a/crates/core/src/index/indexer.rs
+++ b/crates/core/src/index/indexer.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::BTreeSet,
     sync::{Arc, RwLock},
     time::SystemTime,
 };
@@ -37,7 +37,7 @@ where
     /// The time the indexer was created.
     created: SystemTime,
     /// The set of indexed blob ids.
-    indexed: Option<HashSet<Id>>,
+    indexed: Option<BTreeSet<Id>>,
 }
 
 impl<BE: DecryptWriteBackend> Indexer<BE> {
@@ -56,7 +56,7 @@ impl<BE: DecryptWriteBackend> Indexer<BE> {
             file: IndexFile::default(),
             count: 0,
             created: SystemTime::now(),
-            indexed: Some(HashSet::new()),
+            indexed: Some(BTreeSet::new()),
         }
     }
 


### PR DESCRIPTION
I did some tests comparing `HashMap`/`HashSet` and `BTreeMap`/`BTreeSet` with respect to memory usage using `/bin/time`:

Using `Vec<Id>` and inserting 10 mio entries:
0.34user 0.14system 0:00.48elapsed 99%CPU (0avgtext+0avgdata 315008maxresident)k
-> this is quite expected as `Id` is 32 bytes each.

Using `BTreeSet<Id>` and inserting 10 mio entries:
7.41user 0.31system 0:07.73elapsed 99%CPU (0avgtext+0avgdata 517376maxresident)k
-> this is 60% memory overhead compared to the optimal `Vec` case.

Using `HashSet<Id>` and inserting 10 mio entries:
2.27user 0.40system 0:02.68elapsed 99%CPU (0avgtext+0avgdata 813576maxresident)k
-> this is 150% memory overhead compared to the optimal `Vec` case.

N.B.: Yes, inserting into `BTreeSet` is over 3x more expensive w.r.t. to execution time, but with 10 mio entries, we talk about rustic processes with minutes or even hours total processing time - the additional 5s would be quite irrelevant.

Based on these results, I propose to change HashMaps/HashSets  which potentially save (many) Ids into BTreeMaps/BTreeSets.