### PR TITLE
fix: Don't query the default cache directory when a custom one is set

### DIFF
--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -237,11 +237,13 @@ impl Cache {
     /// [`CacheBackendErrorKind::NoCacheDirectory`]: crate::error::CacheBackendErrorKind::NoCacheDirectory
     /// [`CacheBackendErrorKind::FromIoError`]: crate::error::CacheBackendErrorKind::FromIoError
     pub fn new(id: RepositoryId, path: Option<PathBuf>) -> RusticResult<Self> {
-        let mut path = path.unwrap_or({
+        let mut path = if let Some(p) = path {
+            p
+        } else {
             let mut dir = cache_dir().ok_or_else(|| CacheBackendErrorKind::NoCacheDirectory)?;
             dir.push("rustic");
             dir
-        });
+        };
         fs::create_dir_all(&path).map_err(CacheBackendErrorKind::FromIoError)?;
         cachedir::ensure_tag(&path).map_err(CacheBackendErrorKind::FromIoError)?;
         path.push(id.to_hex());


### PR DESCRIPTION
The default cache directory is now only queried if no explicit cache path is given. This is necessary to prevent errors on platforms where the default cache directory does not exist, like Android.