### PR TITLE
feat!: Add support for multiple parents

### DIFF
--- a/crates/core/src/repofile/snapshotfile.rs
+++ b/crates/core/src/repofile/snapshotfile.rs
@@ -334,8 +334,12 @@ pub struct SnapshotFile {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub program_version: String,
 
-    /// The Id of the parent snapshot that this snapshot has been based on
+    /// The Id of the first parent snapshot that this snapshot has been based on
     pub parent: Option<SnapshotId>,
+
+    /// The Ids of all parent snapshots that this snapshot has been based on
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parents: Vec<SnapshotId>,
 
     /// The tree blob id where the contents of this snapshot are stored
     pub tree: TreeId,
@@ -395,6 +399,7 @@ impl Default for SnapshotFile {
                 format!("rustic {project_version}")
             },
             parent: Option::default(),
+            parents: Vec::default(),
             tree: TreeId::default(),
             label: String::default(),
             paths: StringList::default(),
@@ -1144,7 +1149,18 @@ impl SnapshotFile {
     pub(crate) fn clear_ids(mut sn: Self) -> Self {
         sn.id = SnapshotId::default();
         sn.parent = None;
+        sn.parents = Vec::new();
         sn
+    }
+
+    /// Convenience method to get parent snapshots which are stored in the `parent` or `parents` field.
+    #[must_use]
+    pub fn get_parents(&self) -> &[SnapshotId] {
+        if self.parents.is_empty() {
+            self.parent.as_slice()
+        } else {
+            &self.parents
+        }
     }
 }
 

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -107,6 +107,7 @@ fn insta_snapshotfile_redaction() -> Settings {
     });
     settings.add_redaction(".**.time", "[time]");
     settings.add_dynamic_redaction(".**.parent", handle_option);
+    settings.add_redaction(".**.parents", "[parents]");
     settings.add_redaction(".**.id", "[id]");
     settings.add_redaction(".**.original", "[original]");
     settings.add_redaction(".**.hostname", "[hostname]");

--- a/crates/core/tests/snapshots/integration__backup-tar-groups-nix.snap
+++ b/crates/core/tests/snapshots/integration__backup-tar-groups-nix.snap
@@ -50,6 +50,7 @@ expression: snap
       time: "[time]",
       program_version: "rustic [rustic_core_version]",
       parent: "[some]",
+      parents: "[parents]",
       tree: "[tree_id]",
       paths: StringList([
         "test",
@@ -98,6 +99,7 @@ expression: snap
       time: "[time]",
       program_version: "rustic [rustic_core_version]",
       parent: "[some]",
+      parents: "[parents]",
       tree: "[tree_id]",
       paths: StringList([
         "test",

--- a/crates/core/tests/snapshots/integration__backup-tar-matching-snaps-nix.snap
+++ b/crates/core/tests/snapshots/integration__backup-tar-matching-snaps-nix.snap
@@ -7,6 +7,7 @@ expression: snap
     time: "[time]",
     program_version: "rustic [rustic_core_version]",
     parent: "[some]",
+    parents: "[parents]",
     tree: "[tree_id]",
     paths: StringList([
       "test",

--- a/crates/core/tests/snapshots/integration__backup-tar-summary-second-nix.snap
+++ b/crates/core/tests/snapshots/integration__backup-tar-summary-second-nix.snap
@@ -6,6 +6,7 @@ SnapshotFile(
   time: "[time]",
   program_version: "rustic [rustic_core_version]",
   parent: "[some]",
+  parents: "[parents]",
   tree: "[tree_id]",
   paths: StringList([
     "test",

--- a/crates/core/tests/snapshots/integration__backup-tar-summary-third-nix.snap
+++ b/crates/core/tests/snapshots/integration__backup-tar-summary-third-nix.snap
@@ -6,6 +6,7 @@ SnapshotFile(
   time: "[time]",
   program_version: "rustic [rustic_core_version]",
   parent: "[some]",
+  parents: "[parents]",
   tree: "[tree_id]",
   paths: StringList([
     "test",

--- a/crates/core/tests/snapshots/integration__dryrun-tar-summary-second-nix.snap
+++ b/crates/core/tests/snapshots/integration__dryrun-tar-summary-second-nix.snap
@@ -6,6 +6,7 @@ SnapshotFile(
   time: "[time]",
   program_version: "rustic [rustic_core_version]",
   parent: "[some]",
+  parents: "[parents]",
   tree: "[tree_id]",
   paths: StringList([
     "test",


### PR DESCRIPTION
To solve https://github.com/rustic-rs/rustic/issues/493 it will be necessary to add support for multiple parents.

This PR adds this support:
- The `parent` option can be now given multiple times
- In the `SnapshotFile` also mutliple parent ids can now be saved
- All trees of all parent snapshots are processed and a suitable entry of any of the parents is taken