### PR TITLE
refactor!: Add more control over used keys

### DIFF
--- a/crates/core/src/commands/check.rs
+++ b/crates/core/src/commands/check.rs
@@ -238,7 +238,7 @@ pub(crate) fn check_repository<P: ProgressBars, S: Open>(
     trees: Vec<TreeId>,
 ) -> RusticResult<()> {
     let be = repo.dbe();
-    let cache = repo.cache();
+    let cache = &repo.open_status().cache;
     let hot_be = &repo.be_hot;
     let raw_be = repo.dbe();
     let pb = &repo.pb;

--- a/crates/core/src/commands/init.rs
+++ b/crates/core/src/commands/init.rs
@@ -12,7 +12,7 @@ use crate::{
     crypto::aespoly1305::Key,
     error::RusticResult,
     id::Id,
-    repofile::{configfile::RepositoryId, ConfigFile},
+    repofile::{configfile::RepositoryId, ConfigFile, KeyId},
     repository::Repository,
 };
 
@@ -42,7 +42,7 @@ pub(crate) fn init<P, S>(
     pass: &str,
     key_opts: &KeyOptions,
     config_opts: &ConfigOptions,
-) -> RusticResult<(Key, ConfigFile)> {
+) -> RusticResult<(Key, KeyId, ConfigFile)> {
     // Create config first to allow catching errors from here without writing anything
     let repo_id = RepositoryId::from(Id::random());
     let chunker_poly = random_poly()?;
@@ -54,10 +54,10 @@ pub(crate) fn init<P, S>(
     }
     config_opts.apply(&mut config)?;
 
-    let key = init_with_config(repo, pass, key_opts, &config)?;
+    let (key, key_id) = init_with_config(repo, pass, key_opts, &config)?;
     info!("repository {} successfully created.", repo_id);
 
-    Ok((key, config))
+    Ok((key, key_id, config))
 }
 
 /// Initialize a new repository with a given config.
@@ -82,11 +82,11 @@ pub(crate) fn init_with_config<P, S>(
     pass: &str,
     key_opts: &KeyOptions,
     config: &ConfigFile,
-) -> RusticResult<Key> {
+) -> RusticResult<(Key, KeyId)> {
     repo.be.create()?;
     let (key, id) = init_key(repo, key_opts, pass)?;
     info!("key {id} successfully added.");
     save_config(repo, config.clone(), key)?;
 
-    Ok(key)
+    Ok((key, id))
 }

--- a/crates/core/src/repofile.rs
+++ b/crates/core/src/repofile.rs
@@ -8,10 +8,12 @@ pub(crate) mod keyfile;
 pub(crate) mod packfile;
 pub(crate) mod snapshotfile;
 
-/// Marker trait for repository files which are stored as encrypted JSON
+/// Marker trait for repository files which are stored as JSON
 pub trait RepoFile: Serialize + DeserializeOwned + Sized + Send + Sync + 'static {
     /// The [`FileType`] associated with the repository file
     const TYPE: FileType;
+    /// Indicate whether the files are stored encrypted
+    const ENCRYPTED: bool = true;
     /// The Id type associated with the repository file
     type Id: From<Id> + Send;
 }

--- a/crates/core/src/repofile/keyfile.rs
+++ b/crates/core/src/repofile/keyfile.rs
@@ -9,6 +9,7 @@ use crate::{
     crypto::{aespoly1305::Key, CryptoKey},
     error::{ErrorKind, RusticError, RusticResult},
     impl_repoid,
+    repofile::RepoFile,
 };
 
 /// [`KeyFileErrorKind`] describes the errors that can be returned for `KeyFile`s
@@ -73,6 +74,12 @@ pub struct KeyFile {
     /// The salt used with `scrypt`
     #[serde_as(as = "Base64")]
     salt: Vec<u8>,
+}
+
+impl RepoFile for KeyFile {
+    const TYPE: FileType = FileType::Key;
+    const ENCRYPTED: bool = false;
+    type Id = KeyId;
 }
 
 impl KeyFile {
@@ -386,15 +393,15 @@ pub(crate) fn find_key_in_backend<B: ReadBackend>(
     be: &B,
     passwd: &impl AsRef<[u8]>,
     hint: Option<&KeyId>,
-) -> RusticResult<Key> {
+) -> RusticResult<(Key, KeyId)> {
     if let Some(id) = hint {
-        key_from_backend(be, id, passwd)
+        Ok((key_from_backend(be, id, passwd)?, *id))
     } else {
         for id in be.list(FileType::Key)? {
             match key_from_backend(be, &id.into(), passwd) {
-                Ok(key) => return Ok(key),
+                Ok(key) => return Ok((key, KeyId(id))),
                 Err(err) if err.is_code("C001") => continue,
-                err => return err,
+                Err(err) => return Err(err),
             }
         }
 

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -520,13 +520,13 @@ impl<P, S> Repository<P, S> {
             }
         }
 
-        let key = find_key_in_backend(&self.be, &password, None)?;
+        let (key, key_id) = find_key_in_backend(&self.be, &password, None)?;
 
         info!("repository {}: password is correct.", self.name);
 
         let dbe = DecryptBackend::new(self.be.clone(), key);
         let config: ConfigFile = dbe.get_file(&config_id)?;
-        self.open_raw(key, config)
+        self.open_raw(key, key_id, config)
     }
 
     /// Initialize a new repository with given options using the password defined in `RepositoryOptions`
@@ -604,9 +604,9 @@ impl<P, S> Repository<P, S> {
             .attach_context("name", self.name));
         }
 
-        let (key, config) = commands::init::init(&self, pass, key_opts, config_opts)?;
+        let (key, key_id, config) = commands::init::init(&self, pass, key_opts, config_opts)?;
 
-        self.open_raw(key, config)
+        self.open_raw(key, key_id, config)
     }
 
     /// Initialize a new repository with given password and a ready [`ConfigFile`].
@@ -632,9 +632,9 @@ impl<P, S> Repository<P, S> {
         key_opts: &KeyOptions,
         config: ConfigFile,
     ) -> RusticResult<Repository<P, OpenStatus>> {
-        let key = commands::init::init_with_config(&self, password, key_opts, &config)?;
+        let (key, key_id) = commands::init::init_with_config(&self, password, key_opts, &config)?;
         info!("repository {} successfully created.", config.id);
-        self.open_raw(key, config)
+        self.open_raw(key, key_id, config)
     }
 
     /// Open the repository with given [`Key`] and [`ConfigFile`].
@@ -652,7 +652,12 @@ impl<P, S> Repository<P, S> {
     ///
     /// * If the config file has `is_hot` set to `true` but the repository is not hot
     /// * If the config file has `is_hot` set to `false` but the repository is hot
-    fn open_raw(mut self, key: Key, config: ConfigFile) -> RusticResult<Repository<P, OpenStatus>> {
+    fn open_raw(
+        mut self,
+        key: Key,
+        key_id: KeyId,
+        config: ConfigFile,
+    ) -> RusticResult<Repository<P, OpenStatus>> {
         match (config.is_hot == Some(true), self.be_hot.is_some()) {
             (true, false) => return Err(
                 RusticError::new(
@@ -684,7 +689,12 @@ impl<P, S> Repository<P, S> {
         dbe.set_zstd(config.zstd()?);
         dbe.set_extra_verify(config.extra_verify());
 
-        let open = OpenStatus { cache, dbe, config };
+        let open = OpenStatus {
+            cache,
+            dbe,
+            config,
+            key_id,
+        };
 
         Ok(Repository {
             name: self.name,
@@ -755,30 +765,13 @@ impl<P: ProgressBars, S> Repository<P, S> {
 
 /// A repository which is open, i.e. the password has been checked and the decryption key is available.
 pub trait Open {
-    /// Get the cache
-    fn cache(&self) -> Option<&Cache>;
-
-    /// Get the [`DecryptBackend`]
-    fn dbe(&self) -> &DecryptBackend<Key>;
-
-    /// Get the [`ConfigFile`]
-    fn config(&self) -> &ConfigFile;
+    /// Get the open status
+    fn open_status(&self) -> &OpenStatus;
 }
 
 impl<P, S: Open> Open for Repository<P, S> {
-    /// Get the cache
-    fn cache(&self) -> Option<&Cache> {
-        self.status.cache()
-    }
-
-    /// Get the [`DecryptBackend`]
-    fn dbe(&self) -> &DecryptBackend<Key> {
-        self.status.dbe()
-    }
-
-    /// Get the [`ConfigFile`]
-    fn config(&self) -> &ConfigFile {
-        self.status.config()
+    fn open_status(&self) -> &OpenStatus {
+        self.status.open_status()
     }
 }
 
@@ -786,27 +779,18 @@ impl<P, S: Open> Open for Repository<P, S> {
 #[derive(Debug)]
 pub struct OpenStatus {
     /// The cache
-    cache: Option<Cache>,
+    pub(crate) cache: Option<Cache>,
     /// The [`DecryptBackend`]
     dbe: DecryptBackend<Key>,
     /// The [`ConfigFile`]
     config: ConfigFile,
+    /// The [`KeyId`] of the used key
+    key_id: KeyId,
 }
 
 impl Open for OpenStatus {
-    /// Get the cache
-    fn cache(&self) -> Option<&Cache> {
-        self.cache.as_ref()
-    }
-
-    /// Get the [`DecryptBackend`]
-    fn dbe(&self) -> &DecryptBackend<Key> {
-        &self.dbe
-    }
-
-    /// Get the [`ConfigFile`]
-    fn config(&self) -> &ConfigFile {
-        &self.config
+    fn open_status(&self) -> &OpenStatus {
+        self
     }
 }
 
@@ -863,12 +847,26 @@ impl<P, S: Open> Repository<P, S> {
 
     /// Get the repository configuration
     pub fn config(&self) -> &ConfigFile {
-        self.status.config()
+        &self.open_status().config
     }
 
     // TODO: add documentation!
     pub(crate) fn dbe(&self) -> &DecryptBackend<Key> {
-        self.status.dbe()
+        &self.open_status().dbe
+    }
+
+    /// Get the [`KeyId`] of the key used to open the repository
+    pub fn key_id(&self) -> &KeyId {
+        &self.open_status().key_id
+    }
+
+    /// Delete the given key from the repository.
+    ///
+    /// # Errors
+    ///
+    /// * If the key could not be removed.
+    pub fn delete_key(&self, id: &KeyId) -> RusticResult<()> {
+        self.dbe().remove(FileType::Key, id, false)
     }
 }
 
@@ -1557,16 +1555,8 @@ impl<P, S: IndexedFull> IndexedFull for Repository<P, S> {
 }
 
 impl<T, S: Open> Open for IndexedStatus<T, S> {
-    fn cache(&self) -> Option<&Cache> {
-        self.open.cache()
-    }
-
-    fn dbe(&self) -> &DecryptBackend<Key> {
-        self.open.dbe()
-    }
-
-    fn config(&self) -> &ConfigFile {
-        self.open.config()
+    fn open_status(&self) -> &OpenStatus {
+        &self.open.open_status()
     }
 }
 


### PR DESCRIPTION
Adds more control over the used repository keys.
This is needed to implement the missing `key list`, `key remove` commands in the rustic CLI.

As this refactors the `Repository` a bit, this is a breaking change (which will most likely not harm anyone using rustic_core)