### PR TITLE
refactor(commands): decouple logic from option structs for check, prune, repair, key, and restore

### DIFF
--- a/crates/core/src/commands/init.rs
+++ b/crates/core/src/commands/init.rs
@@ -7,7 +7,7 @@ use crate::{
     chunker::random_poly,
     commands::{
         config::{save_config, ConfigOptions},
-        key::KeyOptions,
+        key::{init_key, KeyOptions},
     },
     crypto::aespoly1305::Key,
     error::{RusticErrorKind, RusticResult},
@@ -86,7 +86,7 @@ pub(crate) fn init_with_config<P, S>(
     config: &ConfigFile,
 ) -> RusticResult<Key> {
     repo.be.create().map_err(RusticErrorKind::Backend)?;
-    let (key, id) = key_opts.init_key(repo, pass)?;
+    let (key, id) = init_key(repo, key_opts, pass)?;
     info!("key {id} successfully added.");
     save_config(repo, config.clone(), key)?;
 

--- a/crates/core/src/commands/key.rs
+++ b/crates/core/src/commands/key.rs
@@ -28,88 +28,94 @@ pub struct KeyOptions {
     pub with_created: bool,
 }
 
-impl KeyOptions {
-    /// Add the current key to the repository.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `P` - The progress bar type.
-    /// * `S` - The state the repository is in.
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - The repository to add the key to.
-    /// * `pass` - The password to encrypt the key with.
-    ///
-    /// # Errors
-    ///
-    /// * [`CommandErrorKind::FromJsonError`] - If the key could not be serialized.
-    ///
-    /// # Returns
-    ///
-    /// The id of the key.
-    ///
-    /// [`CommandErrorKind::FromJsonError`]: crate::error::CommandErrorKind::FromJsonError
-    pub(crate) fn add_key<P, S: Open>(
-        &self,
-        repo: &Repository<P, S>,
-        pass: &str,
-    ) -> RusticResult<KeyId> {
-        let key = repo.dbe().key();
-        self.add(repo, pass, *key)
-    }
+/// Add the current key to the repository.
+///
+/// # Type Parameters
+///
+/// * `P` - The progress bar type
+/// * `S` - The state the repository is in
+///
+/// # Arguments
+///
+/// * `repo` - The repository to add the key to
+/// * `opts` - The key options to use
+/// * `pass` - The password to encrypt the key with
+///
+/// # Errors
+///
+/// * [`CommandErrorKind::FromJsonError`] - If the key could not be serialized
+///
+/// # Returns
+///
+/// The id of the key.
+///
+/// [`CommandErrorKind::FromJsonError`]: crate::error::CommandErrorKind::FromJsonError
+pub(crate) fn add_current_key_to_repo<P, S: Open>(
+    repo: &Repository<P, S>,
+    opts: &KeyOptions,
+    pass: &str,
+) -> RusticResult<KeyId> {
+    let key = repo.dbe().key();
+    add_key_to_repo(repo, opts, pass, *key)
+}
 
-    /// Initialize a new key.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `P` - The progress bar type.
-    /// * `S` - The state the repository is in.
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - The repository to add the key to.
-    /// * `pass` - The password to encrypt the key with.
-    ///
-    /// # Returns
-    ///
-    /// A tuple of the key and the id of the key.
-    pub(crate) fn init_key<P, S>(
-        &self,
-        repo: &Repository<P, S>,
-        pass: &str,
-    ) -> RusticResult<(Key, KeyId)> {
-        // generate key
-        let key = Key::new();
-        Ok((key, self.add(repo, pass, key)?))
-    }
+/// Initialize a new key.
+///
+/// # Type Parameters
+///
+/// * `P` - The progress bar type
+/// * `S` - The state the repository is in
+///
+/// # Arguments
+///
+/// * `repo` - The repository to add the key to
+/// * `opts` - The key options to use
+/// * `pass` - The password to encrypt the key with
+///
+/// # Returns
+///
+/// A tuple of the key and the id of the key.
+pub(crate) fn init_key<P, S>(
+    repo: &Repository<P, S>,
+    opts: &KeyOptions,
+    pass: &str,
+) -> RusticResult<(Key, KeyId)> {
+    // generate key
+    let key = Key::new();
+    Ok((key, add_key_to_repo(repo, opts, pass, key)?))
+}
 
-    /// Add a key to the repository.
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - The repository to add the key to.
-    /// * `pass` - The password to encrypt the key with.
-    /// * `key` - The key to add.
-    ///
-    /// # Errors
-    ///
-    /// * [`CommandErrorKind::FromJsonError`] - If the key could not be serialized.
-    ///
-    /// # Returns
-    ///
-    /// The id of the key.
-    ///
-    /// [`CommandErrorKind::FromJsonError`]: crate::error::CommandErrorKind::FromJsonError
-    fn add<P, S>(&self, repo: &Repository<P, S>, pass: &str, key: Key) -> RusticResult<KeyId> {
-        let ko = self.clone();
-        let keyfile = KeyFile::generate(key, &pass, ko.hostname, ko.username, ko.with_created)?;
+/// Add a key to the repository.
+///
+/// # Arguments
+///
+/// * `repo` - The repository to add the key to
+/// * `opts` - The key options to use
+/// * `pass` - The password to encrypt the key with
+/// * `key` - The key to add
+///
+/// # Errors
+///
+/// * [`CommandErrorKind::FromJsonError`] - If the key could not be serialized.
+///
+/// # Returns
+///
+/// The id of the key.
+///
+/// [`CommandErrorKind::FromJsonError`]: crate::error::CommandErrorKind::FromJsonError
+pub(crate) fn add_key_to_repo<P, S>(
+    repo: &Repository<P, S>,
+    opts: &KeyOptions,
+    pass: &str,
+    key: Key,
+) -> RusticResult<KeyId> {
+    let ko = opts.clone();
+    let keyfile = KeyFile::generate(key, &pass, ko.hostname, ko.username, ko.with_created)?;
 
-        let data = serde_json::to_vec(&keyfile).map_err(CommandErrorKind::FromJsonError)?;
-        let id = KeyId::from(hash(&data));
-        repo.be
-            .write_bytes(FileType::Key, &id, false, data.into())
-            .map_err(RusticErrorKind::Backend)?;
-        Ok(id)
-    }
+    let data = serde_json::to_vec(&keyfile).map_err(CommandErrorKind::FromJsonError)?;
+    let id = KeyId::from(hash(&data));
+    repo.be
+        .write_bytes(FileType::Key, &id, false, data.into())
+        .map_err(RusticErrorKind::Backend)?;
+    Ok(id)
 }

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -62,231 +62,232 @@ impl Default for RepairSnapshotsOptions {
 
 // TODO: add documentation
 #[derive(Clone, Copy)]
-enum Changed {
+pub(crate) enum Changed {
     This,
     SubTree,
     None,
 }
 
 #[derive(Default)]
-struct RepairState {
+pub(crate) struct RepairState {
     replaced: BTreeMap<TreeId, (Changed, TreeId)>,
     seen: BTreeSet<TreeId>,
     delete: Vec<SnapshotId>,
 }
 
-impl RepairSnapshotsOptions {
-    /// Runs the `repair snapshots` command
-    ///
-    /// # Type Parameters
-    ///
-    /// * `P` - The progress bar type
-    /// * `S` - The type of the indexed tree.
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - The repository to repair
-    /// * `snapshots` - The snapshots to repair
-    /// * `dry_run` - Whether to actually modify the repository or just print what would be done
-    pub(crate) fn repair<P: ProgressBars, S: IndexedFull>(
-        &self,
-        repo: &Repository<P, S>,
-        snapshots: Vec<SnapshotFile>,
-        dry_run: bool,
-    ) -> RusticResult<()> {
-        let be = repo.dbe();
-        let config_file = repo.config();
+/// Runs the `repair snapshots` command
+///
+/// # Type Parameters
+///
+/// * `P` - The progress bar type
+/// * `S` - The type of the indexed tree.
+///
+/// # Arguments
+///
+/// * `repo` - The repository to repair
+/// * `opts` - The repair options to use
+/// * `snapshots` - The snapshots to repair
+/// * `dry_run` - Whether to actually modify the repository or just print what would be done
+pub(crate) fn repair_snapshots<P: ProgressBars, S: IndexedFull>(
+    repo: &Repository<P, S>,
+    opts: &RepairSnapshotsOptions,
+    snapshots: Vec<SnapshotFile>,
+    dry_run: bool,
+) -> RusticResult<()> {
+    let be = repo.dbe();
+    let config_file = repo.config();
 
-        if self.delete && config_file.append_only == Some(true) {
-            return Err(
-                CommandErrorKind::NotAllowedWithAppendOnly("snapshot removal".to_string()).into(),
-            );
-        }
-
-        let mut state = RepairState::default();
-
-        let indexer = Indexer::new(be.clone()).into_shared();
-        let mut packer = Packer::new(
-            be.clone(),
-            BlobType::Tree,
-            indexer.clone(),
-            config_file,
-            repo.index().total_size(BlobType::Tree),
-        )?;
-
-        for mut snap in snapshots {
-            let snap_id = snap.id;
-            info!("processing snapshot {snap_id}");
-            match self.repair_tree(
-                repo.dbe(),
-                repo.index(),
-                &mut packer,
-                Some(snap.tree),
-                &mut state,
-                dry_run,
-            )? {
-                (Changed::None, _) => {
-                    info!("snapshot {snap_id} is ok.");
-                }
-                (Changed::This, _) => {
-                    warn!("snapshot {snap_id}: root tree is damaged -> marking for deletion!");
-                    state.delete.push(snap_id);
-                }
-                (Changed::SubTree, id) => {
-                    // change snapshot tree
-                    if snap.original.is_none() {
-                        snap.original = Some(snap.id);
-                    }
-                    _ = snap.set_tags(self.tag.clone());
-                    snap.tree = id;
-                    if dry_run {
-                        info!("would have modified snapshot {snap_id}.");
-                    } else {
-                        let new_id = be.save_file(&snap)?;
-                        info!("saved modified snapshot as {new_id}.");
-                    }
-                    state.delete.push(snap_id);
-                }
-            }
-        }
-
-        if !dry_run {
-            _ = packer.finalize()?;
-            indexer.write().unwrap().finalize()?;
-        }
-
-        if self.delete {
-            if dry_run {
-                info!("would have removed {} snapshots.", state.delete.len());
-            } else {
-                be.delete_list(
-                    true,
-                    state.delete.iter(),
-                    repo.pb.progress_counter("remove defect snapshots"),
-                )?;
-            }
-        }
-
-        Ok(())
+    if opts.delete && config_file.append_only == Some(true) {
+        return Err(
+            CommandErrorKind::NotAllowedWithAppendOnly("snapshot removal".to_string()).into(),
+        );
     }
 
-    /// Repairs a tree
-    ///
-    /// # Type Parameters
-    ///
-    /// * `BE` - The type of the backend.
-    ///
-    /// # Arguments
-    ///
-    /// * `be` - The backend to use
-    /// * `packer` - The packer to use
-    /// * `id` - The id of the tree to repair
-    /// * `replaced` - A map of already replaced trees
-    /// * `seen` - A set of already seen trees
-    /// * `dry_run` - Whether to actually modify the repository or just print what would be done
-    ///
-    /// # Returns
-    ///
-    /// A tuple containing the change status and the id of the repaired tree
-    fn repair_tree<BE: DecryptWriteBackend>(
-        &self,
-        be: &impl DecryptFullBackend,
-        index: &impl ReadGlobalIndex,
-        packer: &mut Packer<BE>,
-        id: Option<TreeId>,
-        state: &mut RepairState,
-        dry_run: bool,
-    ) -> RusticResult<(Changed, TreeId)> {
-        let (tree, changed) = match id {
-            None => (Tree::new(), Changed::This),
-            Some(id) => {
-                if state.seen.contains(&id) {
-                    return Ok((Changed::None, id));
+    let mut state = RepairState::default();
+
+    let indexer = Indexer::new(be.clone()).into_shared();
+    let mut packer = Packer::new(
+        be.clone(),
+        BlobType::Tree,
+        indexer.clone(),
+        config_file,
+        repo.index().total_size(BlobType::Tree),
+    )?;
+
+    for mut snap in snapshots {
+        let snap_id = snap.id;
+        info!("processing snapshot {snap_id}");
+        match repair_tree(
+            repo.dbe(),
+            opts,
+            repo.index(),
+            &mut packer,
+            Some(snap.tree),
+            &mut state,
+            dry_run,
+        )? {
+            (Changed::None, _) => {
+                info!("snapshot {snap_id} is ok.");
+            }
+            (Changed::This, _) => {
+                warn!("snapshot {snap_id}: root tree is damaged -> marking for deletion!");
+                state.delete.push(snap_id);
+            }
+            (Changed::SubTree, id) => {
+                // change snapshot tree
+                if snap.original.is_none() {
+                    snap.original = Some(snap.id);
                 }
-                if let Some(r) = state.replaced.get(&id) {
-                    return Ok(*r);
+                _ = snap.set_tags(opts.tag.clone());
+                snap.tree = id;
+                if dry_run {
+                    info!("would have modified snapshot {snap_id}.");
+                } else {
+                    let new_id = be.save_file(&snap)?;
+                    info!("saved modified snapshot as {new_id}.");
                 }
+                state.delete.push(snap_id);
+            }
+        }
+    }
 
-                let (tree, mut changed) = Tree::from_backend(be, index, id).map_or_else(
-                    |_err| {
-                        warn!("tree {id} could not be loaded.");
-                        (Tree::new(), Changed::This)
-                    },
-                    |tree| (tree, Changed::None),
-                );
+    if !dry_run {
+        _ = packer.finalize()?;
+        indexer.write().unwrap().finalize()?;
+    }
 
-                let mut new_tree = Tree::new();
+    if opts.delete {
+        if dry_run {
+            info!("would have removed {} snapshots.", state.delete.len());
+        } else {
+            be.delete_list(
+                true,
+                state.delete.iter(),
+                repo.pb.progress_counter("remove defect snapshots"),
+            )?;
+        }
+    }
 
-                for mut node in tree {
-                    match node.node_type {
-                        NodeType::File {} => {
-                            let mut file_changed = false;
-                            let mut new_content = Vec::new();
-                            let mut new_size = 0;
-                            for blob in node.content.take().unwrap() {
-                                index.get_data(&blob).map_or_else(
-                                    || {
-                                        file_changed = true;
-                                    },
-                                    |ie| {
-                                        new_content.push(blob);
-                                        new_size += u64::from(ie.data_length());
-                                    },
-                                );
-                            }
-                            if file_changed {
-                                warn!("file {}: contents are missing", node.name);
-                                node.name += &self.suffix;
-                                changed = Changed::SubTree;
-                            } else if new_size != node.meta.size {
-                                info!("file {}: corrected file size", node.name);
-                                changed = Changed::SubTree;
-                            }
-                            node.content = Some(new_content);
-                            node.meta.size = new_size;
+    Ok(())
+}
+
+/// Repairs a tree
+///
+/// # Type Parameters
+///
+/// * `BE` - The type of the backend.
+///
+/// # Arguments
+///
+/// * `be` - The backend to use
+/// * `opts` - The repair options to use
+/// * `packer` - The packer to use
+/// * `id` - The id of the tree to repair
+/// * `replaced` - A map of already replaced trees
+/// * `seen` - A set of already seen trees
+/// * `dry_run` - Whether to actually modify the repository or just print what would be done
+///
+/// # Returns
+///
+/// A tuple containing the change status and the id of the repaired tree
+pub(crate) fn repair_tree<BE: DecryptWriteBackend>(
+    be: &impl DecryptFullBackend,
+    opts: &RepairSnapshotsOptions,
+    index: &impl ReadGlobalIndex,
+    packer: &mut Packer<BE>,
+    id: Option<TreeId>,
+    state: &mut RepairState,
+    dry_run: bool,
+) -> RusticResult<(Changed, TreeId)> {
+    let (tree, changed) = match id {
+        None => (Tree::new(), Changed::This),
+        Some(id) => {
+            if state.seen.contains(&id) {
+                return Ok((Changed::None, id));
+            }
+            if let Some(r) = state.replaced.get(&id) {
+                return Ok(*r);
+            }
+
+            let (tree, mut changed) = Tree::from_backend(be, index, id).map_or_else(
+                |_err| {
+                    warn!("tree {id} could not be loaded.");
+                    (Tree::new(), Changed::This)
+                },
+                |tree| (tree, Changed::None),
+            );
+
+            let mut new_tree = Tree::new();
+
+            for mut node in tree {
+                match node.node_type {
+                    NodeType::File {} => {
+                        let mut file_changed = false;
+                        let mut new_content = Vec::new();
+                        let mut new_size = 0;
+                        for blob in node.content.take().unwrap() {
+                            index.get_data(&blob).map_or_else(
+                                || {
+                                    file_changed = true;
+                                },
+                                |ie| {
+                                    new_content.push(blob);
+                                    new_size += u64::from(ie.data_length());
+                                },
+                            );
                         }
-                        NodeType::Dir {} => {
-                            let (c, tree_id) =
-                                self.repair_tree(be, index, packer, node.subtree, state, dry_run)?;
-                            match c {
-                                Changed::None => {}
-                                Changed::This => {
-                                    warn!("dir {}: tree is missing", node.name);
-                                    node.subtree = Some(tree_id);
-                                    node.name += &self.suffix;
-                                    changed = Changed::SubTree;
-                                }
-                                Changed::SubTree => {
-                                    node.subtree = Some(tree_id);
-                                    changed = Changed::SubTree;
-                                }
-                            }
+                        if file_changed {
+                            warn!("file {}: contents are missing", node.name);
+                            node.name += &opts.suffix;
+                            changed = Changed::SubTree;
+                        } else if new_size != node.meta.size {
+                            info!("file {}: corrected file size", node.name);
+                            changed = Changed::SubTree;
                         }
-                        _ => {} // Other types: no check needed
+                        node.content = Some(new_content);
+                        node.meta.size = new_size;
                     }
-                    new_tree.add(node);
+                    NodeType::Dir {} => {
+                        let (c, tree_id) =
+                            repair_tree(be, opts, index, packer, node.subtree, state, dry_run)?;
+                        match c {
+                            Changed::None => {}
+                            Changed::This => {
+                                warn!("dir {}: tree is missing", node.name);
+                                node.subtree = Some(tree_id);
+                                node.name += &opts.suffix;
+                                changed = Changed::SubTree;
+                            }
+                            Changed::SubTree => {
+                                node.subtree = Some(tree_id);
+                                changed = Changed::SubTree;
+                            }
+                        }
+                    }
+                    _ => {} // Other types: no check needed
                 }
-                if matches!(changed, Changed::None) {
-                    _ = state.seen.insert(id);
-                }
-                (new_tree, changed)
+                new_tree.add(node);
             }
-        };
+            if matches!(changed, Changed::None) {
+                _ = state.seen.insert(id);
+            }
+            (new_tree, changed)
+        }
+    };
 
-        match (id, changed) {
-            (None, Changed::None) => panic!("this should not happen!"),
-            (Some(id), Changed::None) => Ok((Changed::None, id)),
-            (_, c) => {
-                // the tree has been changed => save it
-                let (chunk, new_id) = tree.serialize()?;
-                if !index.has_tree(&new_id) && !dry_run {
-                    packer.add(chunk.into(), BlobId::from(*new_id))?;
-                }
-                if let Some(id) = id {
-                    _ = state.replaced.insert(id, (c, new_id));
-                }
-                Ok((c, new_id))
+    match (id, changed) {
+        (None, Changed::None) => panic!("this should not happen!"),
+        (Some(id), Changed::None) => Ok((Changed::None, id)),
+        (_, c) => {
+            // the tree has been changed => save it
+            let (chunk, new_id) = tree.serialize()?;
+            if !index.has_tree(&new_id) && !dry_run {
+                packer.add(chunk.into(), BlobId::from(*new_id))?;
             }
+            if let Some(id) = id {
+                _ = state.replaced.insert(id, (c, new_id));
+            }
+            Ok((c, new_id))
         }
     }
 }

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -41,8 +41,8 @@ use crate::{
         key::{add_current_key_to_repo, KeyOptions},
         prune::{PruneOptions, PrunePlan},
         repair::{
-            index::{index_checked_from_collector, RepairIndexOptions},
-            snapshots::RepairSnapshotsOptions,
+            index::{index_checked_from_collector, repair_index, RepairIndexOptions},
+            snapshots::{repair_snapshots, RepairSnapshotsOptions},
         },
         repoinfo::{IndexInfos, RepoFileInfos},
         restore::{RestoreOptions, RestorePlan},
@@ -1365,7 +1365,7 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     ///
     // TODO: Document errors
     pub fn repair_index(&self, opts: &RepairIndexOptions, dry_run: bool) -> RusticResult<()> {
-        opts.repair(self, dry_run)
+        repair_index(self, *opts, dry_run)
     }
 }
 
@@ -2064,6 +2064,6 @@ impl<P: ProgressBars, S: IndexedFull> Repository<P, S> {
         snapshots: Vec<SnapshotFile>,
         dry_run: bool,
     ) -> RusticResult<()> {
-        opts.repair(self, snapshots, dry_run)
+        repair_snapshots(self, opts, snapshots, dry_run)
     }
 }

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -45,7 +45,7 @@ use crate::{
             snapshots::{repair_snapshots, RepairSnapshotsOptions},
         },
         repoinfo::{IndexInfos, RepoFileInfos},
-        restore::{RestoreOptions, RestorePlan},
+        restore::{collect_and_prepare, restore_repository, RestoreOptions, RestorePlan},
     },
     crypto::aespoly1305::Key,
     error::{CommandErrorKind, KeyFileErrorKind, RepositoryErrorKind, RusticErrorKind},
@@ -1816,7 +1816,7 @@ impl<P: ProgressBars, S: IndexedTree> Repository<P, S> {
         node_streamer: impl Iterator<Item = RusticResult<(PathBuf, Node)>>,
         dest: &LocalDestination,
     ) -> RusticResult<()> {
-        opts.restore(restore_infos, self, node_streamer, dest)
+        restore_repository(restore_infos, self, *opts, node_streamer, dest)
     }
 
     /// Merge the given trees.
@@ -2008,7 +2008,7 @@ impl<P: ProgressBars, S: IndexedFull> Repository<P, S> {
         dest: &LocalDestination,
         dry_run: bool,
     ) -> RusticResult<RestorePlan> {
-        opts.collect_and_prepare(self, node_streamer, dest, dry_run)
+        collect_and_prepare(self, *opts, node_streamer, dest, dry_run)
     }
 
     /// Copy the given `snapshots` to `repo_dest`.

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -38,7 +38,7 @@ use crate::{
         config::ConfigOptions,
         copy::CopySnapshot,
         forget::{ForgetGroups, KeepOptions},
-        key::KeyOptions,
+        key::{add_current_key_to_repo, KeyOptions},
         prune::{PruneOptions, PrunePlan},
         repair::{
             index::{index_checked_from_collector, RepairIndexOptions},
@@ -840,7 +840,7 @@ impl<P, S: Open> Repository<P, S> {
     ///
     /// [`CommandErrorKind::FromJsonError`]: crate::error::CommandErrorKind::FromJsonError
     pub fn add_key(&self, pass: &str, opts: &KeyOptions) -> RusticResult<KeyId> {
-        opts.add_key(self, pass)
+        add_current_key_to_repo(self, opts, pass)
     }
 
     /// Update the repository config by applying the given [`ConfigOptions`]

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -34,7 +34,7 @@ use crate::{
     commands::{
         self,
         backup::BackupOptions,
-        check::CheckOptions,
+        check::{check_repository, CheckOptions},
         config::ConfigOptions,
         copy::CopySnapshot,
         forget::{ForgetGroups, KeepOptions},
@@ -1162,7 +1162,7 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
             .map(|snap| snap.tree)
             .collect();
 
-        opts.run(self, trees)
+        check_repository(self, opts, trees)
     }
 
     /// Check the repository and given trees for errors or inconsistencies
@@ -1175,7 +1175,7 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     ///
     // TODO: Document errors
     pub fn check_with_trees(&self, opts: CheckOptions, trees: Vec<TreeId>) -> RusticResult<()> {
-        opts.run(self, trees)
+        check_repository(self, opts, trees)
     }
 
     /// Get the plan about what should be pruned and/or repacked.

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -39,7 +39,7 @@ use crate::{
         copy::CopySnapshot,
         forget::{ForgetGroups, KeepOptions},
         key::{add_current_key_to_repo, KeyOptions},
-        prune::{PruneOptions, PrunePlan},
+        prune::{prune_repository, PruneOptions, PrunePlan},
         repair::{
             index::{index_checked_from_collector, repair_index, RepairIndexOptions},
             snapshots::{repair_snapshots, RepairSnapshotsOptions},
@@ -1192,7 +1192,29 @@ impl<P: ProgressBars, S: Open> Repository<P, S> {
     ///
     /// The plan about what should be pruned and/or repacked.
     pub fn prune_plan(&self, opts: &PruneOptions) -> RusticResult<PrunePlan> {
-        opts.get_plan(self)
+        PrunePlan::from_prune_options(self, opts)
+    }
+
+    /// Perform the pruning on the repository.
+    ///
+    /// # Arguments
+    ///
+    /// * `opts` - The options for the pruning
+    /// * `prune_plan` - The plan about what should be pruned and/or repacked
+    ///
+    /// # Errors
+    ///
+    /// * [`CommandErrorKind::NotAllowedWithAppendOnly`] - If the repository is in append-only mode
+    /// * [`CommandErrorKind::NoDecision`] - If a pack has no decision
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the pruning was successful
+    ///
+    /// # Panics
+    ///
+    pub fn prune(&self, opts: &PruneOptions, prune_plan: PrunePlan) -> RusticResult<()> {
+        prune_repository(self, opts, prune_plan)
     }
 
     /// Turn the repository into the `IndexedFull` state by reading and storing the index

--- a/crates/core/tests/command_input.rs
+++ b/crates/core/tests/command_input.rs
@@ -1,8 +1,11 @@
+#[cfg(not(windows))]
 use std::fs::File;
 
 use anyhow::Result;
 use rustic_core::CommandInput;
 use serde::{Deserialize, Serialize};
+
+#[cfg(not(windows))]
 use tempfile::tempdir;
 
 #[test]

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -540,7 +540,7 @@ fn test_prune(
     let plan = repo.prune_plan(&prune_opts)?;
     // TODO: Snapshot-test the plan (currently doesn't impl Serialize)
     // assert_ron_snapshot!("prune", plan);
-    plan.do_prune(&repo, &prune_opts)?;
+    repo.prune(&prune_opts, plan)?;
 
     // run check
     let check_opts = CheckOptions::default().read_data(true);
@@ -549,7 +549,7 @@ fn test_prune(
     if !instant_delete {
         // re-run if we only marked pack files. As keep-delete = 0, they should be removed here
         let plan = repo.prune_plan(&prune_opts)?;
-        plan.do_prune(&repo, &prune_opts)?;
+        repo.prune(&prune_opts, plan)?;
         repo.check(check_opts)?;
     }
 


### PR DESCRIPTION
I saw in #224 that `CheckOptions::run()` has been moved to type `CheckResultsCollector`. In other commands we actually have functions, not associated to any type, that take their options as parameters. I applied this here to check, prune, repair, key, and restore as well. Because I think it reduces coupling and increases testability.

The idea behind having these standalone functions is, that check, prune, repair, key, and restore are not run on their options (as a method of e.g. `CheckOptions`), but rather take parameters, where one is the e.g. `CheckOption` itself.

In principle: methods that implement commands don't operate on their own options and have side effects on other types - options are passed into functions as parameters.

Furthermore, a `check()` on `CheckOptions` sounds if it validates these options itself, rather than being run on an external type. I think from that POV it also makes sense to have such freestanding functions as entry point to our commands in `rustic_core`.