### PR TITLE
fix(prune): Correct number of repacks

### DIFF
--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -511,17 +511,9 @@ impl PrunePack {
         match todo {
             PackToDo::Undecided => panic!("not possible"),
             PackToDo::Keep => {
-                stats.blobs[tpe].used += u64::from(pi.used_blobs);
-                stats.blobs[tpe].unused += u64::from(pi.unused_blobs);
-                stats.size[tpe].used += u64::from(pi.used_size);
-                stats.size[tpe].unused += u64::from(pi.unused_size);
                 stats.packs.keep += 1;
             }
             PackToDo::Repack => {
-                stats.blobs[tpe].used += u64::from(pi.used_blobs);
-                stats.blobs[tpe].unused += u64::from(pi.unused_blobs);
-                stats.size[tpe].used += u64::from(pi.used_size);
-                stats.size[tpe].unused += u64::from(pi.unused_size);
                 stats.packs.repack += 1;
                 stats.blobs[tpe].repack += u64::from(pi.unused_blobs + pi.used_blobs);
                 stats.blobs[tpe].repackrm += u64::from(pi.unused_blobs);
@@ -530,8 +522,6 @@ impl PrunePack {
             }
 
             PackToDo::MarkDelete => {
-                stats.blobs[tpe].unused += u64::from(pi.unused_blobs);
-                stats.size[tpe].unused += u64::from(pi.unused_size);
                 stats.blobs[tpe].remove += u64::from(pi.unused_blobs);
                 stats.size[tpe].remove += u64::from(pi.unused_size);
             }
@@ -731,6 +721,11 @@ impl PrunePlan {
                     .filter(|(_, p)| p.delete_mark == mark_case)
                 {
                     let pi = PackInfo::from_pack(pack, &mut self.used_ids);
+                    //update used/unused stats
+                    self.stats.blobs[pi.blob_type].used += u64::from(pi.used_blobs);
+                    self.stats.blobs[pi.blob_type].unused += u64::from(pi.unused_blobs);
+                    self.stats.size[pi.blob_type].used += u64::from(pi.used_size);
+                    self.stats.size[pi.blob_type].unused += u64::from(pi.unused_size);
 
                     // Various checks to determine if packs need to be kept
                     let too_young = pack.time > Some(self.time - keep_pack);


### PR DESCRIPTION
The reference for repacking that is both used for `--max-unused` and `--max-repack` was incomplete. In fact the packs which are at this point are only candidates for repacking (but not yet decided) were not taken into account. Sometimes this can be quite a lot and therefore explains why in a max-repack=10% example less than 10% was repacked. And in the max-unused=5% example it took the 5% of a much smaller amount of used data and hence tried to repack too much as the limit of still tolerated unused data is too low.

This has now been fixed.

closes https://github.com/rustic-rs/rustic/issues/1062