### PR TITLE
feat!: improve restore algorithm

### DIFF
--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -10,6 +10,7 @@ pub use zstd::compression_level_range;
 use crate::{
     Progress,
     backend::{FileType, ReadBackend, WriteBackend},
+    blob::BlobLocation,
     crypto::{CryptoKey, hasher::hash},
     error::{ErrorKind, RusticError, RusticResult},
     id::Id,
@@ -114,13 +115,11 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
         tpe: FileType,
         id: &Id,
         cacheable: bool,
-        offset: u32,
-        length: u32,
-        uncompressed_length: Option<NonZeroU32>,
+        location: BlobLocation,
     ) -> RusticResult<Bytes> {
         self.read_encrypted_from_partial(
-            &self.read_partial(tpe, id, cacheable, offset, length)?,
-            uncompressed_length,
+            &self.read_partial(tpe, id, cacheable, location.offset, location.length)?,
+            location.uncompressed_length,
         )
     }
 

--- a/crates/core/src/commands/repoinfo.rs
+++ b/crates/core/src/commands/repoinfo.rs
@@ -52,7 +52,7 @@ impl BlobInfo {
     // TODO: What happens if the [`IndexEntry`] is not of the same [`BlobType`] as this [`BlobInfo`]?
     pub(crate) fn add(&mut self, ie: IndexEntry) {
         self.count += 1;
-        self.size += u64::from(ie.length);
+        self.size += u64::from(ie.location.length);
         self.data_size += u64::from(ie.data_length());
     }
 }

--- a/crates/core/src/repofile/indexfile.rs
+++ b/crates/core/src/repofile/indexfile.rs
@@ -1,4 +1,4 @@
-use crate::repofile::RusticTime;
+use crate::{blob::BlobLocation, repofile::RusticTime};
 use std::{cmp::Ordering, num::NonZeroU32};
 
 use jiff::Timestamp;
@@ -97,9 +97,11 @@ impl IndexPack {
         self.blobs.push(IndexBlob {
             id,
             tpe,
-            offset,
-            length,
-            uncompressed_length,
+            location: BlobLocation {
+                offset,
+                length,
+                uncompressed_length,
+            },
         });
     }
 
@@ -134,13 +136,10 @@ pub struct IndexBlob {
     #[serde(rename = "type")]
     /// Type of the blob
     pub tpe: BlobType,
-    /// Offset of the blob within the `pack` file
-    pub offset: u32,
-    /// Length of the blob as stored within the `pack` file
-    pub length: u32,
-    /// Data length of the blob. This is only set if the blob is compressed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uncompressed_length: Option<NonZeroU32>,
+
+    #[serde(flatten)]
+    /// Location of the blob within the `pack` file
+    pub location: BlobLocation,
 }
 
 impl PartialOrd<Self> for IndexBlob {
@@ -169,6 +168,6 @@ impl Ord for IndexBlob {
     ///
     /// The ordering of the two blobs
     fn cmp(&self, other: &Self) -> Ordering {
-        self.offset.cmp(&other.offset)
+        self.location.cmp(&other.location)
     }
 }


### PR DESCRIPTION
Enhances the blob-reading optimization used in the restore to also read small holes, like in #448.
In order to re-use the algorithm, a refactoring about blob locations has been done, making this PR a breaking change.