### PR TITLE
fix: updated msrv and fix clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.71.1"
+rust-version = "1.72.0"
 
 [workspace.dependencies]
 aho-corasick = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.71.1`.
+This crate's minimum supported `rustc` version is `1.72.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/backend/README.md
+++ b/crates/backend/README.md
@@ -100,7 +100,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.71.1`.
+This crate's minimum supported `rustc` version is `1.72.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -215,7 +215,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.71.1`.
+This crate's minimum supported `rustc` version is `1.72.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/core/src/blob.rs
+++ b/crates/core/src/blob.rs
@@ -40,7 +40,7 @@ impl BlobType {
 
 pub type BlobTypeMap<T> = EnumMap<BlobType, T>;
 
-/// Initialize is a new trait to define the method init() for a [`BlobTypeMap`]
+/// Initialize is a new trait to define the method `init()` for a [`BlobTypeMap`]
 pub trait Initialize<T: Default + Sized> {
     /// Initialize a [`BlobTypeMap`] by processing a given function for each [`BlobType`]
     fn init<F: FnMut(BlobType) -> T>(init: F) -> BlobTypeMap<T>;


### PR DESCRIPTION
`ahash` bumped their MSRV, we also bump ours now so other PRs are unblocked from CI failing.