### PR TITLE
chore: release

### DIFF
--- a/crates/backend/CHANGELOG.md
+++ b/crates/backend/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.2.0...rustic_backend-v0.2.1) - 2024-09-06
+
+### Added
+- Add autocompletion hints  ([#257](https://github.com/rustic-rs/rustic_core/pull/257))
+
+### Fixed
+- Re-add missing opendal services ([#249](https://github.com/rustic-rs/rustic_core/pull/249))
+
+### Other
+- Revert "backend: specify core version"
+
 ## [0.2.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.1.1...rustic_backend-v0.2.0) - 2024-08-18
 
 ### Added

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_backend"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["the rustic-rs team"]
 categories = ["data-structures", "filesystem"]
 documentation = "https://docs.rs/rustic_backend"

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.3.0...rustic_core-v0.3.1) - 2024-09-06
+
+### Added
+- Add autocompletion hints  ([#257](https://github.com/rustic-rs/rustic_core/pull/257))
+
+### Fixed
+- don't give invalid password error for other keyfile errors ([#247](https://github.com/rustic-rs/rustic_core/pull/247))
+- adjust tests to new Rust version ([#259](https://github.com/rustic-rs/rustic_core/pull/259))
+- fix FromStr for SnapshotGroupCriterion ([#254](https://github.com/rustic-rs/rustic_core/pull/254))
+- make more Indexed traits public ([#253](https://github.com/rustic-rs/rustic_core/pull/253))
+- fix StringList::contains_all ([#246](https://github.com/rustic-rs/rustic_core/pull/246))
+- *(build)* unbreak building on OpenBSD ([#245](https://github.com/rustic-rs/rustic_core/pull/245))
+
 ## [0.3.0](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.2.0...rustic_core-v0.3.0) - 2024-08-18
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["the rustic-rs team"]
 categories = ["data-structures", "encoding", "filesystem"]
 documentation = "https://docs.rs/rustic_core"

--- a/crates/testing/CHANGELOG.md
+++ b/crates/testing/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_testing-v0.2.0...rustic_testing-v0.2.1) - 2024-09-06
+
+### Fixed
+- dprint
+
+### Other
+- use rustic_core from workspace

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_testing"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 publish = true


### PR DESCRIPTION
## 🤖 New release
* `rustic_backend`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `rustic_core`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `rustic_testing`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustic_backend`
<blockquote>

## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.2.0...rustic_backend-v0.2.1) - 2024-09-06

### Added
- Add autocompletion hints  ([#257](https://github.com/rustic-rs/rustic_core/pull/257))

### Fixed
- Re-add missing opendal services ([#249](https://github.com/rustic-rs/rustic_core/pull/249))

### Other
- Revert "backend: specify core version"
</blockquote>

## `rustic_core`
<blockquote>

## [0.3.1](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.3.0...rustic_core-v0.3.1) - 2024-09-06

### Added
- Add autocompletion hints  ([#257](https://github.com/rustic-rs/rustic_core/pull/257))

### Fixed
- don't give invalid password error for other keyfile errors ([#247](https://github.com/rustic-rs/rustic_core/pull/247))
- adjust tests to new Rust version ([#259](https://github.com/rustic-rs/rustic_core/pull/259))
- fix FromStr for SnapshotGroupCriterion ([#254](https://github.com/rustic-rs/rustic_core/pull/254))
- make more Indexed traits public ([#253](https://github.com/rustic-rs/rustic_core/pull/253))
- fix StringList::contains_all ([#246](https://github.com/rustic-rs/rustic_core/pull/246))
- *(build)* unbreak building on OpenBSD ([#245](https://github.com/rustic-rs/rustic_core/pull/245))
</blockquote>

## `rustic_testing`
<blockquote>

## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_testing-v0.2.0...rustic_testing-v0.2.1) - 2024-09-06

### Fixed
- dprint

### Other
- use rustic_core from workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).