### PR TITLE
fix(rclone): Use semver for version checking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rustic_core = { path = "crates/core" }
 simplelog = "0.12.2"
 
 # dev-dependencies
+rstest = "0.18.2"
 tempfile = "3.10.1"
 
 # see: https://nnethercote.github.io/perf-book/build-configuration.html

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -97,4 +97,4 @@ opendal = { version = "0.45", features = ["services-b2", "services-sftp", "servi
 opendal = { version = "0.45", features = ["services-b2", "services-swift", "layers-blocking"], optional = true }
 
 [dev-dependencies]
-rstest = "0.18.2"
+rstest = { workspace = true }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -38,7 +38,7 @@ clap = ["dep:clap"]
 s3 = ["opendal"]
 opendal = ["dep:opendal", "dep:rayon", "dep:tokio", "tokio/rt-multi-thread"]
 rest = ["dep:reqwest", "dep:backoff"]
-rclone = ["rest", "dep:rand"]
+rclone = ["rest", "dep:rand", "dep:semver"]
 # Note: sftp is not yet supported on windows, see below
 sftp = ["opendal"]
 
@@ -82,6 +82,7 @@ reqwest = { version = "0.11.25", default-features = false, features = ["json", "
 
 # rclone backend
 rand = { version = "0.8.5", optional = true }
+semver = { version = "1.0.22", optional = true }
 
 # opendal backend
 rayon = { version = "1.9.0", optional = true }

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -54,6 +54,8 @@ pub enum RcloneErrorKind {
     FromUtf8Error(#[from] Utf8Error),
     /// error parsing verision number from `{0:?}`
     FromParseVersion(String),
+    /// Using rclone without authentication! Upgrade to rclone >= 1.52.2 (current version: `{0}`)!
+    RCloneWithoutAuthentication(String),
 }
 
 /// [`RestErrorKind`] describes the errors that can be returned while dealing with the REST API

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -313,6 +313,7 @@ mod tests {
     #[rstest]
     #[case(b"")]
     #[case(b"rclone v1.52.1\n- os/arch: linux/amd64\n- go version: go1.14.4\n")]
+    #[case(b"rclone v1.51.3-beta\n- os/arch: linux/amd64\n- go version: go1.14.4\n")]
     fn test_check_clone_version_fails(#[case] rclone_version_output: &[u8]) {
         assert!(check_clone_version(rclone_version_output).is_err());
     }

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -79,6 +79,10 @@ fn check_clone_version(rclone_version_output: &[u8]) -> Result<()> {
     // for rclone < 1.52.2 setting user/password via env variable doesn't work. This means
     // we are setting up an rclone without authentication which is a security issue!
     let mut parsed_version = Version::parse(rclone_version)?;
+
+    // we need to set the pre and build fields to empty to make the comparison work
+    // otherwise the comparison will take the pre and build fields into account
+    // which would make beta versions pass the check
     parsed_version.pre = Prerelease::EMPTY;
     parsed_version.build = BuildMetadata::EMPTY;
 

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -86,6 +86,9 @@ fn check_clone_version(rclone_version_output: &[u8]) -> Result<()> {
 
     // for rclone < 1.52.2 setting user/password via env variable doesn't work. This means
     // we are setting up an rclone without authentication which is a security issue!
+    // we hard fail here to prevent this, as we can't guarantee the security of the data
+    // also because 1.52.2 has been released on Jun 24, 2020, we can assume that this is a
+    // reasonable lower bound for the version
     if VersionReq::parse("<1.52.2")?.matches(&parsed_version) {
         return Err(
             RcloneErrorKind::RCloneWithoutAuthentication(rclone_version.to_string()).into(),

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -69,7 +69,7 @@ impl Drop for RcloneBackend {
 /// [`RcloneErrorKind::NoOutputForRcloneVersion`]: RcloneErrorKind::NoOutputForRcloneVersion
 /// [`RcloneErrorKind::FromParseVersion`]: RcloneErrorKind::FromParseVersion
 fn check_clone_version(rclone_version_output: &[u8]) -> Result<()> {
-    let rclone_version = std::str::from_utf8(&rclone_version_output)
+    let rclone_version = std::str::from_utf8(rclone_version_output)
         .map_err(RcloneErrorKind::FromUtf8Error)?
         .lines()
         .next()

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -13,7 +13,7 @@ use rand::{
     thread_rng,
 };
 
-use semver::{Version, VersionReq};
+use semver::{BuildMetadata, Prerelease, Version, VersionReq};
 use shell_words::split;
 
 use crate::{error::RcloneErrorKind, rest::RestBackend};
@@ -78,7 +78,11 @@ fn check_clone_version(rclone_version_output: &[u8]) -> Result<()> {
 
     // for rclone < 1.52.2 setting user/password via env variable doesn't work. This means
     // we are setting up an rclone without authentication which is a security issue!
-    if VersionReq::parse("<1.52.2")?.matches(&Version::parse(rclone_version)?) {
+    let mut parsed_version = Version::parse(rclone_version)?;
+    parsed_version.pre = Prerelease::EMPTY;
+    parsed_version.build = BuildMetadata::EMPTY;
+
+    if VersionReq::parse("<1.52.2")?.matches(&parsed_version) {
         return Err(
             RcloneErrorKind::RCloneWithoutAuthentication(rclone_version.to_string()).into(),
         );

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -76,8 +76,6 @@ fn check_clone_version(rclone_version_output: &[u8]) -> Result<()> {
         .ok_or_else(|| RcloneErrorKind::NoOutputForRcloneVersion)?
         .trim_start_matches(|c: char| !c.is_numeric());
 
-    // for rclone < 1.52.2 setting user/password via env variable doesn't work. This means
-    // we are setting up an rclone without authentication which is a security issue!
     let mut parsed_version = Version::parse(rclone_version)?;
 
     // we need to set the pre and build fields to empty to make the comparison work
@@ -86,6 +84,8 @@ fn check_clone_version(rclone_version_output: &[u8]) -> Result<()> {
     parsed_version.pre = Prerelease::EMPTY;
     parsed_version.build = BuildMetadata::EMPTY;
 
+    // for rclone < 1.52.2 setting user/password via env variable doesn't work. This means
+    // we are setting up an rclone without authentication which is a security issue!
     if VersionReq::parse("<1.52.2")?.matches(&parsed_version) {
         return Err(
             RcloneErrorKind::RCloneWithoutAuthentication(rclone_version.to_string()).into(),

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -128,8 +128,9 @@ impl RcloneBackend {
                 .map_err(RcloneErrorKind::FromIoError)?
                 .stdout;
 
-            // if we want to use a password and rclone_command is not explicitly set, we check for a rclone version supporting
-            // user/password via env variables
+            // if we want to use a password and rclone_command is not explicitly set,
+            // we check for a rclone version supporting user/password via env variables
+            // if the version is not supported, we return an error
             check_clone_version(rclone_version_output.as_slice())?;
         }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -136,7 +136,7 @@ mockall = "0.12.1"
 pretty_assertions = "1.4.0"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-rstest = "0.18.2"
+rstest = { workspace = true }
 rustdoc-json = "0.8.9"
 # We need to have rustic_backend here, because the doc-tests in lib.rs of rustic_core
 rustic_backend = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -113,7 +113,7 @@ gethostname = "0.4.3"
 humantime = "2.1.0"
 itertools = "0.12.1"
 quick_cache = "0.4.1"
-strum = { version = "0.26.1", features = ["derive"] }
+strum = { version = "0.26.2", features = ["derive"] }
 zstd = "0.13.0"
 
 [target.'cfg(not(windows))'.dependencies]


### PR DESCRIPTION
rclone version checking required a version in form "major.minor.patch". Now it supports all semver-compatible versions.

closes https://github.com/rustic-rs/rustic/issues/1097
fixes #6 