### PR TITLE
feat: add search methods to Repository

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,6 +132,7 @@ xattr = "1"
 [dev-dependencies]
 expect-test = "1.4.1"
 flate2 = "1.0.28"
+globset = "0.4.14"
 insta = { version = "1.36.1", features = ["redactions", "ron"] }
 mockall = "0.12.1"
 pretty_assertions = "1.4.0"

--- a/crates/core/src/backend/node.rs
+++ b/crates/core/src/backend/node.rs
@@ -30,7 +30,9 @@ use crate::error::NodeErrorKind;
 
 use crate::id::Id;
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Constructor)]
+#[derive(
+    Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Constructor, PartialOrd, Ord,
+)]
 /// A node within the tree hierarchy
 pub struct Node {
     /// Name of the node: filename or dirname.
@@ -63,7 +65,7 @@ pub struct Node {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(tag = "type", rename_all = "lowercase")]
 /// Types a [`Node`] can have with type-specific additional information
 pub enum NodeType {
@@ -190,7 +192,7 @@ impl Default for NodeType {
     Option => #[serde(default, skip_serializing_if = "Option::is_none")],
     u64 => #[serde(default, skip_serializing_if = "is_default")],
 )]
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Metadata {
     /// Unix file mode
     pub mode: Option<u32>,
@@ -247,7 +249,7 @@ where
 }
 
 /// Extended attribute of a [`Node`]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct ExtendedAttribute {
     /// Name of the extended attribute
     pub name: String,

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -333,6 +333,7 @@ impl Tree {
 /// Results from `find_node_from_path`
 #[derive(Debug)]
 pub struct FindNode {
+    /// found nodes for the given path
     pub nodes: Vec<Node>,
     /// found nodes for all given snapshots. usize is the index of the node
     pub matches: Vec<Option<usize>>,
@@ -341,7 +342,9 @@ pub struct FindNode {
 /// Results from `find_matching_nodes`
 #[derive(Debug)]
 pub struct FindMatches {
+    /// found matching paths
     pub paths: Vec<PathBuf>,
+    /// found matching nodes
     pub nodes: Vec<Node>,
     /// found paths/nodes for all given snapshots. (usize,usize) is the path / node index
     pub matches: Vec<Vec<(usize, usize)>>,

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -331,7 +331,7 @@ impl Tree {
 }
 
 /// Results from `find_node_from_path`
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FindNode {
     /// found nodes for the given path
     pub nodes: Vec<Node>,
@@ -340,7 +340,7 @@ pub struct FindNode {
 }
 
 /// Results from `find_matching_nodes`
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FindMatches {
     /// found matching paths
     pub paths: Vec<PathBuf>,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -129,7 +129,7 @@ pub use crate::{
         FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen, RepositoryBackends,
         WriteBackend, ALL_FILE_TYPES,
     },
-    blob::tree::TreeStreamerOptions as LsOptions,
+    blob::tree::{FindMatches, FindNode, TreeStreamerOptions as LsOptions},
     commands::{
         backup::{BackupOptions, ParentOptions},
         check::CheckOptions,

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -25,7 +25,7 @@ use crate::{
         FileType, ReadBackend, WriteBackend,
     },
     blob::{
-        tree::{NodeStreamer, TreeStreamerOptions as LsOptions},
+        tree::{FindMatches, FindNode, NodeStreamer, TreeStreamerOptions as LsOptions},
         BlobType,
     },
     commands::{
@@ -1501,20 +1501,36 @@ impl<P, S: IndexedTree> Repository<P, S> {
     }
 
     /// Get all [`Node`]s from given root trees and a path
+    ///
+    /// # Arguments
+    ///
+    /// * `ids` - The tree ids to search in
+    /// * `path` - The path
+    ///
+    /// # Errors
+    /// if loading trees from the backend fails
     pub fn find_nodes_from_path(
         &self,
         ids: impl IntoIterator<Item = Id>,
         path: &Path,
-    ) -> RusticResult<(Vec<Node>, Vec<Option<usize>>)> {
+    ) -> RusticResult<FindNode> {
         Tree::find_nodes_from_path(self.dbe(), self.index(), ids, path)
     }
 
-    /// Get all [`Node`]s from given root trees and a path
+    /// Get all [`Node`]s/[`Path`]s from given root trees and a matching criterion
+    ///
+    /// # Arguments
+    ///
+    /// * `ids` - The tree ids to search in
+    /// * `matches` - The matching criterion
+    ///
+    /// # Errors
+    /// if loading trees from the backend fails
     pub fn find_matching_nodes(
         &self,
         ids: impl IntoIterator<Item = Id>,
         matches: &impl Fn(&Path, &Node) -> bool,
-    ) -> RusticResult<(Vec<PathBuf>, Vec<Node>, Vec<Vec<(usize, usize)>>)> {
+    ) -> RusticResult<FindMatches> {
         Tree::find_matching_nodes(self.dbe(), self.index(), ids, matches)
     }
 }

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -1508,6 +1508,15 @@ impl<P, S: IndexedTree> Repository<P, S> {
     ) -> RusticResult<(Vec<Node>, Vec<Option<usize>>)> {
         Tree::find_nodes_from_path(self.dbe(), self.index(), ids, path)
     }
+
+    /// Get all [`Node`]s from given root trees and a path
+    pub fn find_matching_nodes(
+        &self,
+        ids: impl IntoIterator<Item = Id>,
+        matches: &impl Fn(&Path, &Node) -> bool,
+    ) -> RusticResult<(Vec<PathBuf>, Vec<Node>, Vec<Vec<(usize, usize)>>)> {
+        Tree::find_matching_nodes(self.dbe(), self.index(), ids, matches)
+    }
 }
 
 impl<P: ProgressBars, S: IndexedTree> Repository<P, S> {

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -1499,6 +1499,15 @@ impl<P, S: IndexedTree> Repository<P, S> {
     pub fn node_from_path(&self, root_tree: Id, path: &Path) -> RusticResult<Node> {
         Tree::node_from_path(self.dbe(), self.index(), root_tree, Path::new(path))
     }
+
+    /// Get all [`Node`]s from given root trees and a path
+    pub fn find_nodes_from_path(
+        &self,
+        ids: impl IntoIterator<Item = Id>,
+        path: &Path,
+    ) -> RusticResult<(Vec<Node>, Vec<Option<usize>>)> {
+        Tree::find_nodes_from_path(self.dbe(), self.index(), ids, path)
+    }
 }
 
 impl<P: ProgressBars, S: IndexedTree> Repository<P, S> {

--- a/crates/core/tests/snapshots/integration__find-matching-existing-nix.snap
+++ b/crates/core/tests/snapshots/integration__find-matching-existing-nix.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+([
+  "test/0/tests/testfile",
+], [
+  [
+    (0, 0),
+  ],
+])

--- a/crates/core/tests/snapshots/integration__find-matching-existing-windows.snap
+++ b/crates/core/tests/snapshots/integration__find-matching-existing-windows.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+([
+  "test\\0\\tests\\testfile",
+], [
+  [
+    (0, 0),
+  ],
+])

--- a/crates/core/tests/snapshots/integration__find-matching-nodes-not-found-nix.snap
+++ b/crates/core/tests/snapshots/integration__find-matching-nodes-not-found-nix.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+FindMatches(
+  paths: [],
+  nodes: [],
+  matches: [
+    [],
+  ],
+)

--- a/crates/core/tests/snapshots/integration__find-matching-nodes-not-found-windows.snap
+++ b/crates/core/tests/snapshots/integration__find-matching-nodes-not-found-windows.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+FindMatches(
+  paths: [],
+  nodes: [],
+  matches: [
+    [],
+  ],
+)

--- a/crates/core/tests/snapshots/integration__find-matching-wildcard-existing-nix.snap
+++ b/crates/core/tests/snapshots/integration__find-matching-wildcard-existing-nix.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+([
+  "test/0/tests/testfile",
+  "test/0/tests/testfile-hardlink",
+  "test/0/tests/testfile-symlink",
+], [
+  [
+    (0, 0),
+    (1, 1),
+    (2, 2),
+  ],
+])

--- a/crates/core/tests/snapshots/integration__find-matching-wildcard-existing-windows.snap
+++ b/crates/core/tests/snapshots/integration__find-matching-wildcard-existing-windows.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+([
+  "test\\0\\tests\\testfile",
+  "test\\0\\tests\\testfile-hardlink",
+  "test\\0\\tests\\testfile-symlink",
+], [
+  [
+    (0, 0),
+    (1, 1),
+    (2, 2),
+  ],
+])

--- a/crates/core/tests/snapshots/integration__find-nodes-existing-nix.snap
+++ b/crates/core/tests/snapshots/integration__find-nodes-existing-nix.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+[
+  Some(0),
+]

--- a/crates/core/tests/snapshots/integration__find-nodes-existing-windows.snap
+++ b/crates/core/tests/snapshots/integration__find-nodes-existing-windows.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+[
+  Some(0),
+]

--- a/crates/core/tests/snapshots/integration__find-nodes-not-found-nix.snap
+++ b/crates/core/tests/snapshots/integration__find-nodes-not-found-nix.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+FindNode(
+  nodes: [],
+  matches: [
+    None,
+  ],
+)

--- a/crates/core/tests/snapshots/integration__find-nodes-not-found-windows.snap
+++ b/crates/core/tests/snapshots/integration__find-nodes-not-found-windows.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core/tests/integration.rs
+expression: snap
+---
+FindNode(
+  nodes: [],
+  matches: [
+    None,
+  ],
+)

--- a/examples/find/Cargo.toml
+++ b/examples/find/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "find"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+globset = "0.4.14"
+rustic_backend = { workspace = true }
+rustic_core = { workspace = true }
+simplelog = { workspace = true }
+
+[[example]]
+name = "find"

--- a/examples/find/examples/find.rs
+++ b/examples/find/examples/find.rs
@@ -1,0 +1,42 @@
+//! `ls` example
+use globset::Glob;
+use rustic_backend::BackendOptions;
+use rustic_core::{FindMatches, Repository, RepositoryOptions};
+use simplelog::{Config, LevelFilter, SimpleLogger};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Display info logs
+    let _ = SimpleLogger::init(LevelFilter::Info, Config::default());
+
+    // Initialize Backends
+    let backends = BackendOptions::default()
+        .repository("/tmp/repo")
+        .to_backends()?;
+
+    // Open repository
+    let repo_opts = RepositoryOptions::default().password("test");
+
+    let repo = Repository::new(&repo_opts, &backends)?
+        .open()?
+        .to_indexed()?;
+
+    let mut snapshots = repo.get_all_snapshots()?;
+    snapshots.sort_unstable();
+    let tree_ids = snapshots.iter().map(|sn| sn.tree);
+
+    let glob = Glob::new("*.rs")?.compile_matcher();
+    let FindMatches {
+        paths,
+        nodes,
+        matches,
+    } = repo.find_matching_nodes(tree_ids, &|path, _| glob.is_match(path))?;
+    for (snap, matches) in snapshots.iter().zip(matches) {
+        println!("results in {snap:?}");
+        for (path_idx, node_idx) in matches {
+            println!("path: {:?}, node: {:?}", paths[path_idx], nodes[node_idx]);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds `Repository` methods to find a given path in multiple trees.

`find_nodes_from_path`: Searches for an explicitly given path
`find_matching_nodes`: Searches using an arbitrary matching criterion