### PR TITLE
fix: opendal paths on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,6 +3295,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "typed-path",
  "url",
  "walkdir",
 ]
@@ -4248,6 +4249,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
 
 [[package]]
 name = "typenum"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -35,7 +35,13 @@ default = ["opendal", "rest", "rclone"]
 cli = ["merge", "clap"]
 merge = ["dep:conflate"]
 clap = ["dep:clap"]
-opendal = ["dep:opendal", "dep:rayon", "dep:tokio", "tokio/rt-multi-thread"]
+opendal = [
+  "dep:opendal",
+  "dep:rayon",
+  "dep:tokio",
+  "tokio/rt-multi-thread",
+  "dep:typed-path",
+]
 rest = ["dep:reqwest", "dep:backoff"]
 rclone = ["rest", "dep:rand", "dep:semver"]
 
@@ -84,6 +90,7 @@ semver = { version = "1.0.23", optional = true }
 bytesize = "1.3.0"
 rayon = { version = "1.10.0", optional = true }
 tokio = { version = "1.40.0", optional = true, default-features = false }
+typed-path = { version = "0.9.3", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 # opendal backend - sftp is not supported on windows, see https://github.com/apache/incubator-opendal/issues/2963


### PR DESCRIPTION
We now always use UnixPaths to generate the path used in opendal URLs.

closes https://github.com/rustic-rs/rustic/issues/1162
closes https://github.com/rustic-rs/rustic/issues/1302
closes https://github.com/rustic-rs/rustic/issues/1305