### PR TITLE
refactor(error): enhance error logging and output formatting

### DIFF
--- a/crates/backend/src/local.rs
+++ b/crates/backend/src/local.rs
@@ -315,7 +315,7 @@ impl ReadBackend for LocalBackend {
             })
             .inspect(|r| {
                 if let Err(err) = r {
-                    error!("Error while listing files: {}", err.to_log_output());
+                    error!("Error while listing files: {}", err.display_log());
                 }
             })
             .filter_map(RusticResult::ok);
@@ -557,7 +557,7 @@ impl WriteBackend for LocalBackend {
 
         if let Some(command) = &self.post_create_command {
             if let Err(err) = Self::call_command(tpe, id, &filename, command) {
-                warn!("post-create: {}", err.to_log_output());
+                warn!("post-create: {}", err.display_log());
             }
         }
         Ok(())
@@ -587,7 +587,7 @@ impl WriteBackend for LocalBackend {
         )?;
         if let Some(command) = &self.post_delete_command {
             if let Err(err) = Self::call_command(tpe, id, &filename, command) {
-                warn!("post-delete: {}", err.to_log_output());
+                warn!("post-delete: {}", err.display_log());
             }
         }
         Ok(())

--- a/crates/backend/src/local.rs
+++ b/crates/backend/src/local.rs
@@ -312,7 +312,7 @@ impl ReadBackend for LocalBackend {
             })
             .inspect(|r| {
                 if let Err(err) = r {
-                    error!("Error while listing files: {err:?}");
+                    error!("Error while listing files: {}", err.to_log_output());
                 }
             })
             .filter_map(RusticResult::ok);
@@ -563,7 +563,7 @@ impl WriteBackend for LocalBackend {
 
         if let Some(command) = &self.post_create_command {
             if let Err(err) = Self::call_command(tpe, id, &filename, command) {
-                warn!("post-create: {err}");
+                warn!("post-create: {}", err.to_log_output());
             }
         }
         Ok(())
@@ -593,7 +593,7 @@ impl WriteBackend for LocalBackend {
         )?;
         if let Some(command) = &self.post_delete_command {
             if let Err(err) = Self::call_command(tpe, id, &filename, command) {
-                warn!("post-delete: {err}");
+                warn!("post-delete: {}", err.to_log_output());
             }
         }
         Ok(())

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -328,7 +328,7 @@ impl ReadBackend for OpenDALBackend {
             })
             .inspect(|r| {
                 if let Err(err) = r {
-                    error!("Error while listing files: {}", err.to_log_output());
+                    error!("Error while listing files: {}", err.display_log());
                 }
             })
             .filter_map(RusticResult::ok)

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -328,7 +328,7 @@ impl ReadBackend for OpenDALBackend {
             })
             .inspect(|r| {
                 if let Err(err) = r {
-                    error!("Error while listing files: {err:?}");
+                    error!("Error while listing files: {}", err.to_log_output());
                 }
             })
             .filter_map(RusticResult::ok)

--- a/crates/core/src/archiver.rs
+++ b/crates/core/src/archiver.rs
@@ -144,7 +144,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
                     match src.size() {
                         Ok(Some(size)) => p.set_length(size),
                         Ok(None) => {}
-                        Err(err) => warn!("error determining backup size: {}", err.to_log_output()),
+                        Err(err) => warn!("error determining backup size: {}", err.display_log()),
                     }
                 }
             });
@@ -152,7 +152,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
             // filter out errors and handle as_path
             let iter = src.entries().filter_map(|item| match item {
                 Err(err) => {
-                    warn!("ignoring error: {}", err.to_log_output());
+                    warn!("ignoring error: {}", err.display_log());
                     None
                 }
                 Ok(ReadSourceEntry { path, node, open }) => {
@@ -197,7 +197,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
                 .filter_map(|item| match item {
                     Ok(item) => Some(item),
                     Err(err) => {
-                        warn!("ignoring error: {}", err.to_log_output());
+                        warn!("ignoring error: {}", err.display_log());
                         None
                     }
                 })

--- a/crates/core/src/archiver.rs
+++ b/crates/core/src/archiver.rs
@@ -144,15 +144,15 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
                     match src.size() {
                         Ok(Some(size)) => p.set_length(size),
                         Ok(None) => {}
-                        Err(err) => warn!("error determining backup size: {err}"),
+                        Err(err) => warn!("error determining backup size: {}", err.to_log_output()),
                     }
                 }
             });
 
             // filter out errors and handle as_path
             let iter = src.entries().filter_map(|item| match item {
-                Err(e) => {
-                    warn!("ignoring error {e}\n");
+                Err(err) => {
+                    warn!("ignoring error: {}", err.to_log_output());
                     None
                 }
                 Ok(ReadSourceEntry { path, node, open }) => {
@@ -197,7 +197,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
                 .filter_map(|item| match item {
                     Ok(item) => Some(item),
                     Err(err) => {
-                        warn!("ignoring error: {err:?}");
+                        warn!("ignoring error: {}", err.to_log_output());
                         None
                     }
                 })

--- a/crates/core/src/archiver/parent.rs
+++ b/crates/core/src/archiver/parent.rs
@@ -98,7 +98,10 @@ impl Parent {
         let tree = tree_id.and_then(|tree_id| match Tree::from_backend(be, index, tree_id) {
             Ok(tree) => Some(tree),
             Err(err) => {
-                warn!("ignoring error when loading parent tree {tree_id}: {err}");
+                warn!(
+                    "ignoring error when loading parent tree {tree_id}: {}",
+                    err.to_log_output()
+                );
                 None
             }
         });
@@ -202,7 +205,10 @@ impl Parent {
                 |tree_id| match Tree::from_backend(be, index, tree_id) {
                     Ok(tree) => Some(tree),
                     Err(err) => {
-                        warn!("ignoring error when loading parent tree {tree_id}: {err}");
+                        warn!(
+                            "ignoring error when loading parent tree {tree_id}: {}",
+                            err.to_log_output()
+                        );
                         None
                     }
                 },
@@ -274,8 +280,9 @@ impl Parent {
                             ParentResult::Matched(())
                         } else {
                             warn!(
-                            "missing blobs in index for unchanged file {path:?}; re-reading file",
-                        );
+                                "missing blobs in index for unchanged file {}; re-reading file",
+                                path.display()
+                            );
                             ParentResult::NotFound
                         }
                     }

--- a/crates/core/src/archiver/parent.rs
+++ b/crates/core/src/archiver/parent.rs
@@ -100,7 +100,7 @@ impl Parent {
             Err(err) => {
                 warn!(
                     "ignoring error when loading parent tree {tree_id}: {}",
-                    err.to_log_output()
+                    err.display_log()
                 );
                 None
             }
@@ -207,7 +207,7 @@ impl Parent {
                     Err(err) => {
                         warn!(
                             "ignoring error when loading parent tree {tree_id}: {}",
-                            err.to_log_output()
+                            err.display_log()
                         );
                         None
                     }

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -71,7 +71,7 @@ impl ReadBackend for CachedBackend {
             if let Err(err) = self.cache.remove_not_in_list(tpe, &list) {
                 warn!(
                     "Error in cache backend removing files {tpe:?}: {}",
-                    err.to_log_output()
+                    err.display_log()
                 );
             }
         }
@@ -100,7 +100,7 @@ impl ReadBackend for CachedBackend {
                 Ok(None) => {}
                 Err(err) => warn!(
                     "Error in cache backend reading {tpe:?},{id}: {}",
-                    err.to_log_output()
+                    err.display_log()
                 ),
             }
             let res = self.be.read_full(tpe, id);
@@ -108,7 +108,7 @@ impl ReadBackend for CachedBackend {
                 if let Err(err) = self.cache.write_bytes(tpe, id, data) {
                     warn!(
                         "Error in cache backend writing {tpe:?},{id}: {}",
-                        err.to_log_output()
+                        err.display_log()
                     );
                 }
             }
@@ -149,7 +149,7 @@ impl ReadBackend for CachedBackend {
                 Ok(None) => {}
                 Err(err) => warn!(
                     "Error in cache backend reading {tpe:?},{id}: {}",
-                    err.to_log_output()
+                    err.display_log()
                 ),
             };
             // read full file, save to cache and return partial content
@@ -159,7 +159,7 @@ impl ReadBackend for CachedBackend {
                     if let Err(err) = self.cache.write_bytes(tpe, id, &data) {
                         warn!(
                             "Error in cache backend writing {tpe:?},{id}: {}",
-                            err.to_log_output()
+                            err.display_log()
                         );
                     }
                     Ok(Bytes::copy_from_slice(&data.slice(range)))
@@ -200,7 +200,7 @@ impl WriteBackend for CachedBackend {
             if let Err(err) = self.cache.write_bytes(tpe, id, &buf) {
                 warn!(
                     "Error in cache backend writing {tpe:?},{id}: {}",
-                    err.to_log_output()
+                    err.display_log()
                 );
             }
         }
@@ -220,7 +220,7 @@ impl WriteBackend for CachedBackend {
             if let Err(err) = self.cache.remove(tpe, id) {
                 warn!(
                     "Error in cache backend removing {tpe:?},{id}: {}",
-                    err.to_log_output()
+                    err.display_log()
                 );
             }
         }

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -69,7 +69,10 @@ impl ReadBackend for CachedBackend {
 
         if tpe.is_cacheable() {
             if let Err(err) = self.cache.remove_not_in_list(tpe, &list) {
-                warn!("Error in cache backend removing files {tpe:?}: {err}");
+                warn!(
+                    "Error in cache backend removing files {tpe:?}: {}",
+                    err.to_log_output()
+                );
             }
         }
 
@@ -95,12 +98,18 @@ impl ReadBackend for CachedBackend {
             match self.cache.read_full(tpe, id) {
                 Ok(Some(data)) => return Ok(data),
                 Ok(None) => {}
-                Err(err) => warn!("Error in cache backend reading {tpe:?},{id}: {err}"),
+                Err(err) => warn!(
+                    "Error in cache backend reading {tpe:?},{id}: {}",
+                    err.to_log_output()
+                ),
             }
             let res = self.be.read_full(tpe, id);
             if let Ok(data) = &res {
                 if let Err(err) = self.cache.write_bytes(tpe, id, data) {
-                    warn!("Error in cache backend writing {tpe:?},{id}: {err}");
+                    warn!(
+                        "Error in cache backend writing {tpe:?},{id}: {}",
+                        err.to_log_output()
+                    );
                 }
             }
             res
@@ -138,14 +147,20 @@ impl ReadBackend for CachedBackend {
             match self.cache.read_partial(tpe, id, offset, length) {
                 Ok(Some(data)) => return Ok(data),
                 Ok(None) => {}
-                Err(err) => warn!("Error in cache backend reading {tpe:?},{id}: {err}"),
+                Err(err) => warn!(
+                    "Error in cache backend reading {tpe:?},{id}: {}",
+                    err.to_log_output()
+                ),
             };
             // read full file, save to cache and return partial content
             match self.be.read_full(tpe, id) {
                 Ok(data) => {
                     let range = offset as usize..(offset + length) as usize;
                     if let Err(err) = self.cache.write_bytes(tpe, id, &data) {
-                        warn!("Error in cache backend writing {tpe:?},{id}: {err}");
+                        warn!(
+                            "Error in cache backend writing {tpe:?},{id}: {}",
+                            err.to_log_output()
+                        );
                     }
                     Ok(Bytes::copy_from_slice(&data.slice(range)))
                 }
@@ -183,7 +198,10 @@ impl WriteBackend for CachedBackend {
     fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
         if cacheable || tpe.is_cacheable() {
             if let Err(err) = self.cache.write_bytes(tpe, id, &buf) {
-                warn!("Error in cache backend writing {tpe:?},{id}: {err}");
+                warn!(
+                    "Error in cache backend writing {tpe:?},{id}: {}",
+                    err.to_log_output()
+                );
             }
         }
         self.be.write_bytes(tpe, id, cacheable, buf)
@@ -200,7 +218,10 @@ impl WriteBackend for CachedBackend {
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {
         if cacheable || tpe.is_cacheable() {
             if let Err(err) = self.cache.remove(tpe, id) {
-                warn!("Error in cache backend removing {tpe:?},{id}: {err}");
+                warn!(
+                    "Error in cache backend removing {tpe:?},{id}: {}",
+                    err.to_log_output()
+                );
             }
         }
         self.be.remove(tpe, id, cacheable)

--- a/crates/core/src/backend/ignore.rs
+++ b/crates/core/src/backend/ignore.rs
@@ -358,10 +358,10 @@ impl ReadSource for LocalSource {
     fn size(&self) -> RusticResult<Option<u64>> {
         let mut size = 0;
         for entry in self.builder.build() {
-            if let Err(e) = entry.and_then(|e| e.metadata()).map(|m| {
+            if let Err(err) = entry.and_then(|e| e.metadata()).map(|m| {
                 size += if m.is_dir() { 0 } else { m.len() };
             }) {
-                warn!("ignoring error {}", e);
+                warn!("ignoring error {err}");
             }
         }
         Ok(Some(size))
@@ -656,8 +656,8 @@ fn map_entry(
     let links = if m.is_dir() { 0 } else { m.nlink() };
 
     let extended_attributes = match list_extended_attributes(entry.path()) {
-        Err(e) => {
-            warn!("ignoring error: {e}\n");
+        Err(err) => {
+            warn!("ignoring error: {err}");
             vec![]
         }
         Ok(xattr_list) => xattr_list,

--- a/crates/core/src/commands/backup.rs
+++ b/crates/core/src/commands/backup.rs
@@ -267,7 +267,7 @@ pub(crate) fn backup<P: ProgressBars, S: IndexedIds>(
     let (parent_id, parent) = opts.parent_opts.get_parent(repo, &snap, backup_stdin);
     match parent_id {
         Some(id) => {
-            info!("using parent {}", id);
+            info!("using parent {id}");
             snap.parent = Some(id);
         }
         None => {
@@ -276,7 +276,7 @@ pub(crate) fn backup<P: ProgressBars, S: IndexedIds>(
     };
 
     let be = DryRunBackend::new(repo.dbe().clone(), opts.dry_run);
-    info!("starting to backup {source}...");
+    info!("starting to backup {source} ...");
     let archiver = Archiver::new(be, index, repo.config(), parent, snap)?;
     let p = repo.pb.progress_bytes("backing up...");
 

--- a/crates/core/src/commands/check.rs
+++ b/crates/core/src/commands/check.rs
@@ -276,7 +276,7 @@ pub(crate) fn check_repository<P: ProgressBars, S: Open>(
         if let Err(err) = cache.remove_not_in_list(FileType::Pack, &ids) {
             warn!(
                 "Error in cache backend removing pack files: {}",
-                err.to_log_output()
+                err.display_log()
             );
         }
         p.finish();
@@ -312,13 +312,13 @@ pub(crate) fn check_repository<P: ProgressBars, S: Open>(
             let data = match be.read_full(FileType::Pack, &id) {
                 Ok(data) => data,
                 Err(err) => {
-                    error!("Error reading data for pack {id} : {}", err.to_log_output());
+                    error!("Error reading data for pack {id} : {}", err.display_log());
                     return;
                 }
             };
             match check_pack(be, pack, data, &p) {
                 Ok(()) => {}
-                Err(err) => error!("Pack {id} is not valid: {}", err.to_log_output()),
+                Err(err) => error!("Pack {id} is not valid: {}", err.display_log()),
             }
         });
         p.finish();
@@ -411,13 +411,13 @@ fn check_cache_files(
                 (Err(err), _) => {
                     error!(
                         "Error reading cached file Type: {file_type:?}, Id: {id} : {}",
-                        err.to_log_output()
+                        err.display_log()
                     );
                 }
                 (_, Err(err)) => {
                     error!(
                         "Error reading file Type: {file_type:?}, Id: {id} : {}",
-                        err.to_log_output()
+                        err.display_log()
                     );
                 }
                 (Ok(Some(data_cached)), Ok(data)) if data_cached != data => {

--- a/crates/core/src/commands/repair/index.rs
+++ b/crates/core/src/commands/repair/index.rs
@@ -90,7 +90,10 @@ pub(crate) fn repair_index<P: ProgressBars, S: Open>(
         debug!("reading pack {id}...");
         match PackHeader::from_file(be, id, size_hint, packsize) {
             Err(err) => {
-                warn!("error reading pack {id} (-> removing from index): {err}");
+                warn!(
+                    "error reading pack {id} (-> removing from index): {}",
+                    err.to_log_output()
+                );
             }
             Ok(header) => {
                 let pack = IndexPack {

--- a/crates/core/src/commands/repair/index.rs
+++ b/crates/core/src/commands/repair/index.rs
@@ -92,7 +92,7 @@ pub(crate) fn repair_index<P: ProgressBars, S: Open>(
             Err(err) => {
                 warn!(
                     "error reading pack {id} (-> removing from index): {}",
-                    err.to_log_output()
+                    err.display_log()
                 );
             }
             Ok(header) => {

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -213,8 +213,8 @@ pub(crate) fn repair_tree<BE: DecryptWriteBackend>(
             }
 
             let (tree, mut changed) = Tree::from_backend(be, index, id).map_or_else(
-                |_err| {
-                    warn!("tree {id} could not be loaded.");
+                |err| {
+                    warn!("tree {id} could not be loaded: {}", err.to_log_output());
                     (Tree::new(), Changed::This)
                 },
                 |tree| (tree, Changed::None),

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -214,7 +214,7 @@ pub(crate) fn repair_tree<BE: DecryptWriteBackend>(
 
             let (tree, mut changed) = Tree::from_backend(be, index, id).map_or_else(
                 |err| {
-                    warn!("tree {id} could not be loaded: {}", err.to_log_output());
+                    warn!("tree {id} could not be loaded: {}", err.display_log());
                     (Tree::new(), Changed::This)
                 },
                 |tree| (tree, Changed::None),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -372,8 +372,9 @@ impl RusticError {
     }
 
     /// Returns a String representation for logging purposes.
+    ///
     /// This is a more concise version of the error message.
-    pub fn to_log_output(&self) -> String {
+    pub fn display_log(&self) -> String {
         let guidance = if self.context.is_empty() {
             self.guidance.to_string()
         } else {

--- a/crates/core/src/repofile/snapshotfile.rs
+++ b/crates/core/src/repofile/snapshotfile.rs
@@ -607,7 +607,7 @@ impl SnapshotFile {
     /// * If no id could be found.
     /// * If the id is not unique.
     pub(crate) fn from_id<B: DecryptReadBackend>(be: &B, id: &str) -> RusticResult<Self> {
-        info!("getting snapshot...");
+        info!("getting snapshot ...");
         let id = be.find_id(FileType::Snapshot, id)?;
         Self::from_backend(be, &SnapshotId::from(id))
     }

--- a/crates/core/src/repository/warm_up.rs
+++ b/crates/core/src/repository/warm_up.rs
@@ -144,9 +144,9 @@ fn warm_up_repo<P: ProgressBars, S>(
     pool.in_place_scope(|scope| {
         for pack in packs {
             scope.spawn(move |_| {
-                if let Err(e) = backend.warm_up(FileType::Pack, &pack) {
+                if let Err(err) = backend.warm_up(FileType::Pack, &pack) {
                     // FIXME: Use error handling
-                    error!("warm-up failed for pack {pack:?}. {e}");
+                    error!("warm-up failed for pack {pack:?}. {}", err.to_log_output());
                 };
                 progress_bar_ref.inc(1);
             });

--- a/crates/core/src/repository/warm_up.rs
+++ b/crates/core/src/repository/warm_up.rs
@@ -146,7 +146,7 @@ fn warm_up_repo<P: ProgressBars, S>(
             scope.spawn(move |_| {
                 if let Err(err) = backend.warm_up(FileType::Pack, &pack) {
                     // FIXME: Use error handling
-                    error!("warm-up failed for pack {pack:?}. {}", err.to_log_output());
+                    error!("warm-up failed for pack {pack:?}. {}", err.display_log());
                 };
                 progress_bar_ref.inc(1);
             });

--- a/crates/core/tests/errors.rs
+++ b/crates/core/tests/errors.rs
@@ -44,11 +44,11 @@ fn test_error_debug(error: Box<RusticError>) {
 #[rstest]
 #[allow(clippy::boxed_local)]
 fn test_log_output_passes(error: Box<RusticError>) {
-    insta::assert_snapshot!(error.to_log_output());
+    insta::assert_snapshot!(error.display_log());
 }
 
 #[rstest]
 #[allow(clippy::boxed_local)]
 fn test_log_output_minimal_passes(minimal_error: Box<RusticError>) {
-    insta::assert_snapshot!(minimal_error.to_log_output());
+    insta::assert_snapshot!(minimal_error.display_log());
 }

--- a/crates/core/tests/errors.rs
+++ b/crates/core/tests/errors.rs
@@ -20,12 +20,35 @@ fn error() -> Box<RusticError> {
     .ask_report()
 }
 
+#[fixture]
+fn minimal_error() -> Box<RusticError> {
+    RusticError::new(
+        ErrorKind::InputOutput,
+        "A file could not be read, make sure the file at `{path}` is existing and readable by the system.",
+    )
+    .attach_context("path", "/path/to/file")
+}
+
 #[rstest]
+#[allow(clippy::boxed_local)]
 fn test_error_display(error: Box<RusticError>) {
     insta::assert_snapshot!(error);
 }
 
 #[rstest]
+#[allow(clippy::boxed_local)]
 fn test_error_debug(error: Box<RusticError>) {
     insta::assert_debug_snapshot!(error);
+}
+
+#[rstest]
+#[allow(clippy::boxed_local)]
+fn test_log_output_passes(error: Box<RusticError>) {
+    insta::assert_snapshot!(error.to_log_output());
+}
+
+#[rstest]
+#[allow(clippy::boxed_local)]
+fn test_log_output_minimal_passes(minimal_error: Box<RusticError>) {
+    insta::assert_snapshot!(minimal_error.to_log_output());
 }

--- a/crates/core/tests/snapshots/errors__log_output_minimal_passes.snap
+++ b/crates/core/tests/snapshots/errors__log_output_minimal_passes.snap
@@ -1,0 +1,5 @@
+---
+source: crates/core/tests/errors.rs
+expression: minimal_error.to_log_output()
+---
+Error: A file could not be read, make sure the file at `/path/to/file` is existing and readable by the system. (kind: related to input/output operations)

--- a/crates/core/tests/snapshots/errors__log_output_passes.snap
+++ b/crates/core/tests/snapshots/errors__log_output_passes.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core/tests/errors.rs
+expression: error.to_log_output()
+---
+Error: Prepended guidance line
+A file could not be read, make sure the file at `/path/to/file` is existing and readable by the system.
+Appended guidance line (kind: related to input/output operations, code: C001): caused by: Networking Error


### PR DESCRIPTION
- adds `display_log()` to `RusticError` for a minimal display to be used in logging
- uses above method in error!/warn!/info! macros over the codebase
- added snapshot test to make sure the output is as expected