### PR TITLE
chore: release

### DIFF
--- a/crates/backend/CHANGELOG.md
+++ b/crates/backend/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.1.1...rustic_backend-v0.2.0) - 2024-08-18
+
+### Added
+- *(backends)* Add throttle option to opendal backend ([#216](https://github.com/rustic-rs/rustic_core/pull/216))
+- *(backend)* [**breaking**] remove s3 and sftp wrapper around opendal ([#200](https://github.com/rustic-rs/rustic_core/pull/200))
+- [**breaking**] move clippy lints to cargo manifest and fix upcoming issues all over the workspace ([#176](https://github.com/rustic-rs/rustic_core/pull/176))
+- *(opendal)* Add option connections ([#155](https://github.com/rustic-rs/rustic_core/pull/155))
+
+### Fixed
+- clippy lints ([#220](https://github.com/rustic-rs/rustic_core/pull/220))
+- *(backends)* local: Only create repo dir when creating the repository ([#206](https://github.com/rustic-rs/rustic_core/pull/206))
+- *(deps)* update rust crate reqwest to 0.11.26 ([#196](https://github.com/rustic-rs/rustic_core/pull/196))
+- *(deps)* update rust crate thiserror to 1.0.58 ([#192](https://github.com/rustic-rs/rustic_core/pull/192))
+- *(deps)* update rust crate anyhow to 1.0.81 ([#191](https://github.com/rustic-rs/rustic_core/pull/191))
+- *(rclone)* Use semver for version checking ([#188](https://github.com/rustic-rs/rustic_core/pull/188))
+- *(deps)* update rust crate clap to 4.5.2 ([#183](https://github.com/rustic-rs/rustic_core/pull/183))
+- *(config)* Merge repository options for multiple config sources ([#171](https://github.com/rustic-rs/rustic_core/pull/171))
+- *(backend)* Give useful error message when no repository is given.
+- updated msrv and fix clippy lints ([#160](https://github.com/rustic-rs/rustic_core/pull/160))
+
+### Other
+- dependency updates
+- *(deps)* more version updates ([#237](https://github.com/rustic-rs/rustic_core/pull/237))
+- Update MSRV to 1.76.0
+- *(deps)* Several version updates ([#234](https://github.com/rustic-rs/rustic_core/pull/234))
+- Update MSRV (needed by opendal)
+- update opendal to 0.46 and refactor accordingly ([#225](https://github.com/rustic-rs/rustic_core/pull/225))
+- Update MSRV to 1.73.0
+- fix clippy lints
+- *(deps)* update dependencies ([#180](https://github.com/rustic-rs/rustic_core/pull/180))
+- add rustic_testing to workspace crates
+- reset again after release to workspace dependencies for workspace crates
+
 ## [rustic_backend-v0.1.1] - 2024-02-02
 
 ### Documentation

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_backend"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["the rustic-rs team"]
 categories = ["Algorithms", "Data structures", "Filesystem"]
 documentation = "https://docs.rs/rustic_backend"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.2.0](https://github.com/rustic-rs/rustic_core/compare/rustic_config-v0.1.0...rustic_config-v0.2.0) - 2024-08-18
+
+### Added
+- [**breaking**] move clippy lints to cargo manifest and fix upcoming issues all over the workspace ([#176](https://github.com/rustic-rs/rustic_core/pull/176))
+
+### Other
+- Update MSRV to 1.76.0
+- Update MSRV (needed by opendal)
+- Update MSRV to 1.73.0
+- add changelog for rustic_config
+
 ## [rustic_backend-v0.1.0] - 2024-02-04
 
 - Reserving name on crates.io

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_config"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["the rustic-rs team"]
 categories = [
   "Command-Line-Utilities",

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.2.0...rustic_core-v0.3.0) - 2024-08-18
+
+### Added
+- *(forget)* [**breaking**] Make keep-* Options and add keep-none ([#238](https://github.com/rustic-rs/rustic_core/pull/238))
+- add search methods to Repository ([#212](https://github.com/rustic-rs/rustic_core/pull/212))
+- [**breaking**] Allow specifying many options in config profile without array ([#211](https://github.com/rustic-rs/rustic_core/pull/211))
+- [**breaking**] move clippy lints to cargo manifest and fix upcoming issues all over the workspace ([#176](https://github.com/rustic-rs/rustic_core/pull/176))
+- Add extra check before writing data ([#154](https://github.com/rustic-rs/rustic_core/pull/154))
+- Allow missing fields in snapshot summary
+- Hide plain text password from help text ([#170](https://github.com/rustic-rs/rustic_core/pull/170))
+- Add Repository::to_indexed_checked and ::to_index_ids_checked() ([#168](https://github.com/rustic-rs/rustic_core/pull/168))
+- *(prune)* Add more debug info to stats ([#162](https://github.com/rustic-rs/rustic_core/pull/162))
+- Add append-only repository mode ([#164](https://github.com/rustic-rs/rustic_core/pull/164))
+
+### Fixed
+- parse commands given by arg or env using shell_words ([#240](https://github.com/rustic-rs/rustic_core/pull/240))
+- Allow non-value/null xattr ([#235](https://github.com/rustic-rs/rustic_core/pull/235))
+- ensure Rust 1.76.0 compiles
+- backup file even if failed listing extended attributes ([#233](https://github.com/rustic-rs/rustic_core/pull/233))
+- Export types so the Repository type can be fully specified ([#229](https://github.com/rustic-rs/rustic_core/pull/229))
+- Always sort StringList ([#226](https://github.com/rustic-rs/rustic_core/pull/226))
+- *(commands)* Properly finish progress bars
+- *(commands)* [**breaking**] Fix edge case for repair index ([#219](https://github.com/rustic-rs/rustic_core/pull/219))
+- clippy lints ([#220](https://github.com/rustic-rs/rustic_core/pull/220))
+- *(errors)* Show filenames in error message coming from ignore source ([#215](https://github.com/rustic-rs/rustic_core/pull/215))
+- *(paths)* Handle paths starting with "." correctly ([#213](https://github.com/rustic-rs/rustic_core/pull/213))
+- Add warning about unsorted files and sort where neccessary ([#205](https://github.com/rustic-rs/rustic_core/pull/205))
+- *(deps)* update rust crate thiserror to 1.0.58 ([#192](https://github.com/rustic-rs/rustic_core/pull/192))
+- *(deps)* update rust crate anyhow to 1.0.81 ([#191](https://github.com/rustic-rs/rustic_core/pull/191))
+- *(deps)* update rust crate serde_with to 3.7.0 ([#189](https://github.com/rustic-rs/rustic_core/pull/189))
+- *(rclone)* Use semver for version checking ([#188](https://github.com/rustic-rs/rustic_core/pull/188))
+- *(deps)* update rust crate strum to 0.26.2 ([#187](https://github.com/rustic-rs/rustic_core/pull/187))
+- *(deps)* update rust crate clap to 4.5.2 ([#183](https://github.com/rustic-rs/rustic_core/pull/183))
+- Set correct content for symlink with parent snapshot ([#174](https://github.com/rustic-rs/rustic_core/pull/174))
+- update dependency nix ([#169](https://github.com/rustic-rs/rustic_core/pull/169))
+- *(memory)* Limit memory usage for restore when having large pack files ([#165](https://github.com/rustic-rs/rustic_core/pull/165))
+- *(prune)* Correct number of repacks ([#167](https://github.com/rustic-rs/rustic_core/pull/167))
+- updated msrv and fix clippy lints ([#160](https://github.com/rustic-rs/rustic_core/pull/160))
+
+### Other
+- dependency updates
+- Ensure that MSRV 1.76 works
+- *(deps)* more version updates ([#237](https://github.com/rustic-rs/rustic_core/pull/237))
+- Update MSRV to 1.76.0
+- *(deps)* Several version updates ([#234](https://github.com/rustic-rs/rustic_core/pull/234))
+- fix clippy lints ([#236](https://github.com/rustic-rs/rustic_core/pull/236))
+- Update MSRV (needed by opendal)
+- update sha2 dependency
+- add integration tests for `prune` and `ls` ([#221](https://github.com/rustic-rs/rustic_core/pull/221))
+- *(error)* Add error sources ([#217](https://github.com/rustic-rs/rustic_core/pull/217))
+- add more warnings
+- make SnapshotFile::cmp_group public ([#210](https://github.com/rustic-rs/rustic_core/pull/210))
+- Update MSRV to 1.73.0
+- fix clippy lints
+- add backup integration tests using snapshots ([#175](https://github.com/rustic-rs/rustic_core/pull/175))
+- replace dep bitmask-enum by enumset ([#173](https://github.com/rustic-rs/rustic_core/pull/173))
+- *(deps)* update dependencies ([#180](https://github.com/rustic-rs/rustic_core/pull/180))
+- use release-plz action, remove public api fixtures incl. test and related ci and other release related ci
+- Add unit tests for extra verification ([#172](https://github.com/rustic-rs/rustic_core/pull/172))
+- rustic_config v0.1.0
+- add rustic_testing to workspace crates
+
 ## [rustic_core-v0.2.0] - 2024-02-01
 
 ### Bug Fixes

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["the rustic-rs team"]
 categories = [
   "Algorithms",


### PR DESCRIPTION
## 🤖 New release
* `rustic_backend`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `rustic_core`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `rustic_config`: 0.1.0 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustic_backend`
<blockquote>

## [0.2.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.1.1...rustic_backend-v0.2.0) - 2024-08-18

### Added
- *(backends)* Add throttle option to opendal backend ([#216](https://github.com/rustic-rs/rustic_core/pull/216))
- *(backend)* [**breaking**] remove s3 and sftp wrapper around opendal ([#200](https://github.com/rustic-rs/rustic_core/pull/200))
- [**breaking**] move clippy lints to cargo manifest and fix upcoming issues all over the workspace ([#176](https://github.com/rustic-rs/rustic_core/pull/176))
- *(opendal)* Add option connections ([#155](https://github.com/rustic-rs/rustic_core/pull/155))

### Fixed
- clippy lints ([#220](https://github.com/rustic-rs/rustic_core/pull/220))
- *(backends)* local: Only create repo dir when creating the repository ([#206](https://github.com/rustic-rs/rustic_core/pull/206))
- *(deps)* update rust crate reqwest to 0.11.26 ([#196](https://github.com/rustic-rs/rustic_core/pull/196))
- *(deps)* update rust crate thiserror to 1.0.58 ([#192](https://github.com/rustic-rs/rustic_core/pull/192))
- *(deps)* update rust crate anyhow to 1.0.81 ([#191](https://github.com/rustic-rs/rustic_core/pull/191))
- *(rclone)* Use semver for version checking ([#188](https://github.com/rustic-rs/rustic_core/pull/188))
- *(deps)* update rust crate clap to 4.5.2 ([#183](https://github.com/rustic-rs/rustic_core/pull/183))
- *(config)* Merge repository options for multiple config sources ([#171](https://github.com/rustic-rs/rustic_core/pull/171))
- *(backend)* Give useful error message when no repository is given.
- updated msrv and fix clippy lints ([#160](https://github.com/rustic-rs/rustic_core/pull/160))

### Other
- dependency updates
- *(deps)* more version updates ([#237](https://github.com/rustic-rs/rustic_core/pull/237))
- Update MSRV to 1.76.0
- *(deps)* Several version updates ([#234](https://github.com/rustic-rs/rustic_core/pull/234))
- Update MSRV (needed by opendal)
- update opendal to 0.46 and refactor accordingly ([#225](https://github.com/rustic-rs/rustic_core/pull/225))
- Update MSRV to 1.73.0
- fix clippy lints
- *(deps)* update dependencies ([#180](https://github.com/rustic-rs/rustic_core/pull/180))
- add rustic_testing to workspace crates
- reset again after release to workspace dependencies for workspace crates
</blockquote>

## `rustic_core`
<blockquote>

## [0.3.0](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.2.0...rustic_core-v0.3.0) - 2024-08-18

### Added
- *(forget)* [**breaking**] Make keep-* Options and add keep-none ([#238](https://github.com/rustic-rs/rustic_core/pull/238))
- add search methods to Repository ([#212](https://github.com/rustic-rs/rustic_core/pull/212))
- [**breaking**] Allow specifying many options in config profile without array ([#211](https://github.com/rustic-rs/rustic_core/pull/211))
- [**breaking**] move clippy lints to cargo manifest and fix upcoming issues all over the workspace ([#176](https://github.com/rustic-rs/rustic_core/pull/176))
- Add extra check before writing data ([#154](https://github.com/rustic-rs/rustic_core/pull/154))
- Allow missing fields in snapshot summary
- Hide plain text password from help text ([#170](https://github.com/rustic-rs/rustic_core/pull/170))
- Add Repository::to_indexed_checked and ::to_index_ids_checked() ([#168](https://github.com/rustic-rs/rustic_core/pull/168))
- *(prune)* Add more debug info to stats ([#162](https://github.com/rustic-rs/rustic_core/pull/162))
- Add append-only repository mode ([#164](https://github.com/rustic-rs/rustic_core/pull/164))

### Fixed
- parse commands given by arg or env using shell_words ([#240](https://github.com/rustic-rs/rustic_core/pull/240))
- Allow non-value/null xattr ([#235](https://github.com/rustic-rs/rustic_core/pull/235))
- ensure Rust 1.76.0 compiles
- backup file even if failed listing extended attributes ([#233](https://github.com/rustic-rs/rustic_core/pull/233))
- Export types so the Repository type can be fully specified ([#229](https://github.com/rustic-rs/rustic_core/pull/229))
- Always sort StringList ([#226](https://github.com/rustic-rs/rustic_core/pull/226))
- *(commands)* Properly finish progress bars
- *(commands)* [**breaking**] Fix edge case for repair index ([#219](https://github.com/rustic-rs/rustic_core/pull/219))
- clippy lints ([#220](https://github.com/rustic-rs/rustic_core/pull/220))
- *(errors)* Show filenames in error message coming from ignore source ([#215](https://github.com/rustic-rs/rustic_core/pull/215))
- *(paths)* Handle paths starting with "." correctly ([#213](https://github.com/rustic-rs/rustic_core/pull/213))
- Add warning about unsorted files and sort where neccessary ([#205](https://github.com/rustic-rs/rustic_core/pull/205))
- *(deps)* update rust crate thiserror to 1.0.58 ([#192](https://github.com/rustic-rs/rustic_core/pull/192))
- *(deps)* update rust crate anyhow to 1.0.81 ([#191](https://github.com/rustic-rs/rustic_core/pull/191))
- *(deps)* update rust crate serde_with to 3.7.0 ([#189](https://github.com/rustic-rs/rustic_core/pull/189))
- *(rclone)* Use semver for version checking ([#188](https://github.com/rustic-rs/rustic_core/pull/188))
- *(deps)* update rust crate strum to 0.26.2 ([#187](https://github.com/rustic-rs/rustic_core/pull/187))
- *(deps)* update rust crate clap to 4.5.2 ([#183](https://github.com/rustic-rs/rustic_core/pull/183))
- Set correct content for symlink with parent snapshot ([#174](https://github.com/rustic-rs/rustic_core/pull/174))
- update dependency nix ([#169](https://github.com/rustic-rs/rustic_core/pull/169))
- *(memory)* Limit memory usage for restore when having large pack files ([#165](https://github.com/rustic-rs/rustic_core/pull/165))
- *(prune)* Correct number of repacks ([#167](https://github.com/rustic-rs/rustic_core/pull/167))
- updated msrv and fix clippy lints ([#160](https://github.com/rustic-rs/rustic_core/pull/160))

### Other
- dependency updates
- Ensure that MSRV 1.76 works
- *(deps)* more version updates ([#237](https://github.com/rustic-rs/rustic_core/pull/237))
- Update MSRV to 1.76.0
- *(deps)* Several version updates ([#234](https://github.com/rustic-rs/rustic_core/pull/234))
- fix clippy lints ([#236](https://github.com/rustic-rs/rustic_core/pull/236))
- Update MSRV (needed by opendal)
- update sha2 dependency
- add integration tests for `prune` and `ls` ([#221](https://github.com/rustic-rs/rustic_core/pull/221))
- *(error)* Add error sources ([#217](https://github.com/rustic-rs/rustic_core/pull/217))
- add more warnings
- make SnapshotFile::cmp_group public ([#210](https://github.com/rustic-rs/rustic_core/pull/210))
- Update MSRV to 1.73.0
- fix clippy lints
- add backup integration tests using snapshots ([#175](https://github.com/rustic-rs/rustic_core/pull/175))
- replace dep bitmask-enum by enumset ([#173](https://github.com/rustic-rs/rustic_core/pull/173))
- *(deps)* update dependencies ([#180](https://github.com/rustic-rs/rustic_core/pull/180))
- use release-plz action, remove public api fixtures incl. test and related ci and other release related ci
- Add unit tests for extra verification ([#172](https://github.com/rustic-rs/rustic_core/pull/172))
- rustic_config v0.1.0
- add rustic_testing to workspace crates
</blockquote>

## `rustic_config`
<blockquote>

## [0.2.0](https://github.com/rustic-rs/rustic_core/compare/rustic_config-v0.1.0...rustic_config-v0.2.0) - 2024-08-18

### Added
- [**breaking**] move clippy lints to cargo manifest and fix upcoming issues all over the workspace ([#176](https://github.com/rustic-rs/rustic_core/pull/176))

### Other
- Update MSRV to 1.76.0
- Update MSRV (needed by opendal)
- Update MSRV to 1.73.0
- add changelog for rustic_config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).