### PR TITLE
chore: release

### DIFF
--- a/crates/backend/CHANGELOG.md
+++ b/crates/backend/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.2.1...rustic_backend-v0.3.0) - 2024-09-23
+
+### Added
+- [**breaking**] Use CommandInput for commands ([#269](https://github.com/rustic-rs/rustic_core/pull/269))
+
+### Other
+- remove readme versions in usage section for easier release due to release PR ([#271](https://github.com/rustic-rs/rustic_core/pull/271))
+- [**breaking**] Use different Id types ([#256](https://github.com/rustic-rs/rustic_core/pull/256))
+- *(deps)* Update opendal ([#268](https://github.com/rustic-rs/rustic_core/pull/268))
+
 ## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.2.0...rustic_backend-v0.2.1) - 2024-09-06
 
 ### Added

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_backend"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["the rustic-rs team"]
 categories = ["data-structures", "filesystem"]
 documentation = "https://docs.rs/rustic_backend"

--- a/crates/config/CHANGELOG.md
+++ b/crates/config/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_config-v0.2.0...rustic_config-v0.2.1) - 2024-09-23
+
+### Other
+- remove readme versions in usage section for easier release due to release PR ([#271](https://github.com/rustic-rs/rustic_core/pull/271))
+
 ## [0.2.0](https://github.com/rustic-rs/rustic_core/compare/rustic_config-v0.1.0...rustic_config-v0.2.0) - 2024-08-18
 
 ### Added

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_config"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["the rustic-rs team"]
 categories = ["config"]
 documentation = "https://docs.rs/rustic_config"

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.3.1...rustic_core-v0.4.0) - 2024-09-23
+
+### Added
+- Add Repository::drop_index and ::drop_data_from_index ([#166](https://github.com/rustic-rs/rustic_core/pull/166))
+- *(commands)* Add option stdin_command to be used in CLI and config file ([#266](https://github.com/rustic-rs/rustic_core/pull/266))
+- [**breaking**] Use CommandInput for commands ([#269](https://github.com/rustic-rs/rustic_core/pull/269))
+- Add CommandInput ([#252](https://github.com/rustic-rs/rustic_core/pull/252))
+
+### Fixed
+- de/serialize tags as DisplayFromStr ([#270](https://github.com/rustic-rs/rustic_core/pull/270))
+- [**breaking**] use plural names for options ([#267](https://github.com/rustic-rs/rustic_core/pull/267))
+- fix clippy lint
+- *(test)* shorten snapshot names for windows environment
+- [**breaking**] improve password-command error reporting ([#265](https://github.com/rustic-rs/rustic_core/pull/265))
+- properly finish progress bar in Repository::get_snapshot_group ([#263](https://github.com/rustic-rs/rustic_core/pull/263))
+
+### Other
+- remove readme versions in usage section for easier release due to release PR ([#271](https://github.com/rustic-rs/rustic_core/pull/271))
+- [**breaking**] Use different Id types ([#256](https://github.com/rustic-rs/rustic_core/pull/256))
+- Use serde_with::skip_serializing_none instead of manual mapping ([#251](https://github.com/rustic-rs/rustic_core/pull/251))
+
 ## [0.3.1](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.3.0...rustic_core-v0.3.1) - 2024-09-06
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_core"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["the rustic-rs team"]
 categories = ["data-structures", "encoding", "filesystem"]
 documentation = "https://docs.rs/rustic_core"


### PR DESCRIPTION
## 🤖 New release
* `rustic_backend`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `rustic_core`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `rustic_config`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustic_backend`
<blockquote>

## [0.3.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.2.1...rustic_backend-v0.3.0) - 2024-09-23

### Added
- [**breaking**] Use CommandInput for commands ([#269](https://github.com/rustic-rs/rustic_core/pull/269))

### Other
- remove readme versions in usage section for easier release due to release PR ([#271](https://github.com/rustic-rs/rustic_core/pull/271))
- [**breaking**] Use different Id types ([#256](https://github.com/rustic-rs/rustic_core/pull/256))
- *(deps)* Update opendal ([#268](https://github.com/rustic-rs/rustic_core/pull/268))
</blockquote>

## `rustic_core`
<blockquote>

## [0.4.0](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.3.1...rustic_core-v0.4.0) - 2024-09-23

### Added
- Add Repository::drop_index and ::drop_data_from_index ([#166](https://github.com/rustic-rs/rustic_core/pull/166))
- *(commands)* Add option stdin_command to be used in CLI and config file ([#266](https://github.com/rustic-rs/rustic_core/pull/266))
- [**breaking**] Use CommandInput for commands ([#269](https://github.com/rustic-rs/rustic_core/pull/269))
- Add CommandInput ([#252](https://github.com/rustic-rs/rustic_core/pull/252))

### Fixed
- de/serialize tags as DisplayFromStr ([#270](https://github.com/rustic-rs/rustic_core/pull/270))
- [**breaking**] use plural names for options ([#267](https://github.com/rustic-rs/rustic_core/pull/267))
- fix clippy lint
- *(test)* shorten snapshot names for windows environment
- [**breaking**] improve password-command error reporting ([#265](https://github.com/rustic-rs/rustic_core/pull/265))
- properly finish progress bar in Repository::get_snapshot_group ([#263](https://github.com/rustic-rs/rustic_core/pull/263))

### Other
- remove readme versions in usage section for easier release due to release PR ([#271](https://github.com/rustic-rs/rustic_core/pull/271))
- [**breaking**] Use different Id types ([#256](https://github.com/rustic-rs/rustic_core/pull/256))
- Use serde_with::skip_serializing_none instead of manual mapping ([#251](https://github.com/rustic-rs/rustic_core/pull/251))
</blockquote>

## `rustic_config`
<blockquote>

## [0.2.1](https://github.com/rustic-rs/rustic_core/compare/rustic_config-v0.2.0...rustic_config-v0.2.1) - 2024-09-23

### Other
- remove readme versions in usage section for easier release due to release PR ([#271](https://github.com/rustic-rs/rustic_core/pull/271))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).