### PR TITLE
refactor(backend): migrate from `backoff` to `backon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,17 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom",
- "instant",
- "rand",
-]
-
-[[package]]
 name = "backon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,15 +2073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "integer-sqrt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,7 +3565,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "aws-lc-sys",
- "backoff",
+ "backon",
  "bytes",
  "bytesize",
  "clap",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -42,7 +42,7 @@ opendal = [
   "tokio/rt-multi-thread",
   "dep:typed-path",
 ]
-rest = ["dep:reqwest", "dep:backoff"]
+rest = ["dep:reqwest", "dep:backon"]
 rclone = ["rest", "dep:rand", "dep:semver"]
 
 [dependencies]
@@ -78,7 +78,7 @@ aho-corasick = { workspace = true }
 walkdir = "2.5.0"
 
 # rest backend
-backoff = { version = "0.4.0", optional = true }
+backon = { version = "1.2.0", optional = true }
 reqwest = { version = "0.12.8", default-features = false, features = ["json", "rustls-tls-native-roots", "stream", "blocking"], optional = true }
 
 # rclone backend

--- a/crates/backend/src/rest.rs
+++ b/crates/backend/src/rest.rs
@@ -52,7 +52,7 @@ impl RestBackend {
     ///
     /// ## Permanent/non-permanent errors
     ///
-    /// - client_error are considered permanent
+    /// -  `client_error` are considered permanent
     /// - others are not, and are subject to retry
     ///
     /// ## Returns

--- a/crates/backend/src/rest.rs
+++ b/crates/backend/src/rest.rs
@@ -121,6 +121,14 @@ impl backon_extension::NotifyWhenRetry for reqwest::Error {
     }
 }
 
+fn construct_backoff_error(err: reqwest::Error) -> Box<RusticError> {
+    RusticError::with_source(
+        ErrorKind::Backend,
+        "Backoff failed, please check the logs for more information.",
+        err,
+    )
+}
+
 /// A backend implementation that uses REST to access the backend.
 #[derive(Clone, Debug)]
 pub struct RestBackend {
@@ -333,13 +341,7 @@ impl ReadBackend for RestBackend {
                     })
                     .collect())
             })
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Backend,
-                    "Backoff failed, please check the logs for more information.",
-                    err,
-                )
-            })
+            .map_err(construct_backoff_error)
     }
 
     /// Returns the content of a file.
@@ -369,13 +371,7 @@ impl ReadBackend for RestBackend {
                     .error_for_status()?
                     .bytes()?)
             })
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Backend,
-                    "Backoff failed, please check the logs for more information.",
-                    err,
-                )
-            })
+            .map_err(construct_backoff_error)
     }
 
     /// Returns a part of the content of a file.
@@ -420,13 +416,7 @@ impl ReadBackend for RestBackend {
                     .error_for_status()?
                     .bytes()?)
             })
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Backend,
-                    "Backoff failed, please check the logs for more information.",
-                    err,
-                )
-            })
+            .map_err(construct_backoff_error)
     }
 }
 
@@ -465,13 +455,7 @@ impl WriteBackend for RestBackend {
                 _ = self.client.post(url.clone()).send()?.error_for_status()?;
                 Ok(())
             })
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Backend,
-                    "Backoff failed, please check the logs for more information.",
-                    err,
-                )
-            })
+            .map_err(construct_backoff_error)
     }
 
     /// Writes bytes to the given file.
@@ -512,13 +496,7 @@ impl WriteBackend for RestBackend {
                     .error_for_status()?;
                 Ok(())
             })
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Backend,
-                    "Backoff failed, please check the logs for more information.",
-                    err,
-                )
-            })
+            .map_err(construct_backoff_error)
     }
 
     /// Removes the given file.
@@ -543,12 +521,6 @@ impl WriteBackend for RestBackend {
                 _ = self.client.delete(url.clone()).send()?.error_for_status()?;
                 Ok(())
             })
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Backend,
-                    "Backoff failed, please check the logs for more information.",
-                    err,
-                )
-            })
+            .map_err(construct_backoff_error)
     }
 }


### PR DESCRIPTION
Hello,

Removed the unmaintained  `backoff` crate in the `rustic_backend` crate.
Replaced it with the relatively similar `backon` crate.

If `backon` as simpler API, it also lacks a few features that `backoff` had.
For instance: `no_max_delay` or `backoff::retry_notify`. 
To make up for it:
- I opened https://github.com/Xuanwo/backon/pull/160 on the `backon` github.
- I implemented an internal module `backon_extension` inside `backend::rest`.

Let me know what you think of the code!

Fixes https://github.com/rustic-rs/rustic_core/issues/351