### PR TITLE
fix(build): unbreak building on OpenBSD

### DIFF
--- a/crates/core/src/backend/ignore.rs
+++ b/crates/core/src/backend/ignore.rs
@@ -20,7 +20,7 @@ use log::warn;
 #[cfg(not(windows))]
 use nix::unistd::{Gid, Group, Uid, User};
 
-#[cfg(not(any(windows, target_os = "openbsd")))]
+#[cfg(not(windows))]
 use crate::backend::node::ExtendedAttribute;
 
 use crate::{


### PR DESCRIPTION
Building rustic_core on OpenBSD fails with:

```
error[E0412]: cannot find type `ExtendedAttribute` in this scope
   --> /tmp/pobj/rustic-0.8.0/rustic-0.8.0/modcargo-crates/rustic_core-0.3.0/src/backend/ignore.rs:476:62
    |
476 | ...usticResult<Vec<ExtendedAttribute>> {
    |                    ^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this struct
    |
1   + use crate::backend::node::ExtendedAttribute;
    |
```

Unbreak by fixing a conditional check.