### PR TITLE
feat!: extend LocalSourceSaveOptions

### DIFF
--- a/crates/core/src/archiver/parent.rs
+++ b/crates/core/src/archiver/parent.rs
@@ -171,13 +171,21 @@ impl Parent {
 
         p_node
             .find(|p_node| {
+                let p_meta = &p_node.meta;
+                let meta = &node.meta;
+
+                let match_ctime =
+                    ignore_ctime || p_meta.ctime.zip(meta.ctime).is_none_or(|(x, y)| x == y);
+                let match_inode = !ignore_inode
+                    || p_meta.inode == 0
+                    || meta.inode == 0
+                    || p_meta.inode == meta.inode;
+
                 p_node.node_type == node.node_type
-                    && p_node.meta.size == node.meta.size
-                    && p_node.meta.mtime == node.meta.mtime
-                    && (ignore_ctime || p_node.meta.ctime == node.meta.ctime)
-                    && (ignore_inode
-                        || p_node.meta.inode == 0
-                        || p_node.meta.inode == node.meta.inode)
+                    && p_meta.size == meta.size
+                    && p_meta.mtime == meta.mtime
+                    && match_ctime
+                    && match_inode
             })
             .map_or(ParentResult::NotMatched, ParentResult::Matched)
     }

--- a/crates/core/src/backend/ignore.rs
+++ b/crates/core/src/backend/ignore.rs
@@ -1,38 +1,28 @@
+pub mod mapper;
+pub use mapper::LocalSourceSaveOptions;
+
 use std::{
-    fs::{File, read_link},
+    fs::File,
     path::{Path, PathBuf},
 };
 
 use bytesize::ByteSize;
 use derive_setters::Setters;
-use ignore::{DirEntry, Walk, WalkBuilder, overrides::OverrideBuilder};
-use jiff::Timestamp;
+use ignore::{Walk, WalkBuilder, overrides::OverrideBuilder};
 use log::warn;
-use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
 #[cfg(not(windows))]
-use {
-    crate::backend::node::ExtendedAttribute,
-    cached::proc_macro::cached,
-    nix::unistd::{Gid, Group, Uid, User},
-    std::num::TryFromIntError,
-    std::os::unix::fs::{FileTypeExt, MetadataExt},
-};
+use std::num::TryFromIntError;
 
 use crate::{
-    backend::{
-        ReadSource, ReadSourceEntry, ReadSourceOpen,
-        node::{Metadata, Node, NodeType},
-    },
+    backend::{ReadSource, ReadSourceEntry, ReadSourceOpen},
     error::{ErrorKind, RusticError, RusticResult},
 };
 
 /// [`IgnoreErrorKind`] describes the errors that can be returned by a Ignore action in Backends
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum IgnoreErrorKind {
-    /// Failed to get metadata for entry: `{source:?}`
-    FailedToGetMetadata { source: ignore::Error },
     #[cfg(all(not(windows), not(target_os = "openbsd")))]
     /// Error getting xattrs for `{path:?}`: `{source:?}`
     ErrorXattr {
@@ -51,7 +41,6 @@ pub enum IgnoreErrorKind {
         ctime_nsec: i64,
         source: TryFromIntError,
     },
-    #[cfg(not(windows))]
     /// Error acquiring metadata for `{name}`: `{source:?}`
     AcquiringMetadataFailed { name: String, source: ignore::Error },
     /// time error
@@ -67,36 +56,6 @@ pub struct LocalSource {
     builder: WalkBuilder,
     /// The save options to use.
     save_opts: LocalSourceSaveOptions,
-}
-
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum SaveDevId {
-    Always,
-    #[default]
-    Hardlink,
-    Never,
-}
-
-#[serde_as]
-#[cfg_attr(feature = "clap", derive(clap::Parser))]
-#[cfg_attr(feature = "merge", derive(conflate::Merge))]
-#[derive(serde::Deserialize, serde::Serialize, Default, Clone, Copy, Debug, Setters)]
-#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
-#[setters(into)]
-#[non_exhaustive]
-/// [`LocalSourceSaveOptions`] describes how entries from a local source will be saved in the repository.
-pub struct LocalSourceSaveOptions {
-    /// Save access time for files and directories
-    #[cfg_attr(feature = "clap", clap(long))]
-    #[cfg_attr(feature = "merge", merge(strategy = conflate::bool::overwrite_false))]
-    pub with_atime: bool,
-
-    /// Select whether the device ID should be saved [default: hardlink]
-    #[cfg_attr(feature = "clap", clap(long))]
-    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
-    pub with_devid: Option<SaveDevId>,
 }
 
 #[serde_as]
@@ -409,394 +368,23 @@ impl Iterator for LocalSourceWalker {
             item => item,
         }
         .map(|e| {
-            map_entry(
-                e.map_err(|err| {
+            self.save_opts
+                .map_entry(e.map_err(|err| {
                     RusticError::with_source(
                         ErrorKind::Internal,
                         "Failed to get next entry from walk iterator.",
                         err,
                     )
                     .ask_report()
-                })?,
-                self.save_opts.with_atime,
-                self.save_opts.with_devid,
-            )
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Internal,
-                    "Failed to map Directory entry to ReadSourceEntry.",
-                    err,
-                )
-                .ask_report()
-            })
+                })?)
+                .map_err(|err| {
+                    RusticError::with_source(
+                        ErrorKind::Internal,
+                        "Failed to map Directory entry to ReadSourceEntry.",
+                        err,
+                    )
+                    .ask_report()
+                })
         })
-    }
-}
-
-/// Maps a [`DirEntry`] to a [`ReadSourceEntry`].
-///
-/// # Arguments
-///
-/// * `entry` - The [`DirEntry`] to map.
-/// * `with_atime` - Whether to save access time for files and directories.
-/// * `with_devid` - Whether to save device ID for files and directories.
-///
-/// # Errors
-///
-/// * If metadata could not be read.
-/// * If path of the entry could not be read.
-#[cfg(windows)]
-#[allow(clippy::similar_names)]
-fn map_entry(
-    entry: DirEntry,
-    with_atime: bool,
-    _with_devid: Option<SaveDevId>,
-) -> IgnoreResult<ReadSourceEntry<OpenFile>> {
-    let name = entry.file_name();
-    let m = entry
-        .metadata()
-        .map_err(|err| IgnoreErrorKind::FailedToGetMetadata { source: err })?;
-
-    // TODO: Set them to suitable values
-    let uid = None;
-    let gid = None;
-    let user = None;
-    let group = None;
-
-    let size = if m.is_dir() { 0 } else { m.len() };
-    let mode = None;
-    let inode = 0;
-    let device_id = 0;
-    let links = 0;
-
-    let mtime = m.modified().ok().and_then(|t| Timestamp::try_from(t).ok());
-    let atime = if with_atime {
-        m.accessed().ok().and_then(|t| Timestamp::try_from(t).ok())
-    } else {
-        // TODO: Use None here?
-        mtime
-    };
-    let ctime = m.created().ok().and_then(|t| Timestamp::try_from(t).ok());
-
-    let meta = Metadata {
-        size,
-        mtime,
-        atime,
-        ctime,
-        mode,
-        uid,
-        gid,
-        user,
-        group,
-        inode,
-        device_id,
-        links,
-        extended_attributes: Vec::new(),
-    };
-
-    let node = if m.is_dir() {
-        Node::new_node(name, NodeType::Dir, meta)
-    } else if m.is_symlink() {
-        let path = entry.path();
-        let target = read_link(path).map_err(|err| IgnoreErrorKind::ErrorLink {
-            path: path.to_path_buf(),
-            source: err,
-        })?;
-        let node_type = NodeType::from_link(&target);
-        Node::new_node(name, node_type, meta)
-    } else {
-        Node::new_node(name, NodeType::File, meta)
-    };
-
-    let path = entry.into_path();
-    let open = Some(OpenFile(path.clone()));
-    Ok(ReadSourceEntry { path, node, open })
-}
-
-/// Get the user name for the given uid.
-///
-/// # Arguments
-///
-/// * `uid` - The uid to get the user name for.
-///
-/// # Returns
-///
-/// The user name for the given uid or `None` if the user could not be found.
-#[cfg(not(windows))]
-#[cached]
-fn get_user_by_uid(uid: u32) -> Option<String> {
-    match User::from_uid(Uid::from_raw(uid)) {
-        Ok(Some(user)) => Some(user.name),
-        Ok(None) => None,
-        Err(err) => {
-            warn!("error getting user from uid {uid}: {err}");
-            None
-        }
-    }
-}
-
-/// Get the group name for the given gid.
-///
-/// # Arguments
-///
-/// * `gid` - The gid to get the group name for.
-///
-/// # Returns
-///
-/// The group name for the given gid or `None` if the group could not be found.
-#[cfg(not(windows))]
-#[cached]
-fn get_group_by_gid(gid: u32) -> Option<String> {
-    match Group::from_gid(Gid::from_raw(gid)) {
-        Ok(Some(group)) => Some(group.name),
-        Ok(None) => None,
-        Err(err) => {
-            warn!("error getting group from gid {gid}: {err}");
-            None
-        }
-    }
-}
-
-#[cfg(all(not(windows), target_os = "openbsd"))]
-fn list_extended_attributes(path: &Path) -> IgnoreResult<Vec<ExtendedAttribute>> {
-    Ok(vec![])
-}
-
-/// List [`ExtendedAttribute`] for a [`Node`] located at `path`
-///
-/// # Argument
-///
-/// * `path` to the [`Node`] for which to list attributes
-///
-/// # Errors
-///
-/// * If Xattr couldn't be listed or couldn't be read
-#[cfg(all(not(windows), not(target_os = "openbsd")))]
-fn list_extended_attributes(path: &Path) -> IgnoreResult<Vec<ExtendedAttribute>> {
-    xattr::list(path)
-        .map_err(|err| IgnoreErrorKind::ErrorXattr {
-            path: path.to_path_buf(),
-            source: err,
-        })?
-        .map(|name| {
-            Ok(ExtendedAttribute {
-                name: name.to_string_lossy().to_string(),
-                value: xattr::get(path, name).map_err(|err| IgnoreErrorKind::ErrorXattr {
-                    path: path.to_path_buf(),
-                    source: err,
-                })?,
-            })
-        })
-        .collect::<IgnoreResult<Vec<ExtendedAttribute>>>()
-}
-
-/// Maps a [`DirEntry`] to a [`ReadSourceEntry`].
-///
-/// # Arguments
-///
-/// * `entry` - The [`DirEntry`] to map.
-/// * `with_atime` - Whether to save access time for files and directories.
-/// * `with_devid` - Whether to save device ID for files and directories.
-///
-/// # Errors
-///
-/// * If metadata could not be read.
-/// * If the xattr of the entry could not be read.
-#[cfg(not(windows))]
-// map_entry: turn entry into (Path, Node)
-#[allow(clippy::similar_names)]
-fn map_entry(
-    entry: DirEntry,
-    with_atime: bool,
-    with_devid: Option<SaveDevId>,
-) -> IgnoreResult<ReadSourceEntry<OpenFile>> {
-    let name = entry.file_name();
-    let m = entry
-        .metadata()
-        .map_err(|err| IgnoreErrorKind::AcquiringMetadataFailed {
-            name: name.to_string_lossy().to_string(),
-            source: err,
-        })?;
-
-    let uid = m.uid();
-    let gid = m.gid();
-    let user = get_user_by_uid(uid);
-    let group = get_group_by_gid(gid);
-
-    let mtime = m.modified().ok().and_then(|t| Timestamp::try_from(t).ok());
-    let atime = if with_atime {
-        m.accessed().ok().and_then(|t| Timestamp::try_from(t).ok())
-    } else {
-        // TODO: Use None here?
-        mtime
-    };
-    let ctime = Some(Timestamp::new(
-        m.ctime(),
-        m.ctime_nsec().try_into().map_err(|err| {
-            IgnoreErrorKind::CtimeConversionToTimestampFailed {
-                ctime: m.ctime(),
-                ctime_nsec: m.ctime_nsec(),
-                source: err,
-            }
-        })?,
-    )?);
-
-    let size = if m.is_dir() { 0 } else { m.len() };
-    let mode = mapper::map_mode_to_go(m.mode());
-    let inode = m.ino();
-    let links = if m.is_dir() { 0 } else { m.nlink() };
-    let device_id = match with_devid.unwrap_or_default() {
-        SaveDevId::Always | SaveDevId::Hardlink if links > 1 => m.dev(),
-        _ => 0,
-    };
-
-    let extended_attributes = match list_extended_attributes(entry.path()) {
-        Err(err) => {
-            warn!("ignoring error: {err}");
-            vec![]
-        }
-        Ok(xattr_list) => xattr_list,
-    };
-
-    let meta = Metadata {
-        size,
-        mtime,
-        atime,
-        ctime,
-        mode: Some(mode),
-        uid: Some(uid),
-        gid: Some(gid),
-        user,
-        group,
-        inode,
-        device_id,
-        links,
-        extended_attributes,
-    };
-    let filetype = m.file_type();
-
-    let node = if m.is_dir() {
-        Node::new_node(name, NodeType::Dir, meta)
-    } else if m.is_symlink() {
-        let path = entry.path();
-        let target = read_link(path).map_err(|err| IgnoreErrorKind::ErrorLink {
-            path: path.to_path_buf(),
-            source: err,
-        })?;
-        let node_type = NodeType::from_link(&target);
-        Node::new_node(name, node_type, meta)
-    } else if filetype.is_block_device() {
-        let node_type = NodeType::Dev { device: m.rdev() };
-        Node::new_node(name, node_type, meta)
-    } else if filetype.is_char_device() {
-        let node_type = NodeType::Chardev { device: m.rdev() };
-        Node::new_node(name, node_type, meta)
-    } else if filetype.is_fifo() {
-        Node::new_node(name, NodeType::Fifo, meta)
-    } else if filetype.is_socket() {
-        Node::new_node(name, NodeType::Socket, meta)
-    } else {
-        Node::new_node(name, NodeType::File, meta)
-    };
-    let path = entry.into_path();
-    let open = Some(OpenFile(path.clone()));
-    Ok(ReadSourceEntry { path, node, open })
-}
-
-#[cfg(not(windows))]
-pub mod mapper {
-    const MODE_PERM: u32 = 0o777; // permission bits
-
-    // consts from https://pkg.go.dev/io/fs#ModeType
-    const GO_MODE_DIR: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
-    const GO_MODE_SYMLINK: u32 = 0b0000_1000_0000_0000_0000_0000_0000_0000;
-    const GO_MODE_DEVICE: u32 = 0b0000_0100_0000_0000_0000_0000_0000_0000;
-    const GO_MODE_FIFO: u32 = 0b0000_0010_0000_0000_0000_0000_0000_0000;
-    const GO_MODE_SOCKET: u32 = 0b0000_0001_0000_0000_0000_0000_0000_0000;
-    const GO_MODE_SETUID: u32 = 0b0000_0000_1000_0000_0000_0000_0000_0000;
-    const GO_MODE_SETGID: u32 = 0b0000_0000_0100_0000_0000_0000_0000_0000;
-    const GO_MODE_CHARDEV: u32 = 0b0000_0000_0010_0000_0000_0000_0000_0000;
-    const GO_MODE_STICKY: u32 = 0b0000_0000_0001_0000_0000_0000_0000_0000;
-    const GO_MODE_IRREG: u32 = 0b0000_0000_0000_1000_0000_0000_0000_0000;
-
-    // consts from man page inode(7)
-    const S_IFFORMAT: u32 = 0o170_000; // File mask
-    const S_IFSOCK: u32 = 0o140_000; // socket
-    const S_IFLNK: u32 = 0o120_000; // symbolic link
-    const S_IFREG: u32 = 0o100_000; // regular file
-    const S_IFBLK: u32 = 0o060_000; // block device
-    const S_IFDIR: u32 = 0o040_000; // directory
-    const S_IFCHR: u32 = 0o020_000; // character device
-    const S_IFIFO: u32 = 0o010_000; // FIFO
-
-    const S_ISUID: u32 = 0o4000; // set-user-ID bit (see execve(2))
-    const S_ISGID: u32 = 0o2000; // set-group-ID bit (see below)
-    const S_ISVTX: u32 = 0o1000; // sticky bit (see below)
-
-    /// map `st_mode` from POSIX (`inode(7)`) to golang's definition (<https://pkg.go.dev/io/fs#ModeType>)
-    /// Note, that it only sets the bits `os.ModePerm | os.ModeType | os.ModeSetuid | os.ModeSetgid | os.ModeSticky`
-    /// to stay compatible with the restic implementation
-    pub const fn map_mode_to_go(mode: u32) -> u32 {
-        let mut go_mode = mode & MODE_PERM;
-
-        match mode & S_IFFORMAT {
-            S_IFSOCK => go_mode |= GO_MODE_SOCKET,
-            S_IFLNK => go_mode |= GO_MODE_SYMLINK,
-            S_IFBLK => go_mode |= GO_MODE_DEVICE,
-            S_IFDIR => go_mode |= GO_MODE_DIR,
-            S_IFCHR => go_mode |= GO_MODE_CHARDEV & GO_MODE_DEVICE, // no idea why go sets both for char devices...
-            S_IFIFO => go_mode |= GO_MODE_FIFO,
-            // note that POSIX specifies regular files, whereas golang specifies irregular files
-            S_IFREG => {}
-            _ => go_mode |= GO_MODE_IRREG,
-        }
-
-        if mode & S_ISUID > 0 {
-            go_mode |= GO_MODE_SETUID;
-        }
-        if mode & S_ISGID > 0 {
-            go_mode |= GO_MODE_SETGID;
-        }
-        if mode & S_ISVTX > 0 {
-            go_mode |= GO_MODE_STICKY;
-        }
-
-        go_mode
-    }
-
-    /// map golangs mode definition (<https://pkg.go.dev/io/fs#ModeType>) to `st_mode` from POSIX (`inode(7)`)
-    /// This is the inverse function to [`map_mode_to_go`]
-    pub const fn map_mode_from_go(go_mode: u32) -> u32 {
-        let mut mode = go_mode & MODE_PERM;
-
-        if go_mode & GO_MODE_SOCKET > 0 {
-            mode |= S_IFSOCK;
-        } else if go_mode & GO_MODE_SYMLINK > 0 {
-            mode |= S_IFLNK;
-        } else if go_mode & GO_MODE_DEVICE > 0 && go_mode & GO_MODE_CHARDEV == 0 {
-            mode |= S_IFBLK;
-        } else if go_mode & GO_MODE_DIR > 0 {
-            mode |= S_IFDIR;
-        } else if go_mode & (GO_MODE_CHARDEV | GO_MODE_DEVICE) > 0 {
-            mode |= S_IFCHR;
-        } else if go_mode & GO_MODE_FIFO > 0 {
-            mode |= S_IFIFO;
-        } else if go_mode & GO_MODE_IRREG > 0 {
-            // note that POSIX specifies regular files, whereas golang specifies irregular files
-        } else {
-            mode |= S_IFREG;
-        }
-
-        if go_mode & GO_MODE_SETUID > 0 {
-            mode |= S_ISUID;
-        }
-        if go_mode & GO_MODE_SETGID > 0 {
-            mode |= S_ISGID;
-        }
-        if go_mode & GO_MODE_STICKY > 0 {
-            mode |= S_ISVTX;
-        }
-
-        mode
     }
 }

--- a/crates/core/src/backend/ignore/mapper.rs
+++ b/crates/core/src/backend/ignore/mapper.rs
@@ -1,0 +1,316 @@
+#[cfg(not(windows))]
+pub mod nix_mapper;
+
+use std::{ffi::OsStr, path::Path};
+
+use derive_setters::Setters;
+use ignore::DirEntry;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use super::{IgnoreErrorKind, IgnoreResult, OpenFile};
+use crate::backend::{
+    ReadSourceEntry,
+    node::{ExtendedAttribute, Metadata, Node, NodeType},
+};
+
+#[cfg(not(windows))]
+use {
+    log::warn,
+    std::os::unix::fs::{FileTypeExt, MetadataExt},
+};
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TimeOption {
+    Yes,
+    Mtime,
+    No,
+}
+
+impl TimeOption {
+    fn map(self, default: Option<Timestamp>, mtime: Option<Timestamp>) -> Option<Timestamp> {
+        match self {
+            Self::Yes => default,
+            Self::Mtime => mtime,
+            Self::No => None,
+        }
+    }
+}
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DevIdOption {
+    Yes,
+    #[default]
+    Hardlink,
+    No,
+}
+
+impl DevIdOption {
+    #[cfg(windows)]
+    fn map(self, _m: &std::fs::Metadata) -> u64 {
+        0
+    }
+
+    #[cfg(not(windows))]
+    fn map(self, m: &std::fs::Metadata) -> u64 {
+        match self {
+            Self::Yes => m.dev(),
+            Self::Hardlink if m.nlink() > 1 && !m.is_dir() => m.dev(),
+            _ => 0,
+        }
+    }
+}
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BlockdevOption {
+    #[default]
+    Special,
+    File,
+}
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum XattrOption {
+    #[default]
+    Yes,
+    No,
+}
+
+impl XattrOption {
+    #[cfg(any(windows, target_os = "openbsd"))]
+    fn map(&self, _path: &Path) -> Vec<ExtendedAttribute> {
+        Vec::new()
+    }
+
+    /// List [`ExtendedAttribute`] for a [`Node`] located at `path`
+    ///
+    /// # Argument
+    ///
+    /// * `path` to the [`Node`] for which to list attributes
+    ///
+    /// # Errors
+    ///
+    /// * If Xattr couldn't be listed or couldn't be read
+    #[cfg(not(any(windows, target_os = "openbsd")))]
+    fn map(self, path: &Path) -> Vec<ExtendedAttribute> {
+        let list = |path: &Path| {
+            xattr::list(path)
+                .map_err(|err| IgnoreErrorKind::ErrorXattr {
+                    path: path.to_path_buf(),
+                    source: err,
+                })?
+                .map(|name| {
+                    Ok(ExtendedAttribute {
+                        name: name.to_string_lossy().to_string(),
+                        value: xattr::get(path, name).map_err(|err| {
+                            IgnoreErrorKind::ErrorXattr {
+                                path: path.to_path_buf(),
+                                source: err,
+                            }
+                        })?,
+                    })
+                })
+                .collect::<IgnoreResult<Vec<ExtendedAttribute>>>()
+        };
+
+        match self {
+            Self::Yes => list(path)
+                .inspect_err(|err| {
+                    warn!("ignoring error: {err}");
+                })
+                .unwrap_or_default(),
+            Self::No => Vec::new(),
+        }
+    }
+}
+
+#[serde_as]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "merge", derive(conflate::Merge))]
+#[derive(serde::Deserialize, serde::Serialize, Default, Clone, Copy, Debug, Setters)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+#[setters(into)]
+#[non_exhaustive]
+/// [`LocalSourceSaveOptions`] describes how entries from a local source will be saved in the repository.
+pub struct LocalSourceSaveOptions {
+    /// Set access time [default: yes]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_atime: Option<TimeOption>,
+
+    /// Set changed time [default: yes]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_ctime: Option<TimeOption>,
+
+    /// Set device ID [default: hardlink]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_devid: Option<DevIdOption>,
+
+    /// How block devices should be stored [default: special]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_blockdev: Option<BlockdevOption>,
+
+    /// Set extended attributes [default: yes]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_xattrs: Option<XattrOption>,
+}
+
+impl LocalSourceSaveOptions {
+    /// Maps a [`DirEntry`] to a [`ReadSourceEntry`].
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - The [`DirEntry`] to map.
+    /// * `options` - options for saving entries
+    ///
+    /// # Errors
+    ///
+    /// * If metadata could not be read.
+    /// * If the xattr of the entry could not be read.
+    pub fn map_entry(self, entry: DirEntry) -> IgnoreResult<ReadSourceEntry<OpenFile>> {
+        let name = entry.file_name();
+        let m = entry
+            .metadata()
+            .map_err(|err| IgnoreErrorKind::AcquiringMetadataFailed {
+                name: name.to_string_lossy().to_string(),
+                source: err,
+            })?;
+
+        let mtime = m.modified().ok().and_then(|t| Timestamp::try_from(t).ok());
+        let atime = m.accessed().ok().and_then(|t| Timestamp::try_from(t).ok());
+        let atime = self
+            .set_atime
+            .unwrap_or(TimeOption::Mtime)
+            .map(atime, mtime);
+        let ctime = Self::default_ctime(&m);
+        let ctime = self.set_ctime.unwrap_or(TimeOption::Yes).map(ctime, mtime);
+
+        let (uid, user, gid, group) = Self::user_group(&m);
+        let size = if m.is_dir() { 0 } else { m.len() };
+        let device_id = self.set_devid.unwrap_or_default().map(&m);
+        let extended_attributes = self.set_xattrs.unwrap_or_default().map(entry.path());
+        let (mode, inode, links) = Self::nix_infos(&m);
+
+        let meta = Metadata {
+            mode,
+            mtime,
+            atime,
+            ctime,
+            uid,
+            gid,
+            user,
+            group,
+            inode,
+            device_id,
+            size,
+            links,
+            extended_attributes,
+        };
+
+        let node = self.to_node(&entry, &m, meta)?;
+        let path = entry.into_path();
+        let open = Some(OpenFile(path.clone()));
+        Ok(ReadSourceEntry { path, node, open })
+    }
+
+    fn to_node(
+        self,
+        entry: &DirEntry,
+        m: &std::fs::Metadata,
+        meta: Metadata,
+    ) -> IgnoreResult<Node> {
+        let name = entry.file_name();
+        let node = if m.is_dir() {
+            Node::new_node(name, NodeType::Dir, meta)
+        } else if m.is_symlink() {
+            let path = entry.path();
+            let target = std::fs::read_link(path).map_err(|err| IgnoreErrorKind::ErrorLink {
+                path: path.to_path_buf(),
+                source: err,
+            })?;
+            let node_type = NodeType::from_link(&target);
+            Node::new_node(name, node_type, meta)
+        } else {
+            self.to_node_other(name, m, meta)
+        };
+        Ok(node)
+    }
+}
+
+#[cfg(not(windows))]
+impl LocalSourceSaveOptions {
+    fn default_ctime(m: &std::fs::Metadata) -> Option<Timestamp> {
+        #[allow(clippy::cast_possible_truncation)]
+        Timestamp::new(m.ctime(), m.ctime_nsec() as i32).ok()
+    }
+
+    fn user_group(
+        m: &std::fs::Metadata,
+    ) -> (Option<u32>, Option<String>, Option<u32>, Option<String>) {
+        let uid = m.uid();
+        let gid = m.gid();
+        let user = nix_mapper::get_user_by_uid(uid);
+        let group = nix_mapper::get_group_by_gid(gid);
+        (Some(uid), user, Some(gid), group)
+    }
+
+    fn nix_infos(m: &std::fs::Metadata) -> (Option<u32>, u64, u64) {
+        let mode = nix_mapper::map_mode_to_go(m.mode());
+        let inode = m.ino();
+        let links = if m.is_dir() { 0 } else { m.nlink() };
+        (Some(mode), inode, links)
+    }
+
+    fn to_node_other(self, name: &OsStr, m: &std::fs::Metadata, meta: Metadata) -> Node {
+        let filetype = m.file_type();
+        if filetype.is_block_device() {
+            if matches!(self.set_blockdev.unwrap_or_default(), BlockdevOption::File) {
+                Node::new_node(name, NodeType::File, meta)
+            } else {
+                let node_type = NodeType::Dev { device: m.rdev() };
+                Node::new_node(name, node_type, meta)
+            }
+        } else if filetype.is_char_device() {
+            let node_type = NodeType::Chardev { device: m.rdev() };
+            Node::new_node(name, node_type, meta)
+        } else if filetype.is_fifo() {
+            Node::new_node(name, NodeType::Fifo, meta)
+        } else if filetype.is_socket() {
+            Node::new_node(name, NodeType::Socket, meta)
+        } else {
+            Node::new_node(name, NodeType::File, meta)
+        }
+    }
+}
+
+#[cfg(windows)]
+impl LocalSourceSaveOptions {
+    fn default_ctime(m: &std::fs::Metadata) -> Option<Timestamp> {
+        m.created().ok().and_then(|t| Timestamp::try_from(t).ok())
+    }
+    fn user_group(
+        _m: &std::fs::Metadata,
+    ) -> (Option<u32>, Option<String>, Option<u32>, Option<String>) {
+        (None, None, None, None)
+    }
+
+    fn nix_infos(_m: &std::fs::Metadata) -> (Option<u32>, u64, u64) {
+        (None, 0, 0)
+    }
+
+    fn to_node_other(self, name: &OsStr, _m: &std::fs::Metadata, meta: Metadata) -> Node {
+        Node::new_node(name, NodeType::File, meta)
+    }
+}

--- a/crates/core/src/backend/ignore/mapper/nix_mapper.rs
+++ b/crates/core/src/backend/ignore/mapper/nix_mapper.rs
@@ -1,0 +1,142 @@
+use {
+    cached::proc_macro::cached,
+    log::warn,
+    nix::unistd::{Gid, Group, Uid, User},
+};
+
+const MODE_PERM: u32 = 0o777; // permission bits
+
+// consts from https://pkg.go.dev/io/fs#ModeType
+const GO_MODE_DIR: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+const GO_MODE_SYMLINK: u32 = 0b0000_1000_0000_0000_0000_0000_0000_0000;
+const GO_MODE_DEVICE: u32 = 0b0000_0100_0000_0000_0000_0000_0000_0000;
+const GO_MODE_FIFO: u32 = 0b0000_0010_0000_0000_0000_0000_0000_0000;
+const GO_MODE_SOCKET: u32 = 0b0000_0001_0000_0000_0000_0000_0000_0000;
+const GO_MODE_SETUID: u32 = 0b0000_0000_1000_0000_0000_0000_0000_0000;
+const GO_MODE_SETGID: u32 = 0b0000_0000_0100_0000_0000_0000_0000_0000;
+const GO_MODE_CHARDEV: u32 = 0b0000_0000_0010_0000_0000_0000_0000_0000;
+const GO_MODE_STICKY: u32 = 0b0000_0000_0001_0000_0000_0000_0000_0000;
+const GO_MODE_IRREG: u32 = 0b0000_0000_0000_1000_0000_0000_0000_0000;
+
+// consts from man page inode(7)
+const S_IFFORMAT: u32 = 0o170_000; // File mask
+const S_IFSOCK: u32 = 0o140_000; // socket
+const S_IFLNK: u32 = 0o120_000; // symbolic link
+const S_IFREG: u32 = 0o100_000; // regular file
+const S_IFBLK: u32 = 0o060_000; // block device
+const S_IFDIR: u32 = 0o040_000; // directory
+const S_IFCHR: u32 = 0o020_000; // character device
+const S_IFIFO: u32 = 0o010_000; // FIFO
+
+const S_ISUID: u32 = 0o4000; // set-user-ID bit (see execve(2))
+const S_ISGID: u32 = 0o2000; // set-group-ID bit (see below)
+const S_ISVTX: u32 = 0o1000; // sticky bit (see below)
+
+/// map `st_mode` from POSIX (`inode(7)`) to golang's definition (<https://pkg.go.dev/io/fs#ModeType>)
+/// Note, that it only sets the bits `os.ModePerm | os.ModeType | os.ModeSetuid | os.ModeSetgid | os.ModeSticky`
+/// to stay compatible with the restic implementation
+pub const fn map_mode_to_go(mode: u32) -> u32 {
+    let mut go_mode = mode & MODE_PERM;
+
+    match mode & S_IFFORMAT {
+        S_IFSOCK => go_mode |= GO_MODE_SOCKET,
+        S_IFLNK => go_mode |= GO_MODE_SYMLINK,
+        S_IFBLK => go_mode |= GO_MODE_DEVICE,
+        S_IFDIR => go_mode |= GO_MODE_DIR,
+        S_IFCHR => go_mode |= GO_MODE_CHARDEV & GO_MODE_DEVICE, // no idea why go sets both for char devices...
+        S_IFIFO => go_mode |= GO_MODE_FIFO,
+        // note that POSIX specifies regular files, whereas golang specifies irregular files
+        S_IFREG => {}
+        _ => go_mode |= GO_MODE_IRREG,
+    }
+
+    if mode & S_ISUID > 0 {
+        go_mode |= GO_MODE_SETUID;
+    }
+    if mode & S_ISGID > 0 {
+        go_mode |= GO_MODE_SETGID;
+    }
+    if mode & S_ISVTX > 0 {
+        go_mode |= GO_MODE_STICKY;
+    }
+
+    go_mode
+}
+
+/// map golangs mode definition (<https://pkg.go.dev/io/fs#ModeType>) to `st_mode` from POSIX (`inode(7)`)
+/// This is the inverse function to [`map_mode_to_go`]
+pub const fn map_mode_from_go(go_mode: u32) -> u32 {
+    let mut mode = go_mode & MODE_PERM;
+
+    if go_mode & GO_MODE_SOCKET > 0 {
+        mode |= S_IFSOCK;
+    } else if go_mode & GO_MODE_SYMLINK > 0 {
+        mode |= S_IFLNK;
+    } else if go_mode & GO_MODE_DEVICE > 0 && go_mode & GO_MODE_CHARDEV == 0 {
+        mode |= S_IFBLK;
+    } else if go_mode & GO_MODE_DIR > 0 {
+        mode |= S_IFDIR;
+    } else if go_mode & (GO_MODE_CHARDEV | GO_MODE_DEVICE) > 0 {
+        mode |= S_IFCHR;
+    } else if go_mode & GO_MODE_FIFO > 0 {
+        mode |= S_IFIFO;
+    } else if go_mode & GO_MODE_IRREG > 0 {
+        // note that POSIX specifies regular files, whereas golang specifies irregular files
+    } else {
+        mode |= S_IFREG;
+    }
+
+    if go_mode & GO_MODE_SETUID > 0 {
+        mode |= S_ISUID;
+    }
+    if go_mode & GO_MODE_SETGID > 0 {
+        mode |= S_ISGID;
+    }
+    if go_mode & GO_MODE_STICKY > 0 {
+        mode |= S_ISVTX;
+    }
+
+    mode
+}
+
+/// Get the group name for the given gid.
+///
+/// # Arguments
+///
+/// * `gid` - The gid to get the group name for.
+///
+/// # Returns
+///
+/// The group name for the given gid or `None` if the group could not be found.
+#[cached]
+pub fn get_group_by_gid(gid: u32) -> Option<String> {
+    match Group::from_gid(Gid::from_raw(gid)) {
+        Ok(Some(group)) => Some(group.name),
+        Ok(None) => None,
+        Err(err) => {
+            warn!("error getting group from gid {gid}: {err}");
+            None
+        }
+    }
+}
+
+/// Get the user name for the given uid.
+///
+/// # Arguments
+///
+/// * `uid` - The uid to get the user name for.
+///
+/// # Returns
+///
+/// The user name for the given uid or `None` if the user could not be found.
+#[cached]
+pub fn get_user_by_uid(uid: u32) -> Option<String> {
+    match User::from_uid(Uid::from_raw(uid)) {
+        Ok(Some(user)) => Some(user.name),
+        Ok(None) => None,
+        Err(err) => {
+            warn!("error getting user from uid {uid}: {err}");
+            None
+        }
+    }
+}

--- a/crates/core/src/backend/local_destination.rs
+++ b/crates/core/src/backend/local_destination.rs
@@ -25,7 +25,7 @@ use nix::{
 };
 
 #[cfg(not(windows))]
-use crate::backend::ignore::mapper::map_mode_from_go;
+use crate::backend::ignore::mapper::nix_mapper::map_mode_from_go;
 #[cfg(not(windows))]
 use crate::backend::node::NodeType;
 use crate::{


### PR DESCRIPTION
This refacors `LocalSourceSaveOptions` and introduces changed/new options:

- `with-atime` => `set-atime` allows `yes`, `no`, `mtime` (default)
- `set-ctime` allows `yes`, `no`, `mtime` (default)
- `with-devid` => `set-devid` allows `yes`, `no`, `hardlink` (default)
- `set-blockdev` allows `special` (default), `file` - which allows reading block devices; closes #104
- `set-xattrs` allows `yes`, `no`; closes https://github.com/rustic-rs/rustic/issues/1599

Additional, the parent-processing algorithm has been updated. Now ctime and inode are only compared if they are set either in the parent or in the current snapshot.