### PR TITLE
ci: don't run heavy ci on push to main

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -15,16 +15,12 @@ defaults:
     shell: bash
 
 on:
-  push:
-    # Runs when a commit is pushed to the main branch
-    branches:
-      - main
   merge_group:
     # Runs in a merge group
     types: [checks_requested]
   schedule:
-    # Run every Sunday at midnight
-    - cron: "0 0 * * 0"
+    # Run every day at midnight
+    - cron: "0 0 * * *"
 
 jobs:
   fmt:


### PR DESCRIPTION
Due to extensive use of the merge queue, we essentially run the heavy ci twice. once in the merge group and then again when being pushed from the merge group to main. This wastes runner resources and time. Instead we can just run on schedule every night and count on the merge group CI runs.