### PR TITLE
chore: update to 2024 edition and fix clippy lints

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: EmbarkStudios/cargo-deny-action@e2f4ede4a4e60ea15ff31bc0647485d80c66cfba # v2
+      - uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2
         with:
           command: check bans licenses sources
 

--- a/.github/workflows/careful.yml
+++ b/.github/workflows/careful.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: install cargo-careful
-        uses: taiki-e/install-action@8484225d9734e230a8bf38421a4ffec1cc249372 # v2
+        uses: taiki-e/install-action@2dbeb927f58939d3aa13bf06ba0c0a34b76b9bfb # v2
         with:
           tool: cargo-careful
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2

--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: install cargo-hack
-        uses: taiki-e/install-action@8484225d9734e230a8bf38421a4ffec1cc249372 # v2
+        uses: taiki-e/install-action@2dbeb927f58939d3aa13bf06ba0c0a34b76b9bfb # v2
         with:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2
@@ -253,7 +253,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install cargo-hack
-        uses: taiki-e/install-action@8484225d9734e230a8bf38421a4ffec1cc249372 # v2
+        uses: taiki-e/install-action@2dbeb927f58939d3aa13bf06ba0c0a34b76b9bfb # v2
         with:
           tool: cargo-hack
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,9 +7,9 @@ concurrency:
 on:
   push:
     paths:
-      - '**.rs'
-      - '**.snap'
-      - '**.yml'
+      - "**.rs"
+      - "**.snap"
+      - "**.yml"
 jobs:
   test:
     name: Generate Coverage Report
@@ -20,20 +20,20 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install cargo-tarpaulin
-        uses: taiki-e/install-action@8484225d9734e230a8bf38421a4ffec1cc249372 # v2
+        uses: taiki-e/install-action@2dbeb927f58939d3aa13bf06ba0c0a34b76b9bfb # v2
         with:
           tool: cargo-tarpaulin
 
       # We run the coverage report on the workspace, but we configured in codecov to only look at parts of the workspace essentially
-      # 
+      #
       # This is because we have a workspace with multiple crates, and we want to generate coverage for all of them, but we only want to
       # report the coverage of rustic_backend and rustic_core crates (currently) as this is where the main logic is
       - name: Generate code coverage
-        env: 
+        env:
           RUST_BACKTRACE: "0"
         run: |
           cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
-      
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ members = [
   "crates/testing",
   "examples/*",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
-rust-version = "1.76.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Internal Dependencies
@@ -106,6 +106,7 @@ pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 # expect_used = "warn" # TODO!
 # unwrap_used = "warn" # TODO!
+literal_string_with_formatting_args = "allow"
 enum_glob_use = "warn"
 correctness = { level = "warn", priority = -1 }
 suspicious = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.76.0`.
+This crate's minimum supported `rustc` version is `1.85.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0 OR MIT"
 publish = true
 readme = "README.md"
 repository = "https://github.com/rustic-rs/rustic_core/tree/main/crates/backend"
-resolver = "2"
+resolver = "3"
 rust-version = { workspace = true }
 description = """
 rustic_backend - library for supporting various backends in rustic-rs

--- a/crates/backend/README.md
+++ b/crates/backend/README.md
@@ -101,7 +101,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.76.0`.
+This crate's minimum supported `rustc` version is `1.85.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.2"
 authors = ["the rustic-rs team"]
 categories = ["config"]
 documentation = "https://docs.rs/rustic_config"
-edition = "2021"
+edition = "2024"
 homepage = "https://rustic.cli.rs/"
 include = ["src/**/*", "LICENSE-*", "README.md"]
 keywords = ["backup", "restic", "deduplication", "encryption", "library"]
@@ -12,7 +12,7 @@ license = "Apache-2.0 OR MIT"
 publish = true
 readme = "README.md"
 repository = "https://github.com/rustic-rs/rustic_core"
-resolver = "2"
+resolver = "3"
 rust-version = { workspace = true }
 description = """
 rustic_config - library for configuration support in rustic-rs

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -79,7 +79,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.76.0`.
+This crate's minimum supported `rustc` version is `1.85.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.7.3"
 authors = ["the rustic-rs team"]
 categories = ["data-structures", "encoding", "filesystem"]
 documentation = "https://docs.rs/rustic_core"
-edition = "2021"
+edition = "2024"
 homepage = "https://rustic.cli.rs/"
 include = ["src/**/*", "LICENSE-*", "README.md"]
 keywords = ["backup", "restic", "deduplication", "encryption", "library"]
@@ -12,7 +12,7 @@ license = "Apache-2.0 OR MIT"
 publish = true
 readme = "README.md"
 repository = "https://github.com/rustic-rs/rustic_core"
-resolver = "2"
+resolver = "3"
 rust-version = { workspace = true }
 description = """
 rustic_core - library for fast, encrypted, deduplicated backups that powers rustic-rs

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -216,7 +216,7 @@ Please make sure, that you read the
 
 ## Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.76.0`.
+This crate's minimum supported `rustc` version is `1.85.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -123,16 +123,16 @@ pub mod vfs;
 // rustic_core Public API
 pub use crate::{
     backend::{
-        ALL_FILE_TYPES, FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen,
-        RepositoryBackends, WriteBackend,
         decrypt::{compression_level_range, max_compression_level},
         ignore::{LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions},
         local_destination::LocalDestination,
         node::last_modified_node,
+        FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen, RepositoryBackends,
+        WriteBackend, ALL_FILE_TYPES,
     },
     blob::{
-        BlobId, DataId, PackedId,
         tree::{FindMatches, FindNode, TreeId, TreeStreamerOptions as LsOptions},
+        BlobId, DataId, PackedId,
     },
     commands::{
         backup::{BackupOptions, ParentOptions},
@@ -153,8 +153,8 @@ pub use crate::{
         PathList, SnapshotGroup, SnapshotGroupCriterion, SnapshotOptions, StringList,
     },
     repository::{
+        command_input::{CommandInput, CommandInputErrorKind},
         FullIndex, IndexedFull, IndexedIds, IndexedStatus, IndexedTree, Open, OpenStatus,
         Repository, RepositoryOptions,
-        command_input::{CommandInput, CommandInputErrorKind},
     },
 };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -123,16 +123,16 @@ pub mod vfs;
 // rustic_core Public API
 pub use crate::{
     backend::{
+        ALL_FILE_TYPES, FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen,
+        RepositoryBackends, WriteBackend,
         decrypt::{compression_level_range, max_compression_level},
         ignore::{LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions},
         local_destination::LocalDestination,
         node::last_modified_node,
-        FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen, RepositoryBackends,
-        WriteBackend, ALL_FILE_TYPES,
     },
     blob::{
-        tree::{FindMatches, FindNode, TreeId, TreeStreamerOptions as LsOptions},
         BlobId, DataId, PackedId,
+        tree::{FindMatches, FindNode, TreeId, TreeStreamerOptions as LsOptions},
     },
     commands::{
         backup::{BackupOptions, ParentOptions},
@@ -153,8 +153,8 @@ pub use crate::{
         PathList, SnapshotGroup, SnapshotGroupCriterion, SnapshotOptions, StringList,
     },
     repository::{
-        command_input::{CommandInput, CommandInputErrorKind},
         FullIndex, IndexedFull, IndexedIds, IndexedStatus, IndexedTree, Open, OpenStatus,
         Repository, RepositoryOptions,
+        command_input::{CommandInput, CommandInputErrorKind},
     },
 };

--- a/crates/core/src/repofile/keyfile.rs
+++ b/crates/core/src/repofile/keyfile.rs
@@ -1,12 +1,12 @@
 use chrono::{DateTime, Local};
-use rand::{RngCore, rng};
+use rand::{rng, RngCore};
 use scrypt::Params;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as, skip_serializing_none};
 
 use crate::{
     backend::{FileType, ReadBackend},
-    crypto::{CryptoKey, aespoly1305::Key},
+    crypto::{aespoly1305::Key, CryptoKey},
     error::{ErrorKind, RusticError, RusticResult},
     impl_repoid,
 };

--- a/crates/core/src/repofile/keyfile.rs
+++ b/crates/core/src/repofile/keyfile.rs
@@ -1,12 +1,12 @@
 use chrono::{DateTime, Local};
-use rand::{rng, RngCore};
+use rand::{RngCore, rng};
 use scrypt::Params;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as, skip_serializing_none};
 
 use crate::{
     backend::{FileType, ReadBackend},
-    crypto::{aespoly1305::Key, CryptoKey},
+    crypto::{CryptoKey, aespoly1305::Key},
     error::{ErrorKind, RusticError, RusticResult},
     impl_repoid,
 };

--- a/crates/core/src/repofile/snapshotfile.rs
+++ b/crates/core/src/repofile/snapshotfile.rs
@@ -16,16 +16,16 @@ use itertools::Itertools;
 use log::info;
 use path_dedot::ParseDot;
 use serde_derive::{Deserialize, Serialize};
-use serde_with::{DisplayFromStr, serde_as, skip_serializing_none};
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
 use crate::{
-    Id,
-    backend::{FileType, FindInBackend, decrypt::DecryptReadBackend},
+    backend::{decrypt::DecryptReadBackend, FileType, FindInBackend},
     blob::tree::TreeId,
     error::{ErrorKind, RusticError, RusticResult},
     impl_repofile,
     progress::Progress,
     repofile::RepoFile,
+    Id,
 };
 
 /// [`SnapshotFileErrorKind`] describes the errors that can be returned for `SnapshotFile`s

--- a/crates/core/src/repofile/snapshotfile.rs
+++ b/crates/core/src/repofile/snapshotfile.rs
@@ -16,16 +16,16 @@ use itertools::Itertools;
 use log::info;
 use path_dedot::ParseDot;
 use serde_derive::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
+use serde_with::{DisplayFromStr, serde_as, skip_serializing_none};
 
 use crate::{
-    backend::{decrypt::DecryptReadBackend, FileType, FindInBackend},
+    Id,
+    backend::{FileType, FindInBackend, decrypt::DecryptReadBackend},
     blob::tree::TreeId,
     error::{ErrorKind, RusticError, RusticResult},
     impl_repofile,
     progress::Progress,
     repofile::RepoFile,
-    Id,
 };
 
 /// [`SnapshotFileErrorKind`] describes the errors that can be returned for `SnapshotFile`s
@@ -738,10 +738,10 @@ impl SnapshotFile {
         group
             .hostname
             .as_ref()
-            .map_or(true, |val| val == &self.hostname)
-            && group.label.as_ref().map_or(true, |val| val == &self.label)
-            && group.paths.as_ref().map_or(true, |val| val == &self.paths)
-            && group.tags.as_ref().map_or(true, |val| val == &self.tags)
+            .is_none_or(|val| val == &self.hostname)
+            && group.label.as_ref().is_none_or(|val| val == &self.label)
+            && group.paths.as_ref().is_none_or(|val| val == &self.paths)
+            && group.tags.as_ref().is_none_or(|val| val == &self.tags)
     }
 
     /// Get [`SnapshotFile`]s which match the filter grouped by the group criterion

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -38,14 +38,13 @@ use std::{env, fs::File, path::Path, sync::Arc};
 use anyhow::Result;
 use flate2::read::GzDecoder;
 use insta::{
-    assert_ron_snapshot,
+    Settings, assert_ron_snapshot,
     internals::{Content, ContentPath},
-    Settings,
 };
 use rstest::fixture;
 use serde::Serialize;
 use tar::Archive;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 // uncomment for logging output
 // use simplelog::{Config, SimpleLogger};
 

--- a/crates/core/tests/integration/backup.rs
+++ b/crates/core/tests/integration/backup.rs
@@ -9,14 +9,14 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 
 use rustic_core::{
-    repofile::{PackId, SnapshotFile},
     BackupOptions, CommandInput, ParentOptions, PathList, SnapshotGroupCriterion, SnapshotOptions,
     StringList,
+    repofile::{PackId, SnapshotFile},
 };
 
 use super::{
-    assert_with_win, insta_node_redaction, insta_snapshotfile_redaction, set_up_repo,
-    tar_gz_testdata, RepoOpen, TestSource,
+    RepoOpen, TestSource, assert_with_win, insta_node_redaction, insta_snapshotfile_redaction,
+    set_up_repo, tar_gz_testdata,
 };
 
 #[rstest]

--- a/crates/core/tests/integration/find.rs
+++ b/crates/core/tests/integration/find.rs
@@ -8,11 +8,11 @@ use globset::Glob;
 use rstest::rstest;
 
 use rustic_core::{
-    repofile::{Node, SnapshotFile},
     BackupOptions, FindMatches, FindNode,
+    repofile::{Node, SnapshotFile},
 };
 
-use super::{assert_with_win, set_up_repo, tar_gz_testdata, RepoOpen, TestSource};
+use super::{RepoOpen, TestSource, assert_with_win, set_up_repo, tar_gz_testdata};
 
 #[rstest]
 fn test_find(tar_gz_testdata: Result<TestSource>, set_up_repo: Result<RepoOpen>) -> Result<()> {

--- a/crates/core/tests/integration/ls.rs
+++ b/crates/core/tests/integration/ls.rs
@@ -6,12 +6,12 @@ use insta::Settings;
 use rstest::rstest;
 
 use rustic_core::{
-    repofile::{Metadata, Node, SnapshotFile},
     BackupOptions, LsOptions, RusticResult,
+    repofile::{Metadata, Node, SnapshotFile},
 };
 
 use super::{
-    assert_with_win, insta_node_redaction, set_up_repo, tar_gz_testdata, RepoOpen, TestSource,
+    RepoOpen, TestSource, assert_with_win, insta_node_redaction, set_up_repo, tar_gz_testdata,
 };
 
 #[rstest]

--- a/crates/core/tests/integration/prune.rs
+++ b/crates/core/tests/integration/prune.rs
@@ -4,10 +4,10 @@ use anyhow::Result;
 use rstest::rstest;
 
 use rustic_core::{
-    repofile::SnapshotFile, BackupOptions, CheckOptions, LimitOption, PathList, PruneOptions,
+    BackupOptions, CheckOptions, LimitOption, PathList, PruneOptions, repofile::SnapshotFile,
 };
 
-use super::{set_up_repo, tar_gz_testdata, RepoOpen, TestSource};
+use super::{RepoOpen, TestSource, set_up_repo, tar_gz_testdata};
 
 #[rstest]
 fn test_prune(

--- a/crates/core/tests/integration/vfs.rs
+++ b/crates/core/tests/integration/vfs.rs
@@ -6,10 +6,10 @@ use insta::Settings;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 
-use rustic_core::{repofile::SnapshotFile, vfs::Vfs, BackupOptions};
+use rustic_core::{BackupOptions, repofile::SnapshotFile, vfs::Vfs};
 
 use super::{
-    assert_with_win, insta_node_redaction, set_up_repo, tar_gz_testdata, RepoOpen, TestSource,
+    RepoOpen, TestSource, assert_with_win, insta_node_redaction, set_up_repo, tar_gz_testdata,
 };
 
 #[rstest]

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 publish = true
+resolver = "3"
 rust-version = { workspace = true }
 description = """
 rustic_testuing - library for test support in rustic-rs
 """
-resolver = "3"
 
 [dependencies]
 aho-corasick = { workspace = true }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "rustic_testing"
 version = "0.3.2"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 publish = true
 rust-version = { workspace = true }
 description = """
 rustic_testuing - library for test support in rustic-rs
 """
+resolver = "3"
 
 [dependencies]
 aho-corasick = { workspace = true }


### PR DESCRIPTION
## Needs

- [x] cargo-deny-action needs to support 2024 edition/rust 1.85
- [x] cargo tarpaulin needs to support 2024 edition/rust 1.85