### PR TITLE
chore(release): Disable automatic dependency updates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,7 @@
 
 [workspace]
 pr_draft = true
-dependencies_update = true
+# dependencies_update = true # We don't want to update dependencies automatically, as currently our dependencies tree is broken somewhere
 # changelog_config = "cliff.toml" # Don't use this for now, as it will override the default changelog config
 
 [changelog]


### PR DESCRIPTION
We don't want to update dependencies automatically, as currently our dependencies tree is broken somewhere. We also run renovate on a weekly schedule to update the lockfile.