### PR TITLE
fix(repository): use KeyId in delete_key()

### DIFF
--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -871,20 +871,19 @@ impl<P, S: Open> Repository<P, S> {
         &self.open_status().key_id
     }
 
-    /// Delete the key with id starting with the given string from the repository.
+    /// Delete the key with the given id
     ///
     /// # Errors
     ///
     /// * If the key could not be removed.
-    pub fn delete_key(&self, id: &str) -> RusticResult<()> {
-        let id = self.dbe().find_id(FileType::Key, id)?;
-        if self.key_id() == &KeyId::from(id) {
+    pub fn delete_key(&self, id: &KeyId) -> RusticResult<()> {
+        if self.key_id() == id {
             return Err(RusticError::new(
                 ErrorKind::Repository,
                 "Cannot remove the currently used key",
             ));
         }
-        self.dbe().remove(FileType::Key, &id, false)
+        self.dbe().remove(FileType::Key, id, false)
     }
 }
 

--- a/crates/core/tests/integration/key.rs
+++ b/crates/core/tests/integration/key.rs
@@ -36,10 +36,10 @@ fn test_key_commands(set_up_repo: Result<RepoOpen>) -> Result<()> {
     assert!(keyfile2.created.is_some());
 
     // try to remove the used repository key - which should fail
-    assert!(repo.delete_key(&key_id.to_string()).is_err());
+    assert!(repo.delete_key(key_id).is_err());
 
     // try to remove the added key
-    repo.delete_key(&key_id2.to_string())?;
+    repo.delete_key(&key_id2)?;
 
     // we should have just a single key now
     let keys: Vec<KeyId> = repo.list()?.collect();


### PR DESCRIPTION
`delete_key` used a `str` and searched for a matching `KeyId`. Now this methods allows to specify a `KeyId` directly. 
In #411 there is `find_ids` which can be used to search for matching Ids.