### PR TITLE
doc: remove readme versions in usage section for easier release due to release PR

### DIFF
--- a/crates/backend/README.md
+++ b/crates/backend/README.md
@@ -44,7 +44,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustic_backend = "0.1"
+rustic_backend = "*"
 ```
 
 ## Crate features

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -39,7 +39,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustic_config = "0.1"
+rustic_config = "*"
 ```
 
 <!-- ## Crate features

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustic_core = "0.2"
+rustic_core = "*"
 ```
 
 ## Crate features


### PR DESCRIPTION
People should set their own version here if they want it locked to a specific one. This section in the docs would need us to update it every time before we release a new version (major/minor). We can just use a star here and let the user decide.

People will use the copy function of crates.io anyway, I think:
![2024-09-23 17_32_44-rustic_core - crates io_ Rust Package Registry — Mozilla Firefox](https://github.com/user-attachments/assets/e7f12796-8c00-4f1a-9e79-17826e4954ec)
