### PR TITLE
fix: Export types so the Repository type can be fully specified

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -148,5 +148,7 @@ pub use crate::{
     repofile::snapshotfile::{
         PathList, SnapshotGroup, SnapshotGroupCriterion, SnapshotOptions, StringList,
     },
-    repository::{IndexedFull, OpenStatus, Repository, RepositoryOptions},
+    repository::{
+        FullIndex, IndexedFull, IndexedStatus, OpenStatus, Repository, RepositoryOptions,
+    },
 };


### PR DESCRIPTION
See #227 for more details.

I've added a test-case which constructs a minimal wrapper type around a Repository that implements `IndexedFull`, puts two instances into a collection (the primary motivator behind this), and hands them to a function that relies on the trait.
