### PR TITLE
feat: Add Repository::to_indexed_checked and ::to_index_ids_checked()

### DIFF
--- a/crates/core/src/commands/repair/index.rs
+++ b/crates/core/src/commands/repair/index.rs
@@ -10,10 +10,11 @@ use crate::{
         FileType, ReadBackend, WriteBackend,
     },
     error::{CommandErrorKind, RusticErrorKind, RusticResult},
-    index::indexer::Indexer,
+    index::{binarysorted::IndexCollector, indexer::Indexer, GlobalIndex},
     progress::{Progress, ProgressBars},
     repofile::{IndexFile, IndexPack, PackHeader, PackHeaderRef},
     repository::{Open, Repository},
+    Id,
 };
 
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
@@ -49,60 +50,14 @@ impl RepairIndexOptions {
                 CommandErrorKind::NotAllowedWithAppendOnly("index repair".to_string()).into(),
             );
         }
+
         let be = repo.dbe();
-        let p = repo.pb.progress_spinner("listing packs...");
-        let mut packs: HashMap<_, _> = be
-            .list_with_size(FileType::Pack)
-            .map_err(RusticErrorKind::Backend)?
-            .into_iter()
-            .collect();
-        p.finish();
-
-        let mut pack_read_header = Vec::new();
-
-        let mut process_pack = |p: IndexPack,
-                                to_delete: bool,
-                                new_index: &mut IndexFile,
-                                changed: &mut bool| {
-            let index_size = p.pack_size();
-            let id = p.id;
-            match packs.remove(&id) {
-                None => {
-                    // this pack either does not exist or was already indexed in another index file => remove from index!
-                    *changed = true;
-                    debug!("removing non-existing pack {id} from index");
-                }
-                Some(size) => {
-                    if index_size != size {
-                        info!("pack {id}: size computed by index: {index_size}, actual size: {size}, will re-read header");
-                    }
-
-                    if index_size != size || self.read_all {
-                        // pack exists, but sizes do not match or we want to read all pack files
-                        pack_read_header.push((
-                            id,
-                            Some(PackHeaderRef::from_index_pack(&p).size()),
-                            size,
-                        ));
-                        *changed = true;
-                    } else {
-                        new_index.add(p, to_delete);
-                    }
-                }
-            }
-        };
+        let mut checker = PackChecker::new(repo)?;
 
         let p = repo.pb.progress_counter("reading index...");
         for index in be.stream_all::<IndexFile>(&p)? {
             let (index_id, index) = index?;
-            let mut new_index = IndexFile::default();
-            let mut changed = false;
-            for p in index.packs {
-                process_pack(p, false, &mut new_index, &mut changed);
-            }
-            for p in index.packs_to_delete {
-                process_pack(p, true, &mut new_index, &mut changed);
-            }
+            let (new_index, changed) = checker.check_pack(index, self.read_all);
             match (changed, dry_run) {
                 (true, true) => info!("would have modified index file {index_id}"),
                 (true, false) => {
@@ -117,9 +72,7 @@ impl RepairIndexOptions {
         }
         p.finish();
 
-        // process packs which are listed but not contained in the index
-        pack_read_header.extend(packs.into_iter().map(|(id, size)| (id, None, size)));
-
+        let pack_read_header = checker.into_pack_to_read();
         repo.warm_up_wait(pack_read_header.iter().map(|(id, _, _)| *id))?;
 
         let indexer = Indexer::new(be.clone()).into_shared();
@@ -155,4 +108,109 @@ impl RepairIndexOptions {
 
         Ok(())
     }
+}
+
+struct PackChecker {
+    packs: HashMap<Id, u32>,
+    packs_to_read: Vec<(Id, Option<u32>, u32)>,
+}
+
+impl PackChecker {
+    fn new<P: ProgressBars, S: Open>(repo: &Repository<P, S>) -> RusticResult<Self> {
+        let be = repo.dbe();
+        let p = repo.pb.progress_spinner("listing packs...");
+        let packs: HashMap<_, _> = be
+            .list_with_size(FileType::Pack)
+            .map_err(RusticErrorKind::Backend)?
+            .into_iter()
+            .collect();
+        p.finish();
+
+        Ok(Self {
+            packs,
+            packs_to_read: Vec::new(),
+        })
+    }
+
+    fn check_pack(&mut self, indexfile: IndexFile, read_all: bool) -> (IndexFile, bool) {
+        let mut new_index = IndexFile::default();
+        let mut changed = false;
+        for (p, to_delete) in indexfile.all_packs() {
+            let index_size = p.pack_size();
+            let id = p.id;
+            match self.packs.remove(&id) {
+                None => {
+                    // this pack either does not exist or was already indexed in another index file => remove from index!
+                    debug!("removing non-existing pack {id} from index");
+                    changed = true;
+                }
+                Some(size) => {
+                    if index_size != size {
+                        info!("pack {id}: size computed by index: {index_size}, actual size: {size}, will re-read header");
+                    }
+
+                    if index_size != size || read_all {
+                        // pack exists, but sizes do not match or we want to read all pack files
+                        self.packs_to_read.push((
+                            id,
+                            Some(PackHeaderRef::from_index_pack(&p).size()),
+                            size,
+                        ));
+                    } else {
+                        new_index.add(p, to_delete);
+                    }
+                }
+            }
+        }
+        (new_index, changed)
+    }
+
+    fn into_pack_to_read(mut self) -> Vec<(Id, Option<u32>, u32)> {
+        // add packs which are listed but not contained in the index
+        self.packs_to_read
+            .extend(self.packs.into_iter().map(|(id, size)| (id, None, size)));
+        self.packs_to_read
+    }
+}
+
+pub(crate) fn index_checked_from_collector<P: ProgressBars, S: Open>(
+    repo: &Repository<P, S>,
+    mut collector: IndexCollector,
+) -> RusticResult<GlobalIndex> {
+    let mut checker = PackChecker::new(repo)?;
+    let be = repo.dbe();
+
+    let p = repo.pb.progress_counter("reading index...");
+    for index in be.stream_all::<IndexFile>(&p)? {
+        collector.extend(checker.check_pack(index?.1, false).0.packs);
+    }
+    p.finish();
+
+    let pack_read_header = checker.into_pack_to_read();
+    repo.warm_up_wait(pack_read_header.iter().map(|(id, _, _)| *id))?;
+
+    let p = repo.pb.progress_counter("reading pack headers");
+    p.set_length(
+        pack_read_header
+            .len()
+            .try_into()
+            .map_err(CommandErrorKind::ConversionToU64Failed)?,
+    );
+    let index_packs: Vec<_> = pack_read_header
+        .into_iter()
+        .map(|(id, size_hint, packsize)| {
+            debug!("reading pack {id}...");
+            let pack = IndexPack {
+                id,
+                blobs: PackHeader::from_file(be, id, size_hint, packsize)?.into_blobs(),
+                ..Default::default()
+            };
+            p.inc(1);
+            Ok(pack)
+        })
+        .collect::<RusticResult<_>>()?;
+    p.finish();
+
+    collector.extend(index_packs);
+    Ok(GlobalIndex::new_from_index(collector.into_index()))
 }

--- a/crates/core/src/repofile/indexfile.rs
+++ b/crates/core/src/repofile/indexfile.rs
@@ -45,6 +45,13 @@ impl IndexFile {
             self.packs.push(p);
         }
     }
+
+    pub(crate) fn all_packs(self) -> impl Iterator<Item = (IndexPack, bool)> {
+        self.packs
+            .into_iter()
+            .map(|pack| (pack, false))
+            .chain(self.packs_to_delete.into_iter().map(|pack| (pack, true)))
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -1082,12 +1082,12 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     /// This saves the full index in memory which can be quite memory-consuming!
     pub fn to_indexed(self) -> RusticResult<Repository<P, IndexedStatus<FullIndex, S>>> {
         let index = GlobalIndex::new(self.dbe(), &self.pb.progress_counter(""))?;
-        Ok(self.to_indexed_with_index(index))
+        Ok(self.into_indexed_with_index(index))
     }
 
     /// Turn the repository into the `IndexedFull` state by reading and storing the index
     ///
-    /// This is similar to to_indexed(), but also lists the pack files and reads pack headers
+    /// This is similar to `to_indexed()`, but also lists the pack files and reads pack headers
     /// for packs is missing in the index.
     ///
     /// # Errors
@@ -1100,11 +1100,11 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     pub fn to_indexed_checked(self) -> RusticResult<Repository<P, IndexedStatus<FullIndex, S>>> {
         let collector = IndexCollector::new(IndexType::Full);
         let index = index_checked_from_collector(&self, collector)?;
-        Ok(self.to_indexed_with_index(index))
+        Ok(self.into_indexed_with_index(index))
     }
 
     // helper function to deduplicate code
-    fn to_indexed_with_index(
+    fn into_indexed_with_index(
         self,
         index: GlobalIndex,
     ) -> Repository<P, IndexedStatus<FullIndex, S>> {
@@ -1146,12 +1146,12 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     /// However, operations which add data are fully functional.
     pub fn to_indexed_ids(self) -> RusticResult<Repository<P, IndexedStatus<IdIndex, S>>> {
         let index = GlobalIndex::only_full_trees(self.dbe(), &self.pb.progress_counter(""))?;
-        Ok(self.to_indexed_ids_with_index(index))
+        Ok(self.into_indexed_ids_with_index(index))
     }
 
     /// Turn the repository into the `IndexedIds` state by reading and storing a size-optimized index
     ///
-    /// This is similar to to_indexed_ids(), but also lists the pack files and reads pack headers
+    /// This is similar to `to_indexed_ids()`, but also lists the pack files and reads pack headers
     /// for packs is missing in the index.
     ///
     /// # Errors
@@ -1169,11 +1169,11 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     pub fn to_indexed_ids_checked(self) -> RusticResult<Repository<P, IndexedStatus<IdIndex, S>>> {
         let collector = IndexCollector::new(IndexType::DataIds);
         let index = index_checked_from_collector(&self, collector)?;
-        Ok(self.to_indexed_ids_with_index(index))
+        Ok(self.into_indexed_ids_with_index(index))
     }
 
     // helper function to deduplicate code
-    fn to_indexed_ids_with_index(
+    fn into_indexed_ids_with_index(
         self,
         index: GlobalIndex,
     ) -> Repository<P, IndexedStatus<IdIndex, S>> {

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -38,14 +38,20 @@ use crate::{
         forget::{ForgetGroups, KeepOptions},
         key::KeyOptions,
         prune::{PruneOptions, PrunePlan},
-        repair::{index::RepairIndexOptions, snapshots::RepairSnapshotsOptions},
+        repair::{
+            index::{index_checked_from_collector, RepairIndexOptions},
+            snapshots::RepairSnapshotsOptions,
+        },
         repoinfo::{IndexInfos, RepoFileInfos},
         restore::{RestoreOptions, RestorePlan},
     },
     crypto::aespoly1305::Key,
     error::{CommandErrorKind, KeyFileErrorKind, RepositoryErrorKind, RusticErrorKind},
     id::Id,
-    index::{GlobalIndex, IndexEntry, ReadGlobalIndex, ReadIndex},
+    index::{
+        binarysorted::{IndexCollector, IndexType},
+        GlobalIndex, IndexEntry, ReadGlobalIndex, ReadIndex,
+    },
     progress::{NoProgressBars, ProgressBars},
     repofile::{
         keyfile::find_key_in_backend,
@@ -1076,6 +1082,32 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     /// This saves the full index in memory which can be quite memory-consuming!
     pub fn to_indexed(self) -> RusticResult<Repository<P, IndexedStatus<FullIndex, S>>> {
         let index = GlobalIndex::new(self.dbe(), &self.pb.progress_counter(""))?;
+        Ok(self.to_indexed_with_index(index))
+    }
+
+    /// Turn the repository into the `IndexedFull` state by reading and storing the index
+    ///
+    /// This is similar to to_indexed(), but also lists the pack files and reads pack headers
+    /// for packs is missing in the index.
+    ///
+    /// # Errors
+    ///
+    // TODO: Document errors
+    ///
+    /// # Note
+    ///
+    /// This saves the full index in memory which can be quite memory-consuming!
+    pub fn to_indexed_checked(self) -> RusticResult<Repository<P, IndexedStatus<FullIndex, S>>> {
+        let collector = IndexCollector::new(IndexType::Full);
+        let index = index_checked_from_collector(&self, collector)?;
+        Ok(self.to_indexed_with_index(index))
+    }
+
+    // helper function to deduplicate code
+    fn to_indexed_with_index(
+        self,
+        index: GlobalIndex,
+    ) -> Repository<P, IndexedStatus<FullIndex, S>> {
         let status = IndexedStatus {
             open: self.status,
             index,
@@ -1088,14 +1120,14 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
                 ),
             },
         };
-        Ok(Repository {
+        Repository {
             name: self.name,
             be: self.be,
             be_hot: self.be_hot,
             opts: self.opts,
             pb: self.pb,
             status,
-        })
+        }
     }
 
     /// Turn the repository into the `IndexedIds` state by reading and storing a size-optimized index
@@ -1114,19 +1146,50 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     /// However, operations which add data are fully functional.
     pub fn to_indexed_ids(self) -> RusticResult<Repository<P, IndexedStatus<IdIndex, S>>> {
         let index = GlobalIndex::only_full_trees(self.dbe(), &self.pb.progress_counter(""))?;
+        Ok(self.to_indexed_ids_with_index(index))
+    }
+
+    /// Turn the repository into the `IndexedIds` state by reading and storing a size-optimized index
+    ///
+    /// This is similar to to_indexed_ids(), but also lists the pack files and reads pack headers
+    /// for packs is missing in the index.
+    ///
+    /// # Errors
+    ///
+    // TODO: Document errors
+    ///
+    /// # Returns
+    ///
+    /// The repository in the `IndexedIds` state
+    ///
+    /// # Note
+    ///
+    /// This saves only the `Id`s for data blobs. Therefore, not all operations are possible on the repository.
+    /// However, operations which add data are fully functional.
+    pub fn to_indexed_ids_checked(self) -> RusticResult<Repository<P, IndexedStatus<IdIndex, S>>> {
+        let collector = IndexCollector::new(IndexType::DataIds);
+        let index = index_checked_from_collector(&self, collector)?;
+        Ok(self.to_indexed_ids_with_index(index))
+    }
+
+    // helper function to deduplicate code
+    fn to_indexed_ids_with_index(
+        self,
+        index: GlobalIndex,
+    ) -> Repository<P, IndexedStatus<IdIndex, S>> {
         let status = IndexedStatus {
             open: self.status,
             index,
             index_data: IdIndex {},
         };
-        Ok(Repository {
+        Repository {
             name: self.name,
             be: self.be,
             be_hot: self.be_hot,
             opts: self.opts,
             pb: self.pb,
             status,
-        })
+        }
     }
 
     /// Get statistical information from the index


### PR DESCRIPTION
This allows to use a repository even in the case of an defect index without running an index repair. Instead the information is read from the pack files and stored in-memory but not written.
This allows to use read-only commands on repository with defect index.