### PR TITLE
fix: Allow non-value/null xattr

### DIFF
--- a/crates/core/src/backend/ignore.rs
+++ b/crates/core/src/backend/ignore.rs
@@ -496,12 +496,10 @@ fn list_extended_attributes(path: &Path) -> RusticResult<Vec<ExtendedAttribute>>
         .map(|name| {
             Ok(ExtendedAttribute {
                 name: name.to_string_lossy().to_string(),
-                value: xattr::get(path, name)
-                    .map_err(|err| IgnoreErrorKind::ErrorXattr {
-                        path: path.to_path_buf(),
-                        source: err,
-                    })?
-                    .unwrap(),
+                value: xattr::get(path, name).map_err(|err| IgnoreErrorKind::ErrorXattr {
+                    path: path.to_path_buf(),
+                    source: err,
+                })?,
             })
         })
         .collect::<RusticResult<Vec<ExtendedAttribute>>>()

--- a/crates/core/src/backend/local_destination.rs
+++ b/crates/core/src/backend/local_destination.rs
@@ -400,21 +400,20 @@ impl LocalDestination {
                 |(_, ExtendedAttribute { name, .. })| name == curr_name.to_string_lossy().as_ref(),
             ) {
                 Some((index, ExtendedAttribute { name, value })) => {
-                    let curr_value = xattr::get(&filename, name)
-                        .map_err(|err| LocalDestinationErrorKind::GettingXattrFailed {
+                    let curr_value = xattr::get(&filename, name).map_err(|err| {
+                        LocalDestinationErrorKind::GettingXattrFailed {
                             name: name.clone(),
                             filename: filename.clone(),
                             source: err,
-                        })?
-                        .unwrap();
+                        }
+                    })?;
                     if value != &curr_value {
-                        xattr::set(&filename, name, value).map_err(|err| {
-                            LocalDestinationErrorKind::SettingXattrFailed {
+                        xattr::set(&filename, name, value.as_ref().unwrap_or(&Vec::new()))
+                            .map_err(|err| LocalDestinationErrorKind::SettingXattrFailed {
                                 name: name.clone(),
                                 filename: filename.clone(),
                                 source: err,
-                            }
-                        })?;
+                            })?;
                     }
                     done[index] = true;
                 }
@@ -428,13 +427,13 @@ impl LocalDestination {
 
         for (index, ExtendedAttribute { name, value }) in extended_attributes.iter().enumerate() {
             if !done[index] {
-                xattr::set(&filename, name, value).map_err(|err| {
-                    LocalDestinationErrorKind::SettingXattrFailed {
+                xattr::set(&filename, name, value.as_ref().unwrap_or(&Vec::new())).map_err(
+                    |err| LocalDestinationErrorKind::SettingXattrFailed {
                         name: name.clone(),
                         filename: filename.clone(),
                         source: err,
-                    }
-                })?;
+                    },
+                )?;
             }
         }
 

--- a/crates/core/src/backend/node.rs
+++ b/crates/core/src/backend/node.rs
@@ -229,8 +229,8 @@ pub struct ExtendedAttribute {
     /// Name of the extended attribute
     pub name: String,
     /// Value of the extended attribute
-    #[serde_as(as = "DefaultOnNull<Base64::<Standard,Padded>>")]
-    pub value: Vec<u8>,
+    #[serde_as(as = "DefaultOnNull<Option<Base64::<Standard,Padded>>>")]
+    pub value: Option<Vec<u8>>,
 }
 
 pub(crate) fn is_default<T: Default + PartialEq>(t: &T) -> bool {

--- a/crates/core/src/backend/node.rs
+++ b/crates/core/src/backend/node.rs
@@ -22,7 +22,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_with::{
     base64::{Base64, Standard},
     formats::Padded,
-    serde_as, DeserializeAs, SerializeAs,
+    serde_as, DefaultOnNull, DeserializeAs, SerializeAs,
 };
 
 #[cfg(not(windows))]
@@ -82,7 +82,7 @@ pub enum NodeType {
         /// This contains the target only if it is a valid unicode target.
         /// Don't access this field directly, use the [`NodeType::to_link()`] method instead!
         linktarget: String,
-        #[serde_as(as = "Option<Base64>")]
+        #[serde_as(as = "DefaultOnNull<Option<Base64>>")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         /// The raw link target saved as bytes.
         ///

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -13,8 +13,8 @@ use derive_setters::Setters;
 use ignore::overrides::{Override, OverrideBuilder};
 use ignore::Match;
 
-use serde::{Deserialize, Deserializer};
-use serde_derive::Serialize;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DefaultOnNull};
 
 use crate::{
     backend::{
@@ -37,24 +37,15 @@ pub(super) mod constants {
 pub(crate) type TreeStreamItem = RusticResult<(PathBuf, Tree)>;
 type NodeStreamItem = RusticResult<(PathBuf, Node)>;
 
+#[serde_as]
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
 /// A [`Tree`] is a list of [`Node`]s
 pub struct Tree {
-    #[serde(deserialize_with = "deserialize_null_default")]
+    #[serde_as(as = "DefaultOnNull")]
     /// The nodes contained in the tree.
     ///
     /// This is usually sorted by `Node.name()`, i.e. by the node name as `OsString`
     pub nodes: Vec<Node>,
-}
-
-/// Deserializes `Option<T>` as `T::default()` if the value is `null`
-pub(crate) fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    T: Default + Deserialize<'de>,
-    D: Deserializer<'de>,
-{
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
 }
 
 impl Tree {

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -48,6 +48,7 @@ pub struct Tree {
 }
 
 /// Deserializes `Option<T>` as `T::default()` if the value is `null`
+// TODO: Use serde_with::DefaultOnNull instead. But this has problems with RON which is used in our integration tests...
 pub(crate) fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     T: Default + Deserialize<'de>,

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -13,8 +13,8 @@ use derive_setters::Setters;
 use ignore::overrides::{Override, OverrideBuilder};
 use ignore::Match;
 
-use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DefaultOnNull};
+use serde::{Deserialize, Deserializer};
+use serde_derive::Serialize;
 
 use crate::{
     backend::{
@@ -37,15 +37,24 @@ pub(super) mod constants {
 pub(crate) type TreeStreamItem = RusticResult<(PathBuf, Tree)>;
 type NodeStreamItem = RusticResult<(PathBuf, Node)>;
 
-#[serde_as]
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
 /// A [`Tree`] is a list of [`Node`]s
 pub struct Tree {
-    #[serde_as(as = "DefaultOnNull")]
+    #[serde(deserialize_with = "deserialize_null_default")]
     /// The nodes contained in the tree.
     ///
     /// This is usually sorted by `Node.name()`, i.e. by the node name as `OsString`
     pub nodes: Vec<Node>,
+}
+
+/// Deserializes `Option<T>` as `T::default()` if the value is `null`
+pub(crate) fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }
 
 impl Tree {


### PR DESCRIPTION
handle non-value xattr correctly and also allow to read xattr with `null` value.

closes https://github.com/rustic-rs/rustic/issues/1190
closes https://github.com/rustic-rs/rustic/issues/1189