### PR TITLE
fix: Use parents instead of parent; allow latest

### DIFF
--- a/crates/core/tests/integration/backup.rs
+++ b/crates/core/tests/integration/backup.rs
@@ -88,7 +88,7 @@ fn test_backup_with_tar_gz_passes(
         .tags([StringList::from_str("a,b")?])
         .to_snapshot()?;
     let opts =
-        opts.parent_opts(ParentOptions::default().parent(vec![second_snapshot.id.to_string()]));
+        opts.parent_opts(ParentOptions::default().parents(vec![second_snapshot.id.to_string()]));
     let third_snapshot = repo.backup(&opts, paths, snap)?;
 
     insta_snapshotfile_redaction.bind(|| {


### PR DESCRIPTION
follow-up to #427.

We now use `parents` in the toml and additionally allow `latest` or `latest~N` as parents.