### PR TITLE
feat: Hide plain text password from help text

### DIFF
--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -78,7 +78,10 @@ pub struct RepositoryOptions {
     /// # Warning
     ///
     /// Using --password can reveal the password in the process list!
-    #[cfg_attr(feature = "clap", clap(long, global = true, env = "RUSTIC_PASSWORD"))]
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, global = true, env = "RUSTIC_PASSWORD", hide_env_values = true)
+    )]
     // TODO: Security related: use `secrecy` library (#663)
     pub password: Option<String>,
 


### PR DESCRIPTION
When the password is provided via the environment variable like `RUSTIC_PASSWORD=hunter2`, it would be visible in the help text:

```
--password <PASSWORD>     Password of the repository [env: RUSTIC_PASSWORD=hunter2]
```

To avoid exposing any sensitive information this commit hides the password from the help text:

```
--password <PASSWORD>     Password of the repository [env: RUSTIC_PASSWORD]
```