### PR TITLE
feat(repository): Add find_ids and stream_files_list

### DIFF
--- a/crates/core/src/repofile/keyfile.rs
+++ b/crates/core/src/repofile/keyfile.rs
@@ -43,7 +43,7 @@ impl_repoid!(KeyId, FileType::Key);
 /// They are usually stored in the repository under `/keys/<ID>`
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct KeyFile {
     /// Hostname where the key was created
     pub hostname: Option<String>,

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -736,11 +736,7 @@ impl<P, S> Repository<P, S> {
         &self,
         ids: &[T],
     ) -> RusticResult<impl Iterator<Item = I>> {
-        Ok(self
-            .be
-            .find_ids(FileType::Snapshot, ids)?
-            .into_iter()
-            .map(I::from))
+        Ok(self.be.find_ids(I::TYPE, ids)?.into_iter().map(I::from))
     }
 }
 

--- a/crates/core/tests/integration/key.rs
+++ b/crates/core/tests/integration/key.rs
@@ -35,6 +35,16 @@ fn test_key_commands(set_up_repo: Result<RepoOpen>) -> Result<()> {
     assert_eq!(keyfile2.username, Some("my_user".to_string()));
     assert!(keyfile2.created.is_some());
 
+    // try to find the second key by string
+    let found_ids: Vec<KeyId> = repo.find_ids(&[key_id2.to_string()])?.collect();
+    assert_eq!(found_ids, &[key_id2]);
+    let found_keys: Vec<KeyFile> = repo
+        .stream_files_list::<KeyFile>(&found_ids)?
+        .map(|item| item.unwrap().1)
+        .collect();
+    assert_eq!(found_keys.len(), 1);
+    assert_eq!(&found_keys[0], keyfile2);
+
     // try to remove the used repository key - which should fail
     assert!(repo.delete_key(&key_id.to_string()).is_err());
 


### PR DESCRIPTION
Add methods to `Repository` to find ids by `str` and to stream files given in a list.