### PR TITLE
feat(async): add `async_compatible` methods to identify backend compatibility

### DIFF
--- a/crates/backend/src/local.rs
+++ b/crates/backend/src/local.rs
@@ -398,6 +398,13 @@ impl ReadBackend for LocalBackend {
 
         Ok(vec.into())
     }
+
+    /// [`LocalBackend`] doesn't use `async`, even under the hood.
+    ///
+    /// So it can be called from `async` features.
+    fn is_async_compatible(&self) -> bool {
+        true
+    }
 }
 
 impl WriteBackend for LocalBackend {

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -386,6 +386,15 @@ impl ReadBackend for OpenDALBackend {
             )?
             .to_bytes())
     }
+
+    /// [`OpenDALBackend`] is `sync` and uses `block_on(async Fn)` under the hood.
+    ///
+    /// When implementing `rustic_core` using this backend in some `async` features will not work.
+    ///
+    /// see <https://github.com/rustic-rs/rustic/issues/1181>
+    fn is_async_compatible(&self) -> bool {
+        false
+    }
 }
 
 impl WriteBackend for OpenDALBackend {

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -353,6 +353,11 @@ impl ReadBackend for RcloneBackend {
     ) -> RusticResult<Bytes> {
         self.rest.read_partial(tpe, id, cacheable, offset, length)
     }
+
+    /// [`RcloneBackend`] uses [`RestBackend`].
+    fn is_async_compatible(&self) -> bool {
+        self.rest.is_async_compatible()
+    }
 }
 
 impl WriteBackend for RcloneBackend {

--- a/crates/backend/src/rest.rs
+++ b/crates/backend/src/rest.rs
@@ -413,6 +413,16 @@ impl ReadBackend for RestBackend {
         )
         .map_err(construct_backoff_error)
     }
+
+    /// [`RestBackend`] uses `reqwest` which blocking implementation
+    /// uses an `async` runtime under the hood.
+    ///
+    /// When implementing `rustic_core` using this backend in some `async` features will not work.
+    ///
+    /// see <https://github.com/rustic-rs/rustic/issues/1181>
+    fn is_async_compatible(&self) -> bool {
+        false
+    }
 }
 
 fn construct_backoff_error(err: backoff::Error<reqwest::Error>) -> Box<RusticError> {

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -175,7 +175,7 @@ pub trait ReadBackend: Send + Sync + 'static {
         Ok(())
     }
 
-    /// Getter to now if some backend is compatible
+    /// Getter to determine if some backend is compatible
     /// with async features in `rustic_core` implementations.
     ///
     /// ## Default impl

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -162,6 +162,10 @@ impl ReadBackend for CachedBackend {
     fn warm_up(&self, tpe: FileType, id: &Id) -> RusticResult<()> {
         self.be.warm_up(tpe, id)
     }
+
+    fn is_async_compatible(&self) -> bool {
+        self.be.is_async_compatible()
+    }
 }
 
 impl WriteBackend for CachedBackend {

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -216,7 +216,7 @@ pub trait DecryptWriteBackend: WriteBackend + Clone + 'static {
     ///
     /// # Returns
     ///
-    /// The processed data, the original data length and when compression is used, the uncomressed length
+    /// The processed data, the original data length and when compression is used, the uncompressed length
     fn process_data(&self, data: &[u8]) -> RusticResult<(Vec<u8>, u32, Option<NonZeroU32>)>;
 
     /// Writes the given data to the backend without compression and returns the id of the data.
@@ -559,7 +559,7 @@ impl<C: CryptoKey> DecryptWriteBackend for DecryptBackend<C> {
     ///
     /// # Arguments
     ///
-    /// * `extra_echeck` - The compression level to use for zstd.
+    /// * `extra_verify` - The compression level to use for zstd.
     fn set_extra_verify(&mut self, extra_verify: bool) {
         self.extra_verify = extra_verify;
     }
@@ -621,6 +621,10 @@ impl<C: CryptoKey> ReadBackend for DecryptBackend<C> {
         length: u32,
     ) -> RusticResult<Bytes> {
         self.be.read_partial(tpe, id, cacheable, offset, length)
+    }
+
+    fn is_async_compatible(&self) -> bool {
+        self.be.is_async_compatible()
     }
 }
 

--- a/crates/core/src/backend/dry_run.rs
+++ b/crates/core/src/backend/dry_run.rs
@@ -103,6 +103,10 @@ impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
     ) -> RusticResult<Bytes> {
         self.be.read_partial(tpe, id, cacheable, offset, length)
     }
+
+    fn is_async_compatible(&self) -> bool {
+        self.be.is_async_compatible()
+    }
 }
 
 impl<BE: DecryptFullBackend> DecryptWriteBackend for DryRunBackend<BE> {

--- a/crates/core/src/backend/hotcold.rs
+++ b/crates/core/src/backend/hotcold.rs
@@ -75,6 +75,10 @@ impl ReadBackend for HotColdBackend {
     fn warm_up(&self, tpe: FileType, id: &Id) -> RusticResult<()> {
         self.be.warm_up(tpe, id)
     }
+
+    fn is_async_compatible(&self) -> bool {
+        self.be.is_async_compatible()
+    }
 }
 
 impl WriteBackend for HotColdBackend {

--- a/crates/core/src/backend/warm_up.rs
+++ b/crates/core/src/backend/warm_up.rs
@@ -59,6 +59,10 @@ impl ReadBackend for WarmUpAccessBackend {
         _ = self.be.read_partial(tpe, id, false, 0, 1);
         Ok(())
     }
+
+    fn is_async_compatible(&self) -> bool {
+        self.be.is_async_compatible()
+    }
 }
 
 impl WriteBackend for WarmUpAccessBackend {

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -686,6 +686,19 @@ impl<P, S> Repository<P, S> {
     pub fn list<T: RepoId>(&self) -> RusticResult<impl Iterator<Item = T>> {
         Ok(self.be.list(T::TYPE)?.into_iter().map(Into::into))
     }
+
+    /// Check if one of this repository backend is incompatible
+    /// with async features in `rustic_core` implementations.
+    ///
+    /// see <https://github.com/rustic-rs/rustic/issues/1181>
+    pub fn is_async_compatible(&self) -> bool {
+        // check if be or be_hot is incompatible with async
+        self.be.is_async_compatible()
+            && self
+                .be_hot
+                .as_ref()
+                .map_or(true, ReadBackend::is_async_compatible)
+    }
 }
 
 impl<P: ProgressBars, S> Repository<P, S> {
@@ -1874,7 +1887,7 @@ impl<P: ProgressBars, S: IndexedTree> Repository<P, S> {
 impl<P: ProgressBars, S: IndexedIds> Repository<P, S> {
     /// Run a backup of `source` using the given options.
     ///
-    /// You have to give a preflled [`SnapshotFile`] which is modified and saved.
+    /// You have to give a prefilled [`SnapshotFile`] which is modified and saved.
     ///
     /// # Arguments
     ///

--- a/crates/testing/src/backend.rs
+++ b/crates/testing/src/backend.rs
@@ -58,6 +58,11 @@ pub mod in_memory_backend {
         ) -> RusticResult<Bytes> {
             Ok(self.0.read().unwrap()[tpe][id].slice(offset as usize..(offset + length) as usize))
         }
+
+        /// [`InMemoryBackend`] doesn't use `async`, even under the hood.
+        fn is_async_compatible(&self) -> bool {
+            true
+        }
     }
 
     impl WriteBackend for InMemoryBackend {


### PR DESCRIPTION
Add `getters` to warn about `async_incompatible` backends.

Using the type system or fixing all async compatibility issue is big and structural work.
To avoid runtime crash for our users I suggest using this getter as a temporary fix. 

tracking issue: rustic-rs/rustic#1181 (see for more details)