### PR TITLE
fix: backup file even if failed listing extended attributes

### DIFF
--- a/crates/core/src/backend/ignore.rs
+++ b/crates/core/src/backend/ignore.rs
@@ -472,7 +472,7 @@ fn get_group_by_gid(gid: u32) -> Option<String> {
     }
 }
 
-#[cfg(target_os = "openbsd")]
+#[cfg(all(not(windows), target_os = "openbsd"))]
 fn list_extended_attributes(path: &Path) -> RusticResult<Vec<ExtendedAttribute>> {
     Ok(vec![])
 }
@@ -486,7 +486,7 @@ fn list_extended_attributes(path: &Path) -> RusticResult<Vec<ExtendedAttribute>>
 /// # Errors
 ///
 /// * [`IgnoreErrorKind::ErrorXattr`] - if Xattr couldn't be listed or couldn't be read
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(all(not(windows), not(target_os = "openbsd")))]
 fn list_extended_attributes(path: &Path) -> RusticResult<Vec<ExtendedAttribute>> {
     Ok(xattr::list(path)
         .map_err(|err| IgnoreErrorKind::ErrorXattr {


### PR DESCRIPTION
This should fix rustic-rs/rustic_core#232 
However I'm not so sure as the error message I encountered is slightly different from what reported by the issue creator.
In both cases I think this PR is worth looking into when you have time.

## The idea:

Even on a system that supports extended-attributes, we might encounter some part of the file-system that doesn't.
For instance a `mount` with the right option (streams_interface=windows for instace) will not support xattr.
AFAIK it also seems to be the case with a simple sshfs on a debian/ubuntu (as experienced in  #232).

## Note 

I used a debug log to print the XAttr error in order to avoid erroring for every file of an extended attribute incompatible backup.

## Testing

I am once again unsure on what tests to add. 
Please let me know if anything comes up to your mind.