### PR TITLE
fix: Make example for time format even more explicit

### DIFF
--- a/crates/core/src/repofile/snapshotfile.rs
+++ b/crates/core/src/repofile/snapshotfile.rs
@@ -91,7 +91,7 @@ pub struct SnapshotOptions {
     #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
     pub description_from: Option<PathBuf>,
 
-    /// Set the backup time manually (e.g. "2021-01-01 11:15:23+0000")
+    /// Set the backup time manually (e.g. "2021-01-21 14:15:23+0000")
     #[cfg_attr(feature = "clap", clap(long))]
     #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
     pub time: Option<DateTime<Local>>,


### PR DESCRIPTION
This change hints yyy-mm-dd date format usage and 24h clock.

Not all the world is using this format hence it is better for provided example to be unequivocal