### PR TITLE
Draft: [EXPERIMENT] begin adding "async" versions of trait/impls

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -85,6 +85,8 @@ semver = { version = "1.0.23", optional = true }
 bytesize = "1.3.0"
 rayon = { version = "1.10.0", optional = true }
 tokio = { version = "1.39.3", optional = true, default-features = false }
+futures = { version = "0.3", optional = true, default-features = false }
+async-trait = "0.1.81"
 
 [target.'cfg(not(windows))'.dependencies]
 # opendal backend - sftp is not supported on windows, see https://github.com/apache/incubator-opendal/issues/2963

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 /// [`BackendAccessErrorKind`] describes the errors that can be returned by the various Backends
 #[derive(Error, Debug, Display)]
 pub enum BackendAccessErrorKind {
+    /// no async variant implemented for backend {0:1}
+    BackendNoAsync(String),
     /// backend {0:?} is not supported!
     BackendNotSupported(String),
     /// backend {0} cannot be loaded: {1:?}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -109,6 +109,7 @@ itertools = "0.13.0"
 quick_cache = "0.6.2"
 strum = { version = "0.26.3", features = ["derive"] }
 zstd = "0.13.2"
+async-trait = "0.1.81"
 
 [target.'cfg(not(windows))'.dependencies]
 sha2 = { version = "0.10.8", features = ["asm"] }

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -12,6 +12,7 @@ pub(crate) mod warm_up;
 use std::{io::Read, ops::Deref, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
+use async_trait::async_trait;
 use bytes::Bytes;
 use enum_map::Enum;
 use log::trace;
@@ -167,6 +168,101 @@ pub trait ReadBackend: Send + Sync + 'static {
     }
 }
 
+// impl<T> ReadBackend for T where T: AsyncReadBackend {
+//     fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
+
+//     }
+// }
+
+/// TODO
+#[async_trait]
+pub trait AsyncReadBackend: Send + Sync + 'static {
+    /// Returns the location of the backend.
+    fn location(&self) -> String;
+
+    /// Lists all files with their size of the given type.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the files to list.
+    ///
+    /// # Errors
+    ///
+    /// If the files could not be listed.
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>>;
+
+    /// Lists all files of the given type.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the files to list.
+    ///
+    /// # Errors
+    ///
+    /// If the files could not be listed.
+    async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
+        Ok(self
+            .list_with_size(tpe)
+            .await?
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect())
+    }
+
+    /// Reads full data of the given file.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The id of the file.
+    ///
+    /// # Errors
+    ///
+    /// If the file could not be read.
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes>;
+
+    /// Reads partial data of the given file.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The id of the file.
+    /// * `cacheable` - Whether the file should be cached.
+    /// * `offset` - The offset to read from.
+    /// * `length` - The length to read.
+    ///
+    /// # Errors
+    ///
+    /// If the file could not be read.
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Bytes>;
+
+    /// Specify if the backend needs a warming-up of files before accessing them.
+    async fn needs_warm_up(&self) -> bool {
+        false
+    }
+
+    /// Warm-up the given file.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The id of the file.
+    ///
+    /// # Errors
+    ///
+    /// If the file could not be read.
+    async fn warm_up(&self, _tpe: FileType, _id: &Id) -> Result<()> {
+        Ok(())
+    }
+}
+
 /// Trait for Searching in a backend.
 ///
 /// This trait is implemented by all backends that can be searched in.
@@ -286,6 +382,131 @@ pub trait FindInBackend: ReadBackend {
 
 impl<T: ReadBackend> FindInBackend for T {}
 
+impl<T: AsyncReadBackend> AsyncFindInBackend for T {}
+
+#[async_trait]
+pub trait AsyncFindInBackend: AsyncReadBackend {
+    /// Finds the id of the file starting with the given string.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The type of the strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `vec` - The strings to search for.
+    ///
+    /// # Errors
+    ///
+    /// * [`BackendAccessErrorKind::NoSuitableIdFound`] - If no id could be found.
+    /// * [`BackendAccessErrorKind::IdNotUnique`] - If the id is not unique.
+    ///
+    /// # Note
+    ///
+    /// This function is used to find the id of a snapshot.
+    ///
+    /// [`BackendAccessErrorKind::NoSuitableIdFound`]: crate::error::BackendAccessErrorKind::NoSuitableIdFound
+    /// [`BackendAccessErrorKind::IdNotUnique`]: crate::error::BackendAccessErrorKind::IdNotUnique
+    async fn find_starts_with<T: AsRef<str> + Send + Sync>(
+        &self,
+        tpe: FileType,
+        vec: &[T],
+    ) -> RusticResult<Vec<Id>> {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum MapResult<T> {
+            None,
+            Some(T),
+            NonUnique,
+        }
+        let mut results = vec![MapResult::None; vec.len()];
+        for id in self.list(tpe).await.map_err(RusticErrorKind::Backend)? {
+            let id_hex = id.to_hex();
+            for (i, v) in vec.iter().enumerate() {
+                if id_hex.starts_with(v.as_ref()) {
+                    if results[i] == MapResult::None {
+                        results[i] = MapResult::Some(id);
+                    } else {
+                        results[i] = MapResult::NonUnique;
+                    }
+                }
+            }
+        }
+
+        results
+            .into_iter()
+            .enumerate()
+            .map(|(i, id)| match id {
+                MapResult::Some(id) => Ok(id),
+                MapResult::None => Err(BackendAccessErrorKind::NoSuitableIdFound(
+                    (vec[i]).as_ref().to_string(),
+                )
+                .into()),
+                MapResult::NonUnique => {
+                    Err(BackendAccessErrorKind::IdNotUnique((vec[i]).as_ref().to_string()).into())
+                }
+            })
+            .collect()
+    }
+
+    /// Finds the id of the file starting with the given string.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The string to search for.
+    ///
+    /// # Errors
+    ///
+    /// * [`IdErrorKind::HexError`] - If the string is not a valid hexadecimal string
+    /// * [`BackendAccessErrorKind::NoSuitableIdFound`] - If no id could be found.
+    /// * [`BackendAccessErrorKind::IdNotUnique`] - If the id is not unique.
+    ///
+    /// [`IdErrorKind::HexError`]: crate::error::IdErrorKind::HexError
+    /// [`BackendAccessErrorKind::NoSuitableIdFound`]: crate::error::BackendAccessErrorKind::NoSuitableIdFound
+    /// [`BackendAccessErrorKind::IdNotUnique`]: crate::error::BackendAccessErrorKind::IdNotUnique
+    async fn find_id(&self, tpe: FileType, id: &str) -> RusticResult<Id> {
+        Ok(self.find_ids(tpe, &[id.to_string()]).await?.remove(0))
+    }
+
+    /// Finds the ids of the files starting with the given strings.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The type of the strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `ids` - The strings to search for.
+    ///
+    /// # Errors
+    ///
+    /// * [`IdErrorKind::HexError`] - If the string is not a valid hexadecimal string
+    /// * [`BackendAccessErrorKind::NoSuitableIdFound`] - If no id could be found.
+    /// * [`BackendAccessErrorKind::IdNotUnique`] - If the id is not unique.
+    ///
+    /// [`IdErrorKind::HexError`]: crate::error::IdErrorKind::HexError
+    /// [`BackendAccessErrorKind::NoSuitableIdFound`]: crate::error::BackendAccessErrorKind::NoSuitableIdFound
+    /// [`BackendAccessErrorKind::IdNotUnique`]: crate::error::BackendAccessErrorKind::IdNotUnique
+    async fn find_ids<T: AsRef<str> + Send + Sync>(
+        &self,
+        tpe: FileType,
+        ids: &[T],
+    ) -> RusticResult<Vec<Id>> {
+        match ids
+            .iter()
+            .map(|id| Id::from_hex(id.as_ref()))
+            .collect::<RusticResult<Vec<_>>>()
+        {
+            Ok(id_vec) => Ok(id_vec),
+            Err(err) => {
+                trace!("no valid IDs given: {err}, searching for ID starting with given strings instead");
+                self.find_starts_with(tpe, ids).await
+            }
+        }
+    }
+}
 /// Trait for backends that can write.
 /// This trait is implemented by all backends that can write data.
 pub trait WriteBackend: ReadBackend {
@@ -336,6 +557,57 @@ pub trait WriteBackend: ReadBackend {
     ///
     /// The result of the removal.
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()>;
+}
+
+#[async_trait]
+pub trait AsyncWriteBackend: AsyncReadBackend {
+    // Creates a new backend.
+    ///
+    /// # Errors
+    ///
+    /// If the backend could not be created.
+    ///
+    /// # Returns
+    ///
+    /// The result of the creation.
+    async fn create(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Writes bytes to the given file.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The id of the file.
+    /// * `cacheable` - Whether the data can be cached.
+    /// * `buf` - The data to write.
+    ///
+    /// # Errors
+    ///
+    /// If the data could not be written.
+    ///
+    /// # Returns
+    ///
+    /// The result of the write.
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()>;
+
+    /// Removes the given file.
+    ///
+    /// # Arguments
+    ///
+    /// * `tpe` - The type of the file.
+    /// * `id` - The id of the file.
+    /// * `cacheable` - Whether the file is cacheable.
+    ///
+    /// # Errors
+    ///
+    /// If the file could not be removed.
+    ///
+    /// # Returns
+    ///
+    /// The result of the removal.
+    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()>;
 }
 
 #[cfg(test)]
@@ -398,6 +670,66 @@ impl ReadBackend for Arc<dyn WriteBackend> {
     ) -> Result<Bytes> {
         self.deref()
             .read_partial(tpe, id, cacheable, offset, length)
+    }
+}
+
+#[async_trait]
+impl AsyncReadBackend for Arc<dyn AsyncWriteBackend> {
+    fn location(&self) -> String {
+        self.deref().location()
+    }
+    async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
+        self.deref().list(tpe).await
+    }
+
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        self.deref().list_with_size(tpe).await
+    }
+
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
+        self.deref().read_full(tpe, id).await
+    }
+
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Bytes> {
+        self.deref()
+            .read_partial(tpe, id, cacheable, offset, length)
+            .await
+    }
+
+    async fn needs_warm_up(&self) -> bool {
+        self.deref().needs_warm_up().await
+    }
+
+    async fn warm_up(&self, tpe: FileType, id: &Id) -> Result<()> {
+        self.deref().warm_up(tpe, id).await
+    }
+}
+
+#[async_trait]
+impl AsyncWriteBackend for Arc<dyn AsyncWriteBackend> {
+    async fn create(&self) -> Result<()> {
+        self.deref().create().await
+    }
+
+    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+        self.deref().remove(tpe, id, cacheable).await
+    }
+
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
+        self.deref().write_bytes(tpe, id, cacheable, buf).await
+    }
+}
+
+impl std::fmt::Debug for dyn AsyncWriteBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WriteBackend{{{}}}", self.location())
     }
 }
 
@@ -524,6 +856,12 @@ pub struct RepositoryBackends {
     repo_hot: Option<Arc<dyn WriteBackend>>,
 }
 
+#[derive(Debug, Clone)]
+pub struct AsyncRepositoryBackends {
+    repository: Arc<dyn AsyncWriteBackend>,
+    repo_hot: Option<Arc<dyn AsyncWriteBackend>>,
+}
+
 impl RepositoryBackends {
     /// Creates a new [`RepositoryBackends`].
     ///
@@ -547,6 +885,30 @@ impl RepositoryBackends {
     /// Returns the hot repository of this [`RepositoryBackends`].
     #[must_use]
     pub fn repo_hot(&self) -> Option<Arc<dyn WriteBackend>> {
+        self.repo_hot.clone()
+    }
+}
+
+impl AsyncRepositoryBackends {
+    pub fn new(
+        repository: Arc<dyn AsyncWriteBackend>,
+        repo_hot: Option<Arc<dyn AsyncWriteBackend>>,
+    ) -> Self {
+        Self {
+            repository,
+            repo_hot,
+        }
+    }
+
+    /// Returns the repository of this [`RepositoryBackends`].
+    #[must_use]
+    pub fn repository(&self) -> Arc<dyn AsyncWriteBackend> {
+        self.repository.clone()
+    }
+
+    /// Returns the hot repository of this [`RepositoryBackends`].
+    #[must_use]
+    pub fn repo_hot(&self) -> Option<Arc<dyn AsyncWriteBackend>> {
         self.repo_hot.clone()
     }
 }

--- a/crates/core/src/backend/hotcold.rs
+++ b/crates/core/src/backend/hotcold.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use bytes::Bytes;
 
 use crate::{
     backend::{FileType, ReadBackend, WriteBackend},
     id::Id,
 };
+
+use super::{AsyncReadBackend, AsyncWriteBackend};
 
 /// A hot/cold backend implementation.
 ///
@@ -21,6 +24,14 @@ pub struct HotColdBackend {
     be_hot: Arc<dyn WriteBackend>,
 }
 
+#[derive(Clone, Debug)]
+pub struct AsyncHotColdBackend {
+    /// The backend to use.
+    be: Arc<dyn AsyncWriteBackend>,
+    /// The backend to use for hot files.
+    be_hot: Arc<dyn AsyncWriteBackend>,
+}
+
 impl HotColdBackend {
     /// Creates a new `HotColdBackend`.
     ///
@@ -33,6 +44,25 @@ impl HotColdBackend {
     /// * `be` - The backend to use.
     /// * `hot_be` - The backend to use for hot files.
     pub fn new<BE: WriteBackend>(be: BE, hot_be: BE) -> Self {
+        Self {
+            be: Arc::new(be),
+            be_hot: Arc::new(hot_be),
+        }
+    }
+}
+
+impl AsyncHotColdBackend {
+    /// Creates a new `HotColdBackend`.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `BE` - The backend to use.
+    ///
+    /// # Arguments
+    ///
+    /// * `be` - The backend to use.
+    /// * `hot_be` - The backend to use for hot files.
+    pub fn new<BE: AsyncWriteBackend>(be: BE, hot_be: BE) -> Self {
         Self {
             be: Arc::new(be),
             be_hot: Arc::new(hot_be),
@@ -77,6 +107,47 @@ impl ReadBackend for HotColdBackend {
     }
 }
 
+#[async_trait]
+impl AsyncReadBackend for AsyncHotColdBackend {
+    fn location(&self) -> String {
+        self.be.location()
+    }
+
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        self.be.list_with_size(tpe).await
+    }
+
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
+        self.be_hot.read_full(tpe, id).await
+    }
+
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Bytes> {
+        if cacheable || tpe != FileType::Pack {
+            self.be_hot
+                .read_partial(tpe, id, cacheable, offset, length)
+                .await
+        } else {
+            self.be
+                .read_partial(tpe, id, cacheable, offset, length)
+                .await
+        }
+    }
+
+    async fn needs_warm_up(&self) -> bool {
+        self.be.needs_warm_up().await
+    }
+
+    async fn warm_up(&self, tpe: FileType, id: &Id) -> Result<()> {
+        self.be.warm_up(tpe, id).await
+    }
+}
 impl WriteBackend for HotColdBackend {
     fn create(&self) -> Result<()> {
         self.be.create()?;
@@ -95,6 +166,32 @@ impl WriteBackend for HotColdBackend {
         self.be.remove(tpe, id, cacheable)?;
         if cacheable || tpe != FileType::Pack {
             self.be_hot.remove(tpe, id, cacheable)?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AsyncWriteBackend for AsyncHotColdBackend {
+    async fn create(&self) -> Result<()> {
+        self.be.create().await?;
+        self.be_hot.create().await
+    }
+
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
+        if tpe != FileType::Config && (cacheable || tpe != FileType::Pack) {
+            self.be_hot
+                .write_bytes(tpe, id, cacheable, buf.clone())
+                .await?;
+        }
+        self.be.write_bytes(tpe, id, cacheable, buf).await
+    }
+
+    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+        // First remove cold file
+        self.be.remove(tpe, id, cacheable).await?;
+        if cacheable || tpe != FileType::Pack {
+            self.be_hot.remove(tpe, id, cacheable).await?;
         }
         Ok(())
     }

--- a/crates/core/src/backend/warm_up.rs
+++ b/crates/core/src/backend/warm_up.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use bytes::Bytes;
 
 use crate::{
@@ -8,11 +9,25 @@ use crate::{
     id::Id,
 };
 
+use super::{AsyncReadBackend, AsyncWriteBackend};
+
 /// A backend which warms up files by simply accessing them.
 #[derive(Clone, Debug)]
 pub struct WarmUpAccessBackend {
     /// The backend to use.
     be: Arc<dyn WriteBackend>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AsyncWarmUpAccessBackend {
+    /// The backend to use.
+    be: Arc<dyn AsyncWriteBackend>,
+}
+
+impl AsyncWarmUpAccessBackend {
+    pub fn new_warm_up(be: Arc<dyn AsyncWriteBackend>) -> Arc<dyn AsyncWriteBackend> {
+        Arc::new(Self { be })
+    }
 }
 
 impl WarmUpAccessBackend {
@@ -61,6 +76,44 @@ impl ReadBackend for WarmUpAccessBackend {
     }
 }
 
+#[async_trait]
+impl AsyncReadBackend for AsyncWarmUpAccessBackend {
+    fn location(&self) -> String {
+        self.be.location()
+    }
+
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        self.be.list_with_size(tpe).await
+    }
+
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
+        self.be.read_full(tpe, id).await
+    }
+
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Bytes> {
+        self.be
+            .read_partial(tpe, id, cacheable, offset, length)
+            .await
+    }
+
+    async fn needs_warm_up(&self) -> bool {
+        true
+    }
+
+    async fn warm_up(&self, tpe: FileType, id: &Id) -> Result<()> {
+        // warm up files by accessing them - error is ignored as we expect this to error out!
+        _ = self.be.read_partial(tpe, id, false, 0, 1);
+        Ok(())
+    }
+}
+
 impl WriteBackend for WarmUpAccessBackend {
     fn create(&self) -> Result<()> {
         self.be.create()
@@ -73,5 +126,21 @@ impl WriteBackend for WarmUpAccessBackend {
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
         // First remove cold file
         self.be.remove(tpe, id, cacheable)
+    }
+}
+
+#[async_trait]
+impl AsyncWriteBackend for AsyncWarmUpAccessBackend {
+    async fn create(&self) -> Result<()> {
+        self.be.create().await
+    }
+
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
+        self.be.write_bytes(tpe, id, cacheable, buf).await
+    }
+
+    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+        // First remove cold file
+        self.be.remove(tpe, id, cacheable).await
     }
 }

--- a/crates/core/src/commands/init.rs
+++ b/crates/core/src/commands/init.rs
@@ -6,7 +6,7 @@ use crate::{
     backend::WriteBackend,
     chunker::random_poly,
     commands::{
-        config::{save_config, ConfigOptions},
+        config::{save_config, save_config_async, ConfigOptions},
         key::KeyOptions,
     },
     crypto::aespoly1305::Key,
@@ -14,6 +14,7 @@ use crate::{
     id::Id,
     repofile::ConfigFile,
     repository::Repository,
+    AsyncRepository,
 };
 
 /// Initialize a new repository.
@@ -62,6 +63,29 @@ pub(crate) fn init<P, S>(
     Ok((key, config))
 }
 
+pub(crate) async fn init_async<P, S>(
+    repo: &AsyncRepository<P, S>,
+    pass: &str,
+    key_opts: &KeyOptions,
+    config_opts: &ConfigOptions,
+) -> RusticResult<(Key, ConfigFile)> {
+    // Create config first to allow catching errors from here without writing anything
+    let repo_id = Id::random();
+    let chunker_poly = random_poly()?;
+    let mut config = ConfigFile::new(2, repo_id, chunker_poly);
+    if repo.be_hot.is_some() {
+        // for hot/cold repository, `config` must be identical to thee config file which is read by the backend, i.e. the one saved in the hot repo.
+        // Note: init_with_config does handle the is_hot config correctly for the hot and the cold repo.
+        config.is_hot = Some(true);
+    }
+    config_opts.apply(&mut config)?;
+
+    let key = init_with_config_async(repo, pass, key_opts, &config).await?;
+    info!("repository {} successfully created.", repo_id);
+
+    Ok((key, config))
+}
+
 /// Initialize a new repository with a given config.
 ///
 /// # Type Parameters
@@ -89,6 +113,20 @@ pub(crate) fn init_with_config<P, S>(
     let (key, id) = key_opts.init_key(repo, pass)?;
     info!("key {id} successfully added.");
     save_config(repo, config.clone(), key)?;
+
+    Ok(key)
+}
+
+pub(crate) async fn init_with_config_async<P, S>(
+    repo: &AsyncRepository<P, S>,
+    pass: &str,
+    key_opts: &KeyOptions,
+    config: &ConfigFile,
+) -> RusticResult<Key> {
+    repo.be.create().await.map_err(RusticErrorKind::Backend)?;
+    let (key, id) = key_opts.init_key_async(repo, pass).await?;
+    info!("key {id} successfully added.");
+    save_config_async(repo, config.clone(), key).await?;
 
     Ok(key)
 }

--- a/crates/core/src/commands/snapshots.rs
+++ b/crates/core/src/commands/snapshots.rs
@@ -7,7 +7,7 @@ use crate::{
         snapshotfile::{SnapshotGroup, SnapshotGroupCriterion},
         SnapshotFile,
     },
-    repository::{Open, Repository},
+    repository::{AsyncOpen, AsyncRepository, Open, Repository},
 };
 
 /// Get the snapshots from the repository.
@@ -52,6 +52,40 @@ pub(crate) fn get_snapshot_group<P: ProgressBars, S: Open>(
             let item = (
                 SnapshotGroup::default(),
                 SnapshotFile::from_ids(dbe, ids, &p)?,
+            );
+            vec![item]
+        }
+    };
+
+    Ok(groups)
+}
+
+pub(crate) async fn get_snapshot_group_async<P: ProgressBars, S: AsyncOpen>(
+    repo: &AsyncRepository<P, S>,
+    ids: &[String],
+    group_by: SnapshotGroupCriterion,
+    filter: impl FnMut(&SnapshotFile) -> bool,
+) -> RusticResult<Vec<(SnapshotGroup, Vec<SnapshotFile>)>> {
+    let pb = &repo.pb;
+    let dbe = repo.dbe();
+    let p = pb.progress_counter("getting snapshots...");
+    let groups = match ids {
+        [] => SnapshotFile::group_from_backend_async(dbe, filter, group_by, &p).await?,
+        [id] if id == "latest" => SnapshotFile::group_from_backend_async(dbe, filter, group_by, &p)
+            .await?
+            .into_iter()
+            .map(|(group, mut snaps)| {
+                snaps.sort_unstable();
+                let last_idx = snaps.len() - 1;
+                snaps.swap(0, last_idx);
+                snaps.truncate(1);
+                (group, snaps)
+            })
+            .collect::<Vec<_>>(),
+        _ => {
+            let item = (
+                SnapshotGroup::default(),
+                SnapshotFile::from_ids_async(dbe, ids, &p).await?,
             );
             vec![item]
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -126,8 +126,9 @@ pub use crate::{
         ignore::{LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions},
         local_destination::LocalDestination,
         node::last_modified_node,
-        FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen, RepositoryBackends,
-        WriteBackend, ALL_FILE_TYPES,
+        AsyncReadBackend, AsyncRepositoryBackends, AsyncWriteBackend, FileType, ReadBackend,
+        ReadSource, ReadSourceEntry, ReadSourceOpen, RepositoryBackends, WriteBackend,
+        ALL_FILE_TYPES,
     },
     blob::tree::{FindMatches, FindNode, TreeStreamerOptions as LsOptions},
     commands::{
@@ -149,6 +150,7 @@ pub use crate::{
         PathList, SnapshotGroup, SnapshotGroupCriterion, SnapshotOptions, StringList,
     },
     repository::{
-        FullIndex, IndexedFull, IndexedStatus, OpenStatus, Repository, RepositoryOptions,
+        AsyncOpenStatus, AsyncRepository, FullIndex, IndexedFull, IndexedStatus, OpenStatus,
+        Repository, RepositoryOptions,
     },
 };


### PR DESCRIPTION
This is an **experimentation** branch.
The way I duplicated code to """quickly""" have an async impl is a **terrible way** to do it.
To me full code duplication is never a good option.

My goal is to reach a state of rustic/rustic_core/rustic_backend to experiment on the async implementations.

This might be a step towards a long term architectural change that could solve issues like rustic-rs/rustic#1181 and possibly enhance performances? (yet to be measured^^)

___ 

Do you find interesting that I keep on going with this experimentation? 