### PR TITLE
feat!: More rewrite features

### DIFF
--- a/crates/core/src/backend/ignore/mapper.rs
+++ b/crates/core/src/backend/ignore/mapper.rs
@@ -6,65 +6,21 @@ use std::{ffi::OsStr, path::Path};
 use derive_setters::Setters;
 use ignore::DirEntry;
 use jiff::Timestamp;
+use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use super::{IgnoreErrorKind, IgnoreResult, OpenFile};
 use crate::backend::{
     ReadSourceEntry,
-    node::{ExtendedAttribute, Metadata, Node, NodeType},
+    node::{
+        ExtendedAttribute, Metadata, Node, NodeType,
+        modification::{DevIdOption, TimeOption, XattrOption},
+    },
 };
 
 #[cfg(not(windows))]
-use {
-    log::warn,
-    std::os::unix::fs::{FileTypeExt, MetadataExt},
-};
-
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum TimeOption {
-    Yes,
-    Mtime,
-    No,
-}
-
-impl TimeOption {
-    fn map(self, default: Option<Timestamp>, mtime: Option<Timestamp>) -> Option<Timestamp> {
-        match self {
-            Self::Yes => default,
-            Self::Mtime => mtime,
-            Self::No => None,
-        }
-    }
-}
-
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum DevIdOption {
-    Yes,
-    #[default]
-    Hardlink,
-    No,
-}
-
-impl DevIdOption {
-    #[cfg(windows)]
-    fn map(self, _m: &std::fs::Metadata) -> u64 {
-        0
-    }
-
-    #[cfg(not(windows))]
-    fn map(self, m: &std::fs::Metadata) -> u64 {
-        match self {
-            Self::Yes => m.dev(),
-            Self::Hardlink if m.nlink() > 1 && !m.is_dir() => m.dev(),
-            _ => 0,
-        }
-    }
-}
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
@@ -73,63 +29,6 @@ pub enum BlockdevOption {
     #[default]
     Special,
     File,
-}
-
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum XattrOption {
-    #[default]
-    Yes,
-    No,
-}
-
-impl XattrOption {
-    #[cfg(any(windows, target_os = "openbsd"))]
-    fn map(&self, _path: &Path) -> Vec<ExtendedAttribute> {
-        Vec::new()
-    }
-
-    /// List [`ExtendedAttribute`] for a [`Node`] located at `path`
-    ///
-    /// # Argument
-    ///
-    /// * `path` to the [`Node`] for which to list attributes
-    ///
-    /// # Errors
-    ///
-    /// * If Xattr couldn't be listed or couldn't be read
-    #[cfg(not(any(windows, target_os = "openbsd")))]
-    fn map(self, path: &Path) -> Vec<ExtendedAttribute> {
-        let list = |path: &Path| {
-            xattr::list(path)
-                .map_err(|err| IgnoreErrorKind::ErrorXattr {
-                    path: path.to_path_buf(),
-                    source: err,
-                })?
-                .map(|name| {
-                    Ok(ExtendedAttribute {
-                        name: name.to_string_lossy().to_string(),
-                        value: xattr::get(path, name).map_err(|err| {
-                            IgnoreErrorKind::ErrorXattr {
-                                path: path.to_path_buf(),
-                                source: err,
-                            }
-                        })?,
-                    })
-                })
-                .collect::<IgnoreResult<Vec<ExtendedAttribute>>>()
-        };
-
-        match self {
-            Self::Yes => list(path)
-                .inspect_err(|err| {
-                    warn!("ignoring error: {err}");
-                })
-                .unwrap_or_default(),
-            Self::No => Vec::new(),
-        }
-    }
 }
 
 #[serde_as]
@@ -141,7 +40,7 @@ impl XattrOption {
 #[non_exhaustive]
 /// [`LocalSourceSaveOptions`] describes how entries from a local source will be saved in the repository.
 pub struct LocalSourceSaveOptions {
-    /// Set access time [default: yes]
+    /// Set access time [default: mtime]
     #[cfg_attr(feature = "clap", clap(long))]
     #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
     pub set_atime: Option<TimeOption>,
@@ -189,18 +88,29 @@ impl LocalSourceSaveOptions {
             })?;
 
         let mtime = m.modified().ok().and_then(|t| Timestamp::try_from(t).ok());
-        let atime = m.accessed().ok().and_then(|t| Timestamp::try_from(t).ok());
+        let atime = || m.accessed().ok().and_then(|t| Timestamp::try_from(t).ok());
         let atime = self
             .set_atime
             .unwrap_or(TimeOption::Mtime)
-            .map(atime, mtime);
-        let ctime = Self::default_ctime(&m);
-        let ctime = self.set_ctime.unwrap_or(TimeOption::Yes).map(ctime, mtime);
+            .map_or_else(atime, mtime);
+        let ctime = || Self::ctime(&m);
+        let ctime = self
+            .set_ctime
+            .unwrap_or(TimeOption::Yes)
+            .map_or_else(ctime, mtime);
 
         let (uid, user, gid, group) = Self::user_group(&m);
         let size = if m.is_dir() { 0 } else { m.len() };
-        let device_id = self.set_devid.unwrap_or_default().map(&m);
-        let extended_attributes = self.set_xattrs.unwrap_or_default().map(entry.path());
+        let device_id = self
+            .set_devid
+            .unwrap_or_default()
+            .map_or_else(|| Self::device_id(&m), Self::hardlink(&m));
+        let xattr = || {
+            Self::xattrs(entry.path())
+                .inspect_err(|err| warn!("ignoring error obtaining xargs: {err}"))
+                .unwrap_or_default()
+        };
+        let extended_attributes = self.set_xattrs.unwrap_or_default().map_or_else(xattr);
         let (mode, inode, links) = Self::nix_infos(&m);
 
         let meta = Metadata {
@@ -251,9 +161,17 @@ impl LocalSourceSaveOptions {
 
 #[cfg(not(windows))]
 impl LocalSourceSaveOptions {
-    fn default_ctime(m: &std::fs::Metadata) -> Option<Timestamp> {
+    fn ctime(m: &std::fs::Metadata) -> Option<Timestamp> {
         #[allow(clippy::cast_possible_truncation)]
         Timestamp::new(m.ctime(), m.ctime_nsec() as i32).ok()
+    }
+
+    fn device_id(m: &std::fs::Metadata) -> u64 {
+        m.dev()
+    }
+
+    fn hardlink(m: &std::fs::Metadata) -> bool {
+        m.nlink() > 1 && !m.is_dir()
     }
 
     fn user_group(
@@ -271,6 +189,39 @@ impl LocalSourceSaveOptions {
         let inode = m.ino();
         let links = if m.is_dir() { 0 } else { m.nlink() };
         (Some(mode), inode, links)
+    }
+
+    /// List [`ExtendedAttribute`] for a [`Node`] located at `path`
+    ///
+    /// # Argument
+    ///
+    /// * `path` to the [`Node`] for which to list attributes
+    ///
+    /// # Errors
+    ///
+    /// * If Xattr couldn't be listed or couldn't be read
+    #[cfg(not(target_os = "openbsd"))]
+    fn xattrs(path: &Path) -> IgnoreResult<Vec<ExtendedAttribute>> {
+        xattr::list(path)
+            .map_err(|err| IgnoreErrorKind::ErrorXattr {
+                path: path.to_path_buf(),
+                source: err,
+            })?
+            .map(|name| {
+                Ok(ExtendedAttribute {
+                    name: name.to_string_lossy().to_string(),
+                    value: xattr::get(path, name).map_err(|err| IgnoreErrorKind::ErrorXattr {
+                        path: path.to_path_buf(),
+                        source: err,
+                    })?,
+                })
+            })
+            .collect::<IgnoreResult<Vec<ExtendedAttribute>>>()
+    }
+
+    #[cfg(target_os = "openbsd")]
+    fn xattrs(_path: &Path) -> IgnoreResult<Vec<ExtendedAttribute>> {
+        Ok(Vec::new())
     }
 
     fn to_node_other(self, name: &OsStr, m: &std::fs::Metadata, meta: Metadata) -> Node {
@@ -297,8 +248,14 @@ impl LocalSourceSaveOptions {
 
 #[cfg(windows)]
 impl LocalSourceSaveOptions {
-    fn default_ctime(m: &std::fs::Metadata) -> Option<Timestamp> {
+    fn ctime(m: &std::fs::Metadata) -> Option<Timestamp> {
         m.created().ok().and_then(|t| Timestamp::try_from(t).ok())
+    }
+    fn device_id(_m: &std::fs::Metadata) -> u64 {
+        0
+    }
+    fn hardlink(m: &std::fs::Metadata) -> bool {
+        false
     }
     fn user_group(
         _m: &std::fs::Metadata,
@@ -308,6 +265,10 @@ impl LocalSourceSaveOptions {
 
     fn nix_infos(_m: &std::fs::Metadata) -> (Option<u32>, u64, u64) {
         (None, 0, 0)
+    }
+
+    fn xattrs(_path: &Path) -> IgnoreResult<Vec<ExtendedAttribute>> {
+        Ok(Vec::new())
     }
 
     fn to_node_other(self, name: &OsStr, _m: &std::fs::Metadata, meta: Metadata) -> Node {

--- a/crates/core/src/backend/node.rs
+++ b/crates/core/src/backend/node.rs
@@ -1,3 +1,5 @@
+pub mod modification;
+
 use std::{
     cmp::Ordering,
     ffi::{OsStr, OsString},

--- a/crates/core/src/backend/node/modification.rs
+++ b/crates/core/src/backend/node/modification.rs
@@ -1,0 +1,167 @@
+use derive_setters::Setters;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::{backend::node::ExtendedAttribute, repofile::Node};
+
+/// Options how to treat times
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TimeOption {
+    /// Use the given time
+    Yes,
+    /// Use mtime
+    Mtime,
+    /// Use no time at all
+    No,
+}
+
+impl TimeOption {
+    /// Apply the `TimeOption`
+    pub fn map_or_else(
+        self,
+        default: impl FnOnce() -> Option<Timestamp>,
+        mtime: Option<Timestamp>,
+    ) -> Option<Timestamp> {
+        match self {
+            Self::Yes => default(),
+            Self::Mtime => mtime,
+            Self::No => None,
+        }
+    }
+}
+
+/// Options how to set devid
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DevIdOption {
+    /// Use the given devid
+    Yes,
+    /// Use the given devid if this is a hardlink, les not
+    #[default]
+    Hardlink,
+    /// Use no devid at all
+    No,
+}
+
+impl DevIdOption {
+    /// Apply the `DevIdOption`
+    pub fn map_or_else(self, dev_id: impl FnOnce() -> u64, hardlink: bool) -> u64 {
+        match self {
+            Self::Yes => dev_id(),
+            Self::Hardlink if hardlink => dev_id(),
+            _ => 0,
+        }
+    }
+}
+
+/// Options how block devices should be treated
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BlockdevOption {
+    /// As special file, i.e. don't read the data
+    #[default]
+    Special,
+    /// As normal file, i.e. read the data
+    File,
+}
+
+/// Options how to set extended attributes
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum XattrOption {
+    /// Use the given xattr
+    #[default]
+    Yes,
+    /// Use no xattrs at all
+    No,
+}
+
+impl XattrOption {
+    /// Apply the `XattrOption`
+    pub fn map_or_else(
+        self,
+        default: impl FnOnce() -> Vec<ExtendedAttribute>,
+    ) -> Vec<ExtendedAttribute> {
+        match self {
+            Self::Yes => default(),
+            Self::No => Vec::new(),
+        }
+    }
+}
+
+#[serde_as]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "merge", derive(conflate::Merge))]
+#[derive(Deserialize, Serialize, Default, Clone, Debug, PartialEq, Eq, Setters)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+#[setters(into)]
+#[non_exhaustive]
+#[allow(clippy::struct_field_names)]
+/// [`NodeModification`] describes how nodes will be modified
+pub struct NodeModification {
+    /// Set access time [default: mtime]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_atime: Option<TimeOption>,
+
+    /// Set changed time [default: yes]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_ctime: Option<TimeOption>,
+
+    /// Set device ID [default: hardlink]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_devid: Option<DevIdOption>,
+
+    /// Set extended attributes [default: yes]
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub set_xattrs: Option<XattrOption>,
+}
+
+impl NodeModification {
+    #[must_use]
+    /// Determines if no modification is in fact given
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+
+    #[must_use]
+    /// Modify the given node
+    ///
+    /// # Returns
+    /// true if the node was changed else false
+    pub fn modify_node(&self, node: &mut Node) -> bool {
+        let mut meta = node.meta.clone();
+
+        let mtime = meta.mtime;
+        meta.atime = self
+            .set_atime
+            .unwrap_or(TimeOption::Mtime)
+            .map_or_else(|| meta.atime, mtime);
+        meta.ctime = self
+            .set_ctime
+            .unwrap_or(TimeOption::Yes)
+            .map_or_else(|| meta.ctime, mtime);
+        meta.device_id = self
+            .set_devid
+            .unwrap_or_default()
+            .map_or_else(|| meta.device_id, meta.links > 1 && !node.is_dir());
+
+        meta.extended_attributes = self
+            .set_xattrs
+            .unwrap_or_default()
+            .map_or_else(|| meta.extended_attributes);
+
+        let changed = node.meta != meta;
+        node.meta = meta;
+        changed
+    }
+}

--- a/crates/core/src/commands/rewrite.rs
+++ b/crates/core/src/commands/rewrite.rs
@@ -1,34 +1,72 @@
 use std::path::PathBuf;
 
+use derive_setters::Setters;
+use serde::{Deserialize, Serialize};
+
 use crate::{
-    ErrorKind, Excludes, IndexedFull, Open, ProgressBars, Repository, RusticError, RusticResult,
-    blob::tree::{modify::ModifierChange, rewrite::Rewriter},
+    ErrorKind, IndexedFull, Open, ProgressBars, Repository, RusticError, RusticResult, StringList,
+    blob::tree::{
+        modify::ModifierChange,
+        rewrite::{RewriteTreesOptions, Rewriter},
+    },
     repofile::{SnapshotFile, SnapshotModification},
     repository::IndexedTree,
 };
 
-pub(crate) fn rewrite_snapshots_with_excludes<P: ProgressBars, S: IndexedFull>(
+/// Options for rewrite
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "merge", derive(conflate::Merge))]
+#[derive(Clone, Debug, Default, Setters, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+#[setters(into)]
+#[non_exhaustive]
+pub struct RewriteOptions {
+    /// remove original snapshots
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::bool::overwrite_false))]
+    pub forget: bool,
+
+    /// Tags to add to rewritten snapshots [default: "rewrite" if original snapshots are not removed]
+    #[cfg_attr(feature = "clap", clap(long, value_name = "TAG[,TAG,..]"))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub tags_rewritten: Option<StringList>,
+
+    /// Snapshot modifications
+    #[cfg_attr(feature = "clap", clap(flatten))]
+    pub modification: SnapshotModification,
+
+    /// Dry-run: Don't save any modification
+    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::bool::overwrite_false))]
+    pub dry_run: bool,
+}
+
+pub(crate) fn rewrite_snapshots_and_trees<P: ProgressBars, S: IndexedFull>(
     repo: &Repository<P, S>,
     snapshots: Vec<SnapshotFile>,
-    modification: &SnapshotModification,
-    excludes: &Excludes,
-    dry_run: bool,
-    delete: bool,
+    opts: &RewriteOptions,
+    tree_opts: &RewriteTreesOptions,
 ) -> RusticResult<Vec<SnapshotFile>> {
     let config_file = repo.config();
-    if delete && config_file.append_only == Some(true) {
+    if opts.forget && config_file.append_only == Some(true) {
         return Err(RusticError::new(
             ErrorKind::AppendOnly,
             "Removing snapshots is not allowed in append-only repositories. Please disable append-only mode first, if you know what you are doing. Aborting.",
         ));
     }
-    let mut rewriter = Rewriter::new(repo.dbe(), repo.index(), repo.config(), dry_run, excludes)?;
+    let mut rewriter = Rewriter::new(
+        repo.dbe(),
+        repo.index(),
+        repo.config(),
+        tree_opts,
+        opts.dry_run,
+    )?;
 
     let snapshots: Vec<_> = snapshots
         .into_iter()
         .map(|mut sn| {
             #[allow(clippy::useless_let_if_seq)] // false positive lint
-            let mut changed = sn.modify(modification)?;
+            let mut changed = sn.modify(&opts.modification)?;
 
             if let ModifierChange::Changed(new_tree) =
                 rewriter.rewrite_tree(PathBuf::new(), sn.tree)?
@@ -53,18 +91,16 @@ pub(crate) fn rewrite_snapshots_with_excludes<P: ProgressBars, S: IndexedFull>(
 
     rewriter.finalize()?;
 
-    process_snapshots(repo, snapshots, dry_run, delete)
+    process_snapshots(repo, snapshots, opts)
 }
 
 pub(crate) fn rewrite_snapshots<P: ProgressBars, S: Open>(
     repo: &Repository<P, S>,
     snapshots: Vec<SnapshotFile>,
-    modification: &SnapshotModification,
-    dry_run: bool,
-    delete: bool,
+    opts: &RewriteOptions,
 ) -> RusticResult<Vec<SnapshotFile>> {
     let config_file = repo.config();
-    if delete && config_file.append_only == Some(true) {
+    if opts.forget && config_file.append_only == Some(true) {
         return Err(RusticError::new(
             ErrorKind::AppendOnly,
             "Removing snapshots is not allowed in append-only repositories. Please disable append-only mode first, if you know what you are doing. Aborting.",
@@ -72,22 +108,31 @@ pub(crate) fn rewrite_snapshots<P: ProgressBars, S: Open>(
     }
     let snapshots: Vec<_> = snapshots
         .into_iter()
-        .map(|mut sn| Ok(sn.modify(modification)?.then_some(sn)))
+        .map(|mut sn| Ok(sn.modify(&opts.modification)?.then_some(sn)))
         .filter_map(Result::transpose)
         .collect::<RusticResult<_>>()?;
 
-    process_snapshots(repo, snapshots, dry_run, delete)
+    process_snapshots(repo, snapshots, opts)
 }
 
 fn process_snapshots<P: ProgressBars, S: Open>(
     repo: &Repository<P, S>,
-    snapshots: Vec<SnapshotFile>,
-    dry_run: bool,
-    delete: bool,
+    mut snapshots: Vec<SnapshotFile>,
+    opts: &RewriteOptions,
 ) -> RusticResult<Vec<SnapshotFile>> {
-    if !snapshots.is_empty() && !dry_run {
+    if !snapshots.is_empty() && !opts.dry_run {
+        match (&opts.tags_rewritten, opts.forget) {
+            (Some(tags), _) => snapshots
+                .iter_mut()
+                .for_each(|sn| _ = sn.add_tags(vec![tags.clone()])),
+            (None, false) => snapshots
+                .iter_mut()
+                .for_each(|sn| sn.tags.add("rewrite".to_string())),
+            (None, true) => {}
+        }
+
         repo.save_snapshots(snapshots.clone())?;
-        if delete {
+        if opts.forget {
             let old_snap_ids: Vec<_> = snapshots.iter().map(|sn| sn.id).collect();
             repo.delete_snapshots(&old_snap_ids)?;
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -128,12 +128,18 @@ pub use crate::{
         decrypt::{compression_level_range, max_compression_level},
         ignore::{LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions},
         local_destination::LocalDestination,
-        node::last_modified_node,
+        node::{
+            last_modified_node,
+            modification::{
+                BlockdevOption, DevIdOption, NodeModification, TimeOption, XattrOption,
+            },
+        },
     },
     blob::{
         BlobId, DataId, PackedId,
         tree::{
             FindMatches, FindNode, TreeId, TreeStreamerOptions as LsOptions, excludes::Excludes,
+            rewrite::RewriteTreesOptions,
         },
     },
     commands::{
@@ -147,6 +153,7 @@ pub use crate::{
         repair::{index::RepairIndexOptions, snapshots::RepairSnapshotsOptions},
         repoinfo::{BlobInfo, IndexInfos, PackInfo, RepoFileInfo, RepoFileInfos},
         restore::{FileDirStats, RestoreOptions, RestorePlan, RestoreStats},
+        rewrite::RewriteOptions,
     },
     error::{ErrorKind, RusticError, RusticResult, Severity, Status},
     id::{HexId, Id},

--- a/crates/core/src/repofile/snapshotfile/modification.rs
+++ b/crates/core/src/repofile/snapshotfile/modification.rs
@@ -15,7 +15,7 @@ use crate::{
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 #[cfg_attr(feature = "merge", derive(conflate::Merge))]
 #[serde_as]
-#[derive(Debug, Default, Setters, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Setters, Serialize, Deserialize)]
 #[setters(into)]
 #[non_exhaustive]
 pub struct SnapshotModification {

--- a/crates/core/tests/integration/rewrite.rs
+++ b/crates/core/tests/integration/rewrite.rs
@@ -7,7 +7,8 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 
 use rustic_core::{
-    BackupOptions, Excludes, LsOptions, RusticResult, StringList,
+    BackupOptions, Excludes, LsOptions, NodeModification, RewriteOptions, RewriteTreesOptions,
+    RusticResult, StringList,
     repofile::{Metadata, Node, SnapshotFile, SnapshotModification},
 };
 
@@ -17,7 +18,7 @@ use super::{
 };
 
 #[rstest]
-fn test_backup_with_tar_gz_passes(
+fn test_rewrite(
     tar_gz_testdata: Result<TestSource>,
     set_up_repo: Result<RepoOpen>,
     insta_snapshotfile_redaction: Settings,
@@ -32,10 +33,10 @@ fn test_backup_with_tar_gz_passes(
     let paths = &source.path_list();
 
     // we use as_path to not depend on the actual tempdir
-    let opts = BackupOptions::default().as_path(PathBuf::from_str("test")?);
+    let backup_opts = BackupOptions::default().as_path(PathBuf::from_str("test")?);
 
     // first backup
-    let snapshot = repo.backup(&opts, paths, SnapshotFile::default())?;
+    let snapshot = repo.backup(&backup_opts, paths, SnapshotFile::default())?;
 
     let modification = SnapshotModification::default()
         .set_label("label".to_string())
@@ -44,7 +45,10 @@ fn test_backup_with_tar_gz_passes(
         .add_tags(vec!["tag1,tag2".parse::<StringList>()?])
         .set_description("description".to_string())
         .set_delete_never(true);
-    let rewrite_snaps = repo.rewrite_snapshots(vec![snapshot], &modification, false, true)?;
+    let mut rewrite_opts = RewriteOptions::default()
+        .modification(modification)
+        .forget(true);
+    let rewrite_snaps = repo.rewrite_snapshots(vec![snapshot], &rewrite_opts)?;
     insta_snapshotfile_redaction.bind(|| {
         assert_with_win("rewrite-snapshots-first", &rewrite_snaps);
     });
@@ -54,28 +58,23 @@ fn test_backup_with_tar_gz_passes(
 
     let repo = repo.to_indexed()?;
 
-    let excludes = Excludes::default().globs(vec!["!/test/0/0/9/6*".to_string()]);
+    let rewrite_tree_params = RewriteTreesOptions::default()
+        .excludes(Excludes::default().globs(vec!["!/test/0/0/9/6*".to_string()]))
+        .node_modification(NodeModification::default());
+
     // with dry_run
-    let rewrite_snaps_dryrun = repo.rewrite_snapshots_with_excludes(
-        snaps.clone(),
-        &SnapshotModification::default(),
-        &excludes,
-        true,
-        true,
-    )?;
+    rewrite_opts.dry_run = true;
+    let rewrite_snaps_dryrun =
+        repo.rewrite_snapshots_and_trees(snaps.clone(), &rewrite_opts, &rewrite_tree_params)?;
     insta_snapshotfile_redaction.bind(|| {
         assert_with_win("rewrite-snapshots-second", &rewrite_snaps_dryrun);
     });
     let snaps_after_dryrun = repo.get_all_snapshots()?;
     assert_eq!(rewrite_snaps_dryrun, snaps_after_dryrun);
 
-    let rewrite_snaps = repo.rewrite_snapshots_with_excludes(
-        snaps,
-        &SnapshotModification::default(),
-        &excludes,
-        false,
-        true,
-    )?;
+    rewrite_opts.dry_run = false;
+    let rewrite_snaps =
+        repo.rewrite_snapshots_and_trees(snaps, &rewrite_opts, &rewrite_tree_params)?;
     assert_eq!(rewrite_snaps_dryrun, rewrite_snaps);
     assert_eq!(rewrite_snaps.len(), 1);
 
@@ -103,11 +102,13 @@ fn test_backup_with_tar_gz_passes(
 
     // backup with excludes
     let glob = "!".to_string() + source.path().to_str().unwrap() + "/0/0/9/6*"; // other exclude as we use as-path
+
     // #[cfg(windows)]
     let glob = glob.replace('\\', "/"); // correct windows paths for glob
+
     let excludes = Excludes::default().globs(vec![glob]);
-    let opts = opts.excludes(excludes);
-    let snapshot = repo.backup(&opts, paths, SnapshotFile::default())?;
+    let backup_opts = backup_opts.excludes(excludes);
+    let snapshot = repo.backup(&backup_opts, paths, SnapshotFile::default())?;
     // trees should be identical
     assert_eq!(snapshot.tree, rewrite_snaps[0].tree);
 


### PR DESCRIPTION
Adds more features to `rewrite`
- allow to tag modified snapshots
- allow to modify nodes (atime,ctime,devid,xattrs)
- rebuild all trees (also with serialization changes)

This is breaking as the methods in `Repository` have changed.