### PR TITLE
feat!: Allow specifying many options in config profile without array

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -85,7 +85,6 @@ filetime = "0.2.23"
 ignore = "0.4.22"
 nix = { version = "0.28", default-features = false, features = ["user", "fs"] }
 path-dedot = "3.1.1"
-shell-words = "1.1.0"
 walkdir = "2.5.0"
 
 # cache

--- a/crates/core/src/backend/ignore.rs
+++ b/crates/core/src/backend/ignore.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use serde_with::{serde_as, DisplayFromStr};
+use serde_with::{serde_as, DisplayFromStr, OneOrMany};
 
 use bytesize::ByteSize;
 #[cfg(not(windows))]
@@ -70,21 +70,25 @@ pub struct LocalSourceFilterOptions {
     /// Glob pattern to exclude/include (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub glob: Vec<String>,
 
     /// Same as --glob pattern but ignores the casing of filenames
     #[cfg_attr(feature = "clap", clap(long, value_name = "GLOB"))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub iglob: Vec<String>,
 
     /// Read glob patterns to exclude/include from this file (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long, value_name = "FILE"))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub glob_file: Vec<String>,
 
     /// Same as --glob-file ignores the casing of filenames in patterns
     #[cfg_attr(feature = "clap", clap(long, value_name = "FILE"))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub iglob_file: Vec<String>,
 
     /// Ignore files based on .gitignore files
@@ -100,11 +104,13 @@ pub struct LocalSourceFilterOptions {
     /// Treat the provided filename like a .gitignore file (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long, value_name = "FILE"))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub custom_ignorefile: Vec<String>,
 
     /// Exclude contents of directories containing this filename (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long, value_name = "FILE"))]
     #[cfg_attr(feature = "merge", merge(strategy = merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub exclude_if_present: Vec<String>,
 
     /// Exclude other file systems, don't cross filesystem boundaries and subvolumes

--- a/crates/core/src/commands/forget.rs
+++ b/crates/core/src/commands/forget.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Datelike, Duration, Local, Timelike};
 use derivative::Derivative;
 use derive_setters::Setters;
 use serde_derive::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
+use serde_with::{serde_as, DisplayFromStr, OneOrMany};
 
 use crate::{
     error::RusticResult,
@@ -107,13 +107,14 @@ pub(crate) fn get_forget_snapshots<P: ProgressBars, S: Open>(
 pub struct KeepOptions {
     /// Keep snapshots with this taglist (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long, value_name = "TAG[,TAG,..]"))]
-    #[serde_as(as = "Vec<DisplayFromStr>")]
+    #[serde_as(as = "OneOrMany<DisplayFromStr>")]
     #[cfg_attr(feature = "merge", merge(strategy=merge::vec::overwrite_empty))]
     pub keep_tags: Vec<StringList>,
 
     /// Keep snapshots ids that start with ID (can be specified multiple times)
     #[cfg_attr(feature = "clap", clap(long = "keep-id", value_name = "ID"))]
     #[cfg_attr(feature = "merge", merge(strategy=merge::vec::overwrite_empty))]
+    #[serde_as(as = "OneOrMany<_>")]
     pub keep_ids: Vec<String>,
 
     /// Keep the last N snapshots (N == -1: keep all snapshots)

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -290,8 +290,6 @@ pub enum RepositoryErrorKind {
     /// error accessing config file
     AccessToConfigFileFailed,
     /// {0:?}
-    FromSplitError(#[from] shell_words::ParseError),
-    /// {0:?}
     FromThreadPoolbilderError(rayon::ThreadPoolBuildError),
     /// reading Password failed: `{0:?}`
     ReadingPasswordFromReaderFailed(std::io::Error),
@@ -437,8 +435,6 @@ pub enum SnapshotFileErrorKind {
     UnpackingSnapshotFileResultFailed,
     /// collecting IDs failed: {0:?}
     FindingIdsFailed(Vec<String>),
-    /// {0:?}
-    FromSplitError(#[from] shell_words::ParseError),
     /// removing dots from paths failed: `{0:?}`
     RemovingDotsFromPathFailed(std::io::Error),
     /// canonicalizing path failed: `{0:?}`


### PR DESCRIPTION
Adds the possibility to specify many options in config profile files as single strings which required arrays of strings - in the case of the array only containing 1 entry.

Breaking change:
Also removes the splitting of one string from `password-command` and `warmup-command`. Now the already-split command has to be given as array (or single string if there are no arguments to the command).
