### PR TITLE
fix!: improve password-command error reporting

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -281,8 +281,8 @@ pub enum RepositoryErrorKind {
     IsNotHotRepository,
     /// incorrect password!
     IncorrectPassword,
-    /// failed to call password command
-    PasswordCommandParsingFailed,
+    /// error running the password command
+    PasswordCommandExecutionFailed,
     /// error reading password from command
     ReadingPasswordFromCommandFailed,
     /// error listing the repo config file


### PR DESCRIPTION
* When process spawning failed, e.g. command did not exist, then previously the only output was "error: No such file or directory" without any context about what Rustic was trying to do. This is changed.
* Also when `wait_with_output()` failed, the detailed error was not reported.
* Renamed error kind `PasswordCommandParsingFailed` to `PasswordCommandExecutionFailed` because the error conditions had nothing to do with parsing. (Also updated `rustic`: https://github.com/rustic-rs/rustic/pull/1237)
