### PR TITLE
fix: Set correct content for symlink with parent snapshot

### DIFF
--- a/crates/core/src/archiver/parent.rs
+++ b/crates/core/src/archiver/parent.rs
@@ -279,7 +279,7 @@ impl Parent {
                 let parent = match parent {
                     ParentResult::Matched(p_node) => {
                         if p_node.content.iter().flatten().all(|id| index.has_data(id)) {
-                            node.content = Some(p_node.content.iter().flatten().copied().collect());
+                            node.content = p_node.content.clone();
                             ParentResult::Matched(())
                         } else {
                             warn!(


### PR DESCRIPTION
When having a symlink which is already present in a parent snapshot, rustic set `content = []` instead of using the parent content. While this does no harm (for symlinks the content is anyway not read), it may lead to changed trees even though no change was actually performed. This PR fixes that.