### PR TITLE
feat: Add Repository::lock_repo

### DIFF
--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -358,7 +358,15 @@ pub trait WriteBackend: ReadBackend {
     /// If the file could not be read.
     fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
         debug!("no locking implemented. {tpe:?}, {id}, {until:?}");
-        Ok(())
+
+        if self.can_lock() {
+            unimplemented!("Using default implementation. No locking implemented in backend.");
+        } else {
+            Err(RusticError::new(
+                ErrorKind::Backend,
+                "No locking configured on backend.",
+            ))
+        }
     }
 }
 

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -6,6 +6,7 @@ pub(crate) mod dry_run;
 pub(crate) mod hotcold;
 pub(crate) mod ignore;
 pub(crate) mod local_destination;
+pub(crate) mod lock;
 pub(crate) mod node;
 pub(crate) mod stdin;
 pub(crate) mod warm_up;
@@ -13,8 +14,9 @@ pub(crate) mod warm_up;
 use std::{io::Read, ops::Deref, path::PathBuf, sync::Arc};
 
 use bytes::Bytes;
+use chrono::{DateTime, Local};
 use enum_map::Enum;
-use log::trace;
+use log::{debug, trace};
 
 #[cfg(test)]
 use mockall::mock;
@@ -337,6 +339,27 @@ pub trait WriteBackend: ReadBackend {
     ///
     /// The result of the removal.
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()>;
+
+    /// Specify if the backend is able to lock files
+    fn can_lock(&self) -> bool {
+        false
+    }
+
+    /// Lock the given file.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The id of the file.
+    /// * `until` - The date until when to lock. May be `None` which usually specifies a unlimited lock
+    ///
+    /// # Errors
+    ///
+    /// If the file could not be read.
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        debug!("no locking implemented. {tpe:?}, {id}, {until:?}");
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -373,6 +396,12 @@ impl WriteBackend for Arc<dyn WriteBackend> {
     }
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {
         self.deref().remove(tpe, id, cacheable)
+    }
+    fn can_lock(&self) -> bool {
+        self.deref().can_lock()
+    }
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        self.deref().lock(tpe, id, until)
     }
 }
 

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -233,6 +233,13 @@ impl WriteBackend for CachedBackend {
     }
 
     fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        if !self.can_lock() {
+            return Err(RusticError::new(
+                ErrorKind::Backend,
+                "No locking configured on backend.",
+            ));
+        }
+
         self.be.lock(tpe, id, until)
     }
 }

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use chrono::{DateTime, Local};
 use dirs::cache_dir;
 use log::{trace, warn};
 use walkdir::WalkDir;
@@ -225,6 +226,14 @@ impl WriteBackend for CachedBackend {
             }
         }
         self.be.remove(tpe, id, cacheable)
+    }
+
+    fn can_lock(&self) -> bool {
+        self.be.can_lock()
+    }
+
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        self.be.lock(tpe, id, until)
     }
 }
 

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -643,6 +643,13 @@ impl<C: CryptoKey> WriteBackend for DecryptBackend<C> {
     }
 
     fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        if !self.can_lock() {
+            return Err(RusticError::new(
+                ErrorKind::Backend,
+                "No locking configured on backend.",
+            ));
+        }
+
         self.be.lock(tpe, id, until)
     }
 }

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -1,6 +1,7 @@
 use std::{num::NonZeroU32, sync::Arc};
 
 use bytes::Bytes;
+use chrono::{DateTime, Local};
 use crossbeam_channel::{Receiver, unbounded};
 use rayon::prelude::*;
 use zstd::stream::{copy_encode, decode_all, encode_all};
@@ -635,6 +636,14 @@ impl<C: CryptoKey> WriteBackend for DecryptBackend<C> {
 
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {
         self.be.remove(tpe, id, cacheable)
+    }
+
+    fn can_lock(&self) -> bool {
+        self.be.can_lock()
+    }
+
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        self.be.lock(tpe, id, until)
     }
 }
 

--- a/crates/core/src/backend/dry_run.rs
+++ b/crates/core/src/backend/dry_run.rs
@@ -171,6 +171,12 @@ impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
     }
 
     fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        if !self.can_lock() {
+            return Err(RusticError::new(
+                ErrorKind::Backend,
+                "No locking configured on backend.",
+            ));
+        }
         self.be.lock(tpe, id, until)
     }
 }

--- a/crates/core/src/backend/dry_run.rs
+++ b/crates/core/src/backend/dry_run.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use chrono::{DateTime, Local};
 use zstd::decode_all;
 
 use crate::{
@@ -163,5 +164,13 @@ impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
         } else {
             self.be.remove(tpe, id, cacheable)
         }
+    }
+
+    fn can_lock(&self) -> bool {
+        self.be.can_lock()
+    }
+
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        self.be.lock(tpe, id, until)
     }
 }

--- a/crates/core/src/backend/hotcold.rs
+++ b/crates/core/src/backend/hotcold.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Local};
 
 use crate::{
+    ErrorKind, RusticError,
     backend::{FileType, ReadBackend, WriteBackend},
     error::RusticResult,
     id::Id,
@@ -105,6 +106,12 @@ impl WriteBackend for HotColdBackend {
     }
 
     fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        if !self.can_lock() {
+            return Err(RusticError::new(
+                ErrorKind::Backend,
+                "No locking configured on backend.",
+            ));
+        }
         self.be.lock(tpe, id, until)
     }
 }

--- a/crates/core/src/backend/hotcold.rs
+++ b/crates/core/src/backend/hotcold.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use chrono::{DateTime, Local};
 
 use crate::{
     backend::{FileType, ReadBackend, WriteBackend},
@@ -97,5 +98,13 @@ impl WriteBackend for HotColdBackend {
             self.be_hot.remove(tpe, id, cacheable)?;
         }
         Ok(())
+    }
+
+    fn can_lock(&self) -> bool {
+        self.be.can_lock()
+    }
+
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        self.be.lock(tpe, id, until)
     }
 }

--- a/crates/core/src/backend/lock.rs
+++ b/crates/core/src/backend/lock.rs
@@ -1,0 +1,123 @@
+use std::{process::Command, sync::Arc};
+
+use bytes::Bytes;
+use chrono::{DateTime, Local};
+use log::{debug, warn};
+
+use crate::{
+    CommandInput, ErrorKind, RusticError, RusticResult,
+    backend::{FileType, ReadBackend, WriteBackend},
+    id::Id,
+};
+
+/// A backend which warms up files by simply accessing them.
+#[derive(Clone, Debug)]
+pub struct LockBackend {
+    /// The backend to use.
+    be: Arc<dyn WriteBackend>,
+    /// The command to be called to lock files in the backend
+    command: CommandInput,
+}
+
+impl LockBackend {
+    /// Creates a new `WarmUpAccessBackend`.
+    ///
+    /// # Arguments
+    ///
+    /// * `be` - The backend to use.
+    pub fn new_lock(be: Arc<dyn WriteBackend>, command: CommandInput) -> Arc<dyn WriteBackend> {
+        Arc::new(Self { be, command })
+    }
+}
+
+impl ReadBackend for LockBackend {
+    fn location(&self) -> String {
+        self.be.location()
+    }
+
+    fn list_with_size(&self, tpe: FileType) -> RusticResult<Vec<(Id, u32)>> {
+        self.be.list_with_size(tpe)
+    }
+
+    fn read_full(&self, tpe: FileType, id: &Id) -> RusticResult<Bytes> {
+        self.be.read_full(tpe, id)
+    }
+
+    fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> RusticResult<Bytes> {
+        self.be.read_partial(tpe, id, cacheable, offset, length)
+    }
+
+    fn list(&self, tpe: FileType) -> RusticResult<Vec<Id>> {
+        self.be.list(tpe)
+    }
+
+    fn needs_warm_up(&self) -> bool {
+        self.be.needs_warm_up()
+    }
+
+    fn warm_up(&self, tpe: FileType, id: &Id) -> RusticResult<()> {
+        self.be.warm_up(tpe, id)
+    }
+}
+
+fn path(tpe: FileType, id: &Id) -> String {
+    let hex_id = id.to_hex();
+    match tpe {
+        FileType::Config => "config".into(),
+        FileType::Pack => format!("data/{}/{}", &hex_id[0..2], &*hex_id),
+        _ => format!("{}/{}", tpe.dirname(), &*hex_id),
+    }
+}
+
+impl WriteBackend for LockBackend {
+    fn create(&self) -> RusticResult<()> {
+        self.be.create()
+    }
+
+    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
+        self.be.write_bytes(tpe, id, cacheable, buf)
+    }
+
+    fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {
+        self.be.remove(tpe, id, cacheable)
+    }
+
+    fn can_lock(&self) -> bool {
+        true
+    }
+
+    fn lock(&self, tpe: FileType, id: &Id, until: Option<DateTime<Local>>) -> RusticResult<()> {
+        let until = until.map_or_else(String::new, |u| u.to_rfc3339());
+        let path = path(tpe, id);
+        let args = self.command.args().iter().map(|c| {
+            c.replace("%id", &id.to_hex())
+                .replace("%type", tpe.dirname())
+                .replace("%path", &path)
+                .replace("%until", &until)
+        });
+        debug!("calling {:?}...", self.command);
+        let status = Command::new(self.command.command())
+            .args(args)
+            .status()
+            .map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "error calling lock command for {tpe}, id: {id}.",
+                    err,
+                )
+                .attach_context("tpe", tpe.to_string())
+                .attach_context("id", id.to_string())
+            })?;
+        if !status.success() {
+            warn!("lock command was not successful for {tpe:?}, id: {id}. {status}");
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/commands.rs
+++ b/crates/core/src/commands.rs
@@ -12,6 +12,7 @@ pub mod dump;
 pub mod forget;
 pub mod init;
 pub mod key;
+pub mod lock;
 pub mod merge;
 pub mod prune;
 /// The `repair` command.

--- a/crates/core/src/commands/lock.rs
+++ b/crates/core/src/commands/lock.rs
@@ -1,0 +1,84 @@
+//! `lock` subcommand
+
+use chrono::{DateTime, Local};
+use log::error;
+use rayon::ThreadPoolBuilder;
+
+use crate::{
+    ErrorKind, RusticError, WriteBackend,
+    error::RusticResult,
+    progress::{Progress, ProgressBars},
+    repofile::{IndexId, KeyId, PackId, RepoId, SnapshotId, configfile::ConfigId},
+    repository::Repository,
+};
+
+pub(super) mod constants {
+    /// The maximum number of reader threads to use for locking.
+    pub(super) const MAX_LOCKER_THREADS_NUM: usize = 20;
+}
+
+pub fn lock_repo<P: ProgressBars, S>(
+    repo: &Repository<P, S>,
+    until: Option<DateTime<Local>>,
+) -> RusticResult<()> {
+    lock_all_files::<P, S, ConfigId>(repo, until)?;
+    lock_all_files::<P, S, KeyId>(repo, until)?;
+    lock_all_files::<P, S, SnapshotId>(repo, until)?;
+    lock_all_files::<P, S, IndexId>(repo, until)?;
+    lock_all_files::<P, S, PackId>(repo, until)?;
+    Ok(())
+}
+
+pub fn lock_all_files<P: ProgressBars, S, ID: RepoId + std::fmt::Debug>(
+    repo: &Repository<P, S>,
+    until: Option<DateTime<Local>>,
+) -> RusticResult<()> {
+    if !repo.be.can_lock() {
+        return Err(RusticError::new(
+            ErrorKind::Internal,
+            "Tried to call lock_all_files on a backend which isn't able to lock.",
+        ));
+    }
+
+    let p = &repo
+        .pb
+        .progress_spinner(format!("listing {:?} files..", ID::TYPE));
+    let ids: Vec<ID> = repo.list()?.collect();
+    p.finish();
+    lock_files(repo, &ids, until)
+}
+
+fn lock_files<P: ProgressBars, S, ID: RepoId + std::fmt::Debug>(
+    repo: &Repository<P, S>,
+    ids: &[ID],
+    until: Option<DateTime<Local>>,
+) -> RusticResult<()> {
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(constants::MAX_LOCKER_THREADS_NUM)
+        .build()
+        .map_err(|err| {
+            RusticError::with_source(
+                ErrorKind::Internal,
+                "Failed to create thread pool for warm-up. Please try again.",
+                err,
+            )
+        })?;
+    let p = &repo
+        .pb
+        .progress_counter(format!("locking {:?} files..", ID::TYPE));
+    p.set_length(ids.len().try_into().unwrap());
+    let backend = &repo.be;
+    pool.in_place_scope(|scope| {
+        for id in ids {
+            scope.spawn(move |_| {
+                if let Err(e) = backend.lock(ID::TYPE, id, until) {
+                    // FIXME: Use error handling
+                    error!("lock failed for {:?} {id:?}. {e}", ID::TYPE);
+                }
+                p.inc(1);
+            });
+        }
+    });
+    p.finish();
+    Ok(())
+}

--- a/crates/core/src/commands/lock.rs
+++ b/crates/core/src/commands/lock.rs
@@ -35,8 +35,8 @@ pub fn lock_all_files<P: ProgressBars, S, ID: RepoId + std::fmt::Debug>(
 ) -> RusticResult<()> {
     if !repo.be.can_lock() {
         return Err(RusticError::new(
-            ErrorKind::Internal,
-            "Tried to call lock_all_files on a backend which isn't able to lock.",
+            ErrorKind::Backend,
+            "No locking configured on backend.",
         ));
     }
 
@@ -71,9 +71,9 @@ fn lock_files<P: ProgressBars, S, ID: RepoId + std::fmt::Debug>(
     pool.in_place_scope(|scope| {
         for id in ids {
             scope.spawn(move |_| {
-                if let Err(e) = backend.lock(ID::TYPE, id, until) {
-                    // FIXME: Use error handling
-                    error!("lock failed for {:?} {id:?}. {e}", ID::TYPE);
+                if let Err(err) = backend.lock(ID::TYPE, id, until) {
+                    // FIXME: Use error handling, e.g. use a channel to collect the errors
+                    error!("lock failed for {:?} {id:?}. {err}", ID::TYPE);
                 }
                 p.inc(1);
             });

--- a/crates/core/src/repository/warm_up.rs
+++ b/crates/core/src/repository/warm_up.rs
@@ -97,16 +97,14 @@ fn warm_up_command<P: ProgressBars>(
     });
     p.set_length(packs.len() as u64);
     for pack in packs {
-        let args: Vec<_> = command
+        let args = command
             .args()
             .iter()
-            .map(|c| c.replace("%id", &pack.to_hex()))
-            .collect();
-
+            .map(|c| c.replace("%id", &pack.to_hex()));
         debug!("calling {command:?}...");
 
         let status = Command::new(command.command())
-            .args(&args)
+            .args(args)
             .status()
             .map_err(|err| {
                 RusticError::with_source(


### PR DESCRIPTION
Adds `Repository::lock_repo` which locks all repository files. Also the backend trait is extended to support locking and a `lock_command` has been added to `RepositoryOptions` which turns any backend into a backend capable of locking.

see https://github.com/rustic-rs/rustic/discussions/1050

Missing points:
- [ ] Add unit tests