### PR TITLE
fix: update dependency nix

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -83,7 +83,7 @@ cached = { version = "0.48.1", default-features = false, features = ["proc_macro
 dunce = "1.0.4"
 filetime = "0.2.23"
 ignore = "0.4.22"
-nix = { version = "0.27.1", default-features = false, features = ["user", "fs"] }
+nix = { version = "0.28", default-features = false, features = ["user", "fs"] }
 path-dedot = "3.1.1"
 shell-words = "1.1.0"
 walkdir = "2.4.0"

--- a/crates/core/src/backend/local_destination.rs
+++ b/crates/core/src/backend/local_destination.rs
@@ -16,7 +16,10 @@ use log::warn;
 #[cfg(not(windows))]
 use nix::sys::stat::{mknod, Mode, SFlag};
 #[cfg(not(windows))]
-use nix::unistd::{fchownat, FchownatFlags, Gid, Group, Uid, User};
+use nix::{
+    fcntl::AtFlags,
+    unistd::{fchownat, Gid, Group, Uid, User},
+};
 
 #[cfg(not(windows))]
 use crate::backend::ignore::mapper::map_mode_from_go;
@@ -241,7 +244,7 @@ impl LocalDestination {
         // use gid from group if valid, else from saved gid (if saved)
         let gid = group.or_else(|| meta.gid.map(Gid::from_raw));
 
-        fchownat(None, &filename, uid, gid, FchownatFlags::NoFollowSymlink)
+        fchownat(None, &filename, uid, gid, AtFlags::AT_SYMLINK_NOFOLLOW)
             .map_err(LocalDestinationErrorKind::FromErrnoError)?;
         Ok(())
     }
@@ -281,7 +284,7 @@ impl LocalDestination {
         let uid = meta.uid.map(Uid::from_raw);
         let gid = meta.gid.map(Gid::from_raw);
 
-        fchownat(None, &filename, uid, gid, FchownatFlags::NoFollowSymlink)
+        fchownat(None, &filename, uid, gid, AtFlags::AT_SYMLINK_NOFOLLOW)
             .map_err(LocalDestinationErrorKind::FromErrnoError)?;
         Ok(())
     }


### PR DESCRIPTION
Due to a memory alignment bug, crashes on macOS happened. This is fixed by this dependency update.

closes https://github.com/rustic-rs/rustic/issues/1075