### PR TITLE
feat: Add append-only repository mode

### DIFF
--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -1003,6 +1003,9 @@ impl PrunePlan {
         repo: &Repository<P, S>,
         opts: &PruneOptions,
     ) -> RusticResult<()> {
+        if repo.config().append_only == Some(true) {
+            return Err(CommandErrorKind::NotAllowedWithAppendOnly("prune".to_string()).into());
+        }
         repo.warm_up_wait(self.repack_packs().into_iter())?;
         let be = repo.dbe();
         let pb = &repo.pb;

--- a/crates/core/src/commands/repair/index.rs
+++ b/crates/core/src/commands/repair/index.rs
@@ -44,6 +44,11 @@ impl RepairIndexOptions {
         repo: &Repository<P, S>,
         dry_run: bool,
     ) -> RusticResult<()> {
+        if repo.config().append_only == Some(true) {
+            return Err(
+                CommandErrorKind::NotAllowedWithAppendOnly("index repair".to_string()).into(),
+            );
+        }
         let be = repo.dbe();
         let p = repo.pb.progress_spinner("listing packs...");
         let mut packs: HashMap<_, _> = be

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -11,7 +11,7 @@ use crate::{
         FileType,
     },
     blob::{packer::Packer, tree::Tree, BlobType},
-    error::RusticResult,
+    error::{CommandErrorKind, RusticResult},
     id::Id,
     index::{indexer::Indexer, ReadGlobalIndex, ReadIndex},
     progress::ProgressBars,
@@ -93,6 +93,12 @@ impl RepairSnapshotsOptions {
     ) -> RusticResult<()> {
         let be = repo.dbe();
         let config_file = repo.config();
+
+        if self.delete && config_file.append_only == Some(true) {
+            return Err(
+                CommandErrorKind::NotAllowedWithAppendOnly("snapshot removal".to_string()).into(),
+            );
+        }
 
         let mut state = RepairState::default();
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -214,6 +214,8 @@ pub enum CommandErrorKind {
     FromRayonError(#[from] rayon::ThreadPoolBuildError),
     /// conversion to `u64` failed: `{0:?}`
     ConversionToU64Failed(TryFromIntError),
+    /// {0} is not allowed on an append-only repository
+    NotAllowedWithAppendOnly(String),
 }
 
 /// [`CryptoErrorKind`] describes the errors that can happen while dealing with Cryptographic functions

--- a/crates/core/src/repofile/configfile.rs
+++ b/crates/core/src/repofile/configfile.rs
@@ -49,6 +49,13 @@ pub struct ConfigFile {
     /// When using hot/cold repositories, this is only set within the hot part of the repository.
     pub is_hot: Option<bool>,
 
+    /// Marker if this is a append-only repository.
+    ///
+    /// # Note
+    ///
+    /// Commands which are not append-only won't run once this is set.
+    pub append_only: Option<bool>,
+
     /// Compression level
     ///
     /// # Note

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -43,7 +43,7 @@ use crate::{
         restore::{RestoreOptions, RestorePlan},
     },
     crypto::aespoly1305::Key,
-    error::{KeyFileErrorKind, RepositoryErrorKind, RusticErrorKind},
+    error::{CommandErrorKind, KeyFileErrorKind, RepositoryErrorKind, RusticErrorKind},
     id::Id,
     index::{GlobalIndex, IndexEntry, ReadGlobalIndex, ReadIndex},
     progress::{NoProgressBars, ProgressBars},
@@ -1003,6 +1003,12 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     ///
     /// If the files could not be deleted.
     pub fn delete_snapshots(&self, ids: &[Id]) -> RusticResult<()> {
+        if self.config().append_only == Some(true) {
+            return Err(CommandErrorKind::NotAllowedWithAppendOnly(
+                "snapshots removal".to_string(),
+            )
+            .into());
+        }
         let p = self.pb.progress_counter("removing snapshots...");
         self.dbe()
             .delete_list(FileType::Snapshot, true, ids.iter(), p)?;


### PR DESCRIPTION
This PR allows to configure a repository to be append-only. Commands which would not work on an append-only backend will no longer try to perform these operations when this option is set.