### PR TITLE
feat!: Add masterkey as credential option

### DIFF
--- a/crates/core/src/commands/init.rs
+++ b/crates/core/src/commands/init.rs
@@ -13,7 +13,7 @@ use crate::{
     error::RusticResult,
     id::Id,
     repofile::{ConfigFile, KeyId, configfile::RepositoryId},
-    repository::Repository,
+    repository::{Repository, credentials::Credentials},
 };
 
 /// Initialize a new repository.
@@ -26,7 +26,7 @@ use crate::{
 /// # Arguments
 ///
 /// * `repo` - The repository to initialize.
-/// * `pass` - The password to encrypt the key with.
+/// * `credentials` - The credentials to use.
 /// * `key_opts` - The options to create the key with.
 /// * `config_opts` - The options to create the config with.
 ///
@@ -39,22 +39,22 @@ use crate::{
 /// A tuple of the key and the config file.
 pub(crate) fn init<P, S>(
     repo: &Repository<P, S>,
-    pass: &str,
+    credentials: &Credentials,
     key_opts: &KeyOptions,
     config_opts: &ConfigOptions,
-) -> RusticResult<(Key, KeyId, ConfigFile)> {
+) -> RusticResult<(Key, Option<KeyId>, ConfigFile)> {
     // Create config first to allow catching errors from here without writing anything
     let repo_id = RepositoryId::from(Id::random());
     let chunker_poly = random_poly()?;
     let mut config = ConfigFile::new(2, repo_id, chunker_poly);
     if repo.be_hot.is_some() {
-        // for hot/cold repository, `config` must be identical to thee config file which is read by the backend, i.e. the one saved in the hot repo.
+        // for hot/cold repository, `config` must be identical to the config file which is read by the backend, i.e. the one saved in the hot repo.
         // Note: init_with_config does handle the is_hot config correctly for the hot and the cold repo.
         config.is_hot = Some(true);
     }
     config_opts.apply(&mut config)?;
 
-    let (key, key_id) = init_with_config(repo, pass, key_opts, &config)?;
+    let (key, key_id) = init_with_config(repo, credentials, key_opts, &config)?;
     info!("repository {repo_id} successfully created.");
 
     Ok((key, key_id, config))
@@ -79,13 +79,19 @@ pub(crate) fn init<P, S>(
 /// The key used to encrypt the config.
 pub(crate) fn init_with_config<P, S>(
     repo: &Repository<P, S>,
-    pass: &str,
+    credentials: &Credentials,
     key_opts: &KeyOptions,
     config: &ConfigFile,
-) -> RusticResult<(Key, KeyId)> {
+) -> RusticResult<(Key, Option<KeyId>)> {
     repo.be.create()?;
-    let (key, id) = init_key(repo, key_opts, pass)?;
-    info!("key {id} successfully added.");
+    let (key, id) = match credentials {
+        Credentials::Password(password) => {
+            let (key, id) = init_key(repo, key_opts, password)?;
+            info!("key {id} successfully added.");
+            (key, Some(id))
+        }
+        Credentials::Masterkey(key) => (key.key(), None),
+    };
     save_config(repo, config.clone(), key)?;
 
     Ok((key, id))

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -132,8 +132,8 @@ pub enum ErrorKind {
     /// general operations
     #[default]
     Other,
-    /// password handling
-    Password,
+    /// credentials handling
+    Credentials,
     /// the repository
     Repository,
     /// unsupported operations

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,15 +25,16 @@ implement [`serde::Serialize`] and [`serde::Deserialize`].
 
 ```rust
     use rustic_backend::BackendOptions;
-    use rustic_core::{BackupOptions, ConfigOptions, KeyOptions, PathList,
-        Repository, RepositoryOptions, SnapshotOptions
+    use rustic_core::{repofile::MasterKey, BackupOptions, ConfigOptions, Credentials,
+        KeyOptions, PathList, Repository, RepositoryOptions, SnapshotOptions,
     };
 
     // Initialize the repository in a temporary dir
     let repo_dir = tempfile::tempdir().unwrap();
 
-    let repo_opts = RepositoryOptions::default()
-        .password("test");
+    let repo_opts = RepositoryOptions::default();
+     // In real life, make sure to save this credential!
+    let credentials = Credentials::Masterkey(MasterKey::new());
 
     // Initialize Backends
     let backends = BackendOptions::default()
@@ -45,10 +46,13 @@ implement [`serde::Serialize`] and [`serde::Deserialize`].
 
     let config_opts = ConfigOptions::default();
 
-    let _repo = Repository::new(&repo_opts, &backends.clone()).unwrap().init(&key_opts, &config_opts).unwrap();
+    let _repo = Repository::new(&repo_opts, &backends)
+        .unwrap()
+        .init(&credentials, &key_opts, &config_opts)
+        .unwrap();
 
     // We could have used _repo directly, but open the repository again to show how to open it...
-    let repo = Repository::new(&repo_opts, &backends).unwrap().open().unwrap();
+    let repo = Repository::new(&repo_opts, &backends).unwrap().open(&credentials).unwrap();
 
     // Get all snapshots from the repository
     let snaps = repo.get_all_snapshots().unwrap();
@@ -165,5 +169,6 @@ pub use crate::{
         FullIndex, IdIndex, IndexedFull, IndexedIds, IndexedStatus, IndexedTree, Open, OpenStatus,
         Repository, RepositoryOptions,
         command_input::{CommandInput, CommandInputErrorKind},
+        credentials::{CredentialOptions, Credentials},
     },
 };

--- a/crates/core/src/repofile.rs
+++ b/crates/core/src/repofile.rs
@@ -160,7 +160,7 @@ pub use {
     },
     configfile::{Chunker, ConfigFile},
     indexfile::{IndexBlob, IndexFile, IndexId, IndexPack},
-    keyfile::{KeyFile, KeyId},
+    keyfile::{KeyFile, KeyId, MasterKey},
     packfile::{HeaderEntry, PackHeader, PackHeaderLength, PackHeaderRef, PackId},
     snapshotfile::{
         DeleteOption, PathList, SnapshotFile, SnapshotId, SnapshotModification, SnapshotSummary,

--- a/crates/core/src/repository/credentials.rs
+++ b/crates/core/src/repository/credentials.rs
@@ -1,0 +1,214 @@
+use std::fs::File;
+use std::io::BufRead;
+use std::{io::BufReader, path::Path, path::PathBuf};
+
+use derive_setters::Setters;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+#[cfg(feature = "clap")]
+use clap::ValueHint;
+
+use crate::{CommandInput, ErrorKind, RusticError, RusticResult, repofile::MasterKey};
+
+#[derive(Debug, Clone)]
+/// Credential to open a repository
+pub enum Credentials {
+    /// credentials are given directly by specifying the masterkey
+    Masterkey(MasterKey),
+    /// credentials are given by a password
+    Password(String),
+}
+
+impl Credentials {
+    /// Convenience constructor for password
+    pub fn password(pass: impl AsRef<str>) -> Self {
+        Self::Password(pass.as_ref().to_string())
+    }
+}
+
+/// Options for using and opening a [`Repository`]
+#[serde_as]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "merge", derive(conflate::Merge))]
+#[derive(Clone, Default, Debug, Deserialize, Serialize, Setters)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+#[setters(into, strip_option)]
+#[non_exhaustive]
+pub struct CredentialOptions {
+    /// masterkey to use
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, global = true, env = "RUSTIC_KEY", hide_env_values = true)
+    )]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub key: Option<String>,
+
+    /// File to read the masterkey from
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            long,
+            global = true,
+            env = "RUSTIC_KEY_FILE",
+            conflicts_with_all = &["password", "password_file", "password_command"],
+            value_hint = ValueHint::FilePath,
+        )
+    )]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub key_file: Option<PathBuf>,
+
+    /// Command to read the masterkey from. Key is read from stdout
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            long,
+            global = true,
+            env = "RUSTIC_KEY_COMMAND",
+            conflicts_with_all = &["password", "password_file", "password_command"],
+            value_hint = ValueHint::FilePath,
+        )
+    )]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub key_command: Option<CommandInput>,
+
+    /// Password for the repository
+    ///
+    /// # Warning
+    ///
+    /// * Using --password can reveal the password in the process list!
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, global = true, env = "RUSTIC_PASSWORD", hide_env_values = true)
+    )]
+    // TODO: Security related: use `secrecy` library (#663)
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub password: Option<String>,
+
+    /// File to read the password from
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            short,
+            long,
+            global = true,
+            env = "RUSTIC_PASSWORD_FILE",
+            conflicts_with = "password",
+            value_hint = ValueHint::FilePath,
+        )
+    )]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub password_file: Option<PathBuf>,
+
+    /// Command to read the password from. Password is read from stdout
+    #[cfg_attr(feature = "clap", clap(
+        long,
+        global = true,
+        env = "RUSTIC_PASSWORD_COMMAND",
+        conflicts_with_all = &["password", "password_file"],
+    ))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub password_command: Option<CommandInput>,
+}
+
+impl CredentialOptions {
+    /// Evaluates the credentials given by the repository options
+    ///
+    /// # Errors
+    ///
+    /// * If opening the key or password file failed
+    /// * If reading the key or password failed
+    /// * If splitting the key or password command failed
+    /// * If executing the key or password command failed
+    /// * If reading the key or password from the command failed
+    ///
+    /// # Returns
+    ///
+    /// The credentials or `None`
+    pub fn credentials(&self) -> RusticResult<Option<Credentials>> {
+        // helpers
+        fn get_key(key: impl AsRef<[u8]>) -> RusticResult<MasterKey> {
+            let key = key.as_ref();
+            serde_json::from_slice(key).map_err(|err| {
+                RusticError::with_source(ErrorKind::Credentials, "Error deserializing key", err)
+            })
+        }
+        let read_password_file = |file: &Path| {
+            let mut file = BufReader::new(File::open(file).map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Credentials,
+                    "Opening password file failed. Is the path `{path}` correct?",
+                    err,
+                )
+                .attach_context("path", file.display().to_string())
+            })?);
+
+            read_password_from_reader(&mut file)
+        };
+        let read_key_file = |file: &Path| {
+            std::fs::read_to_string(file).map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Credentials,
+                    "Opening key file failed. Is the path `{path}` correct?",
+                    err,
+                )
+                .attach_context("path", file.display().to_string())
+            })
+        };
+        let pass_from_command = |command: &CommandInput| {
+            let output = command.stdout()?;
+            let mut pwd = BufReader::new(&*output);
+            read_password_from_reader(&mut pwd)
+        };
+
+        let credentials = if let Some(key) = &self.key {
+            Some(Credentials::Masterkey(get_key(key)?))
+        } else if let Some(file) = &self.key_file {
+            Some(Credentials::Masterkey(get_key(&read_key_file(file)?)?))
+        } else if let Some(command) = &self.key_command {
+            Some(Credentials::Masterkey(get_key(command.stdout()?)?))
+        } else if let Some(pwd) = &self.password {
+            Some(Credentials::Password(pwd.clone()))
+        } else if let Some(file) = &self.password_file {
+            Some(Credentials::Password(read_password_file(file)?))
+        } else if let Some(command) = &self.password_command {
+            Some(Credentials::Password(pass_from_command(command)?))
+        } else {
+            None
+        };
+        Ok(credentials)
+    }
+}
+
+/// Read a password from a reader
+///
+/// # Arguments
+///
+/// * `file` - The reader to read the password from
+///
+/// # Errors
+///
+/// * If reading the password failed
+pub fn read_password_from_reader(file: &mut impl BufRead) -> RusticResult<String> {
+    let mut password = String::new();
+    _ = file.read_line(&mut password).map_err(|err| {
+        RusticError::with_source(
+            ErrorKind::Credentials,
+            "Reading password from reader failed. Is the file empty? Please check the file and the password.",
+            err
+        )
+        .attach_context("password", password.clone())
+    })?;
+
+    // Remove the \n from the line if present
+    if password.ends_with('\n') {
+        _ = password.pop();
+    }
+
+    // Remove the \r from the line if present
+    if password.ends_with('\r') {
+        _ = password.pop();
+    }
+
+    Ok(password)
+}

--- a/crates/core/tests/integration/check.rs
+++ b/crates/core/tests/integration/check.rs
@@ -8,7 +8,7 @@ use tar::Archive;
 use tempfile::tempdir;
 
 use rustic_backend::LocalBackend;
-use rustic_core::{CheckOptions, Repository, RepositoryBackends, RepositoryOptions};
+use rustic_core::{CheckOptions, Credentials, Repository, RepositoryBackends, RepositoryOptions};
 
 #[rstest]
 #[case("repo-data-missing.tar.gz")]
@@ -30,8 +30,8 @@ fn test_check(#[case] repo_file: String) -> Result<()> {
 
     let be = LocalBackend::new(dir.path().join("repo").to_str().unwrap(), None)?;
     let be = RepositoryBackends::new(Arc::new(be), None);
-    let options = RepositoryOptions::default().password("geheim");
-    let repo = Repository::new(&options, &be)?.open()?;
+    let options = RepositoryOptions::default();
+    let repo = Repository::new(&options, &be)?.open(&Credentials::password("geheim"))?;
 
     let opts = CheckOptions::default().read_data(true);
     let check_results = repo.check(opts)?;

--- a/examples/backup/examples/backup.rs
+++ b/examples/backup/examples/backup.rs
@@ -1,6 +1,8 @@
 //! `backup` example
 use rustic_backend::BackendOptions;
-use rustic_core::{BackupOptions, PathList, Repository, RepositoryOptions, SnapshotOptions};
+use rustic_core::{
+    BackupOptions, Credentials, PathList, Repository, RepositoryOptions, SnapshotOptions,
+};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -15,10 +17,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-
+    let repo_opts = RepositoryOptions::default();
+    let credentials = Credentials::password("test");
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&credentials)?
         .to_indexed_ids()?;
 
     let backup_opts = BackupOptions::default();

--- a/examples/check/examples/check.rs
+++ b/examples/check/examples/check.rs
@@ -1,6 +1,6 @@
 //! `check` example
 use rustic_backend::BackendOptions;
-use rustic_core::{CheckOptions, Repository, RepositoryOptions};
+use rustic_core::{CheckOptions, Credentials, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,8 +14,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-    let repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let repo_opts = RepositoryOptions::default();
+    let credentials = Credentials::password("test");
+    let repo = Repository::new(&repo_opts, &backends)?.open(&credentials)?;
 
     // Check repository with standard options but omitting cache checks
     let opts = CheckOptions::default().trust_cache(true);

--- a/examples/config/examples/config.rs
+++ b/examples/config/examples/config.rs
@@ -1,6 +1,8 @@
 //! `config` example
 use rustic_backend::BackendOptions;
-use rustic_core::{max_compression_level, ConfigOptions, Repository, RepositoryOptions};
+use rustic_core::{
+    max_compression_level, ConfigOptions, Credentials, Repository, RepositoryOptions,
+};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,8 +16,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-    let mut repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let repo_opts = RepositoryOptions::default();
+    let mut repo = Repository::new(&repo_opts, &backends)?.open(&Credentials::password("test"))?;
 
     // Set Config, e.g. Compression level
     let config_opts = ConfigOptions::default().set_compression(max_compression_level());

--- a/examples/copy/examples/copy.rs
+++ b/examples/copy/examples/copy.rs
@@ -1,6 +1,6 @@
 //! `copy` example
 use rustic_backend::BackendOptions;
-use rustic_core::{CopySnapshot, Repository, RepositoryOptions};
+use rustic_core::{CopySnapshot, Credentials, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,10 +14,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let src_repo_opts = RepositoryOptions::default().password("test");
+    let src_repo_opts = RepositoryOptions::default();
+    let credentials = Credentials::password("test");
 
     let src_repo = Repository::new(&src_repo_opts, &src_backends)?
-        .open()?
+        .open(&credentials)?
         .to_indexed()?;
 
     // Initialize dst backends
@@ -25,10 +26,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .repository("/tmp/repo")
         .to_backends()?;
 
-    let dst_repo_opts = RepositoryOptions::default().password("test");
+    let dst_repo_opts = RepositoryOptions::default();
 
     let dst_repo = Repository::new(&dst_repo_opts, &dst_backends)?
-        .open()?
+        .open(&credentials)?
         .to_indexed_ids()?;
 
     // get snapshots which are missing in dst_repo

--- a/examples/find/examples/find.rs
+++ b/examples/find/examples/find.rs
@@ -1,7 +1,7 @@
-//! `ls` example
+//! `find` example
 use globset::Glob;
 use rustic_backend::BackendOptions;
-use rustic_core::{FindMatches, Repository, RepositoryOptions};
+use rustic_core::{Credentials, FindMatches, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -15,10 +15,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
 
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&Credentials::password("test"))?
         .to_indexed()?;
 
     let mut snapshots = repo.get_all_snapshots()?;

--- a/examples/forget/examples/forget.rs
+++ b/examples/forget/examples/forget.rs
@@ -1,6 +1,8 @@
 //! `forget` example
 use rustic_backend::BackendOptions;
-use rustic_core::{KeepOptions, Repository, RepositoryOptions, SnapshotGroupCriterion};
+use rustic_core::{
+    Credentials, KeepOptions, Repository, RepositoryOptions, SnapshotGroupCriterion,
+};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,9 +16,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
 
-    let repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let repo = Repository::new(&repo_opts, &backends)?.open(&Credentials::password("test"))?;
 
     // Check repository with standard options
     let group_by = SnapshotGroupCriterion::default();

--- a/examples/init/examples/init.rs
+++ b/examples/init/examples/init.rs
@@ -1,6 +1,8 @@
 //! `init` example
 use rustic_backend::BackendOptions;
-use rustic_core::{ConfigOptions, KeyOptions, Repository, RepositoryOptions};
+use rustic_core::{
+    repofile::MasterKey, ConfigOptions, Credentials, KeyOptions, Repository, RepositoryOptions,
+};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,10 +16,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Init repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
     let key_opts = KeyOptions::default();
     let config_opts = ConfigOptions::default();
-    let _repo = Repository::new(&repo_opts, &backends)?.init(&key_opts, &config_opts)?;
+    let _repo = Repository::new(&repo_opts, &backends)?.init(
+        &Credentials::Masterkey(MasterKey::new()), // in real life, make sure you save this masterkey after generating it!
+        &key_opts,
+        &config_opts,
+    )?;
 
     // -> use _repo for any operation on an open repository
     Ok(())

--- a/examples/key/examples/key.rs
+++ b/examples/key/examples/key.rs
@@ -1,6 +1,6 @@
 //! `key` example
 use rustic_backend::BackendOptions;
-use rustic_core::{KeyOptions, Repository, RepositoryOptions};
+use rustic_core::{Credentials, KeyOptions, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,9 +14,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-
-    let repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let repo_opts = RepositoryOptions::default();
+    let repo = Repository::new(&repo_opts, &backends)?.open(&Credentials::password("test"))?;
 
     // Add a new key with the given password
     let key_opts = KeyOptions::default();

--- a/examples/ls/examples/ls.rs
+++ b/examples/ls/examples/ls.rs
@@ -1,6 +1,6 @@
 //! `ls` example
 use rustic_backend::BackendOptions;
-use rustic_core::{LsOptions, Repository, RepositoryOptions};
+use rustic_core::{Credentials, LsOptions, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,10 +14,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
 
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&Credentials::password("test"))?
         .to_indexed()?;
 
     // use latest snapshot without filtering snapshots

--- a/examples/merge/examples/merge.rs
+++ b/examples/merge/examples/merge.rs
@@ -1,6 +1,8 @@
 //! `merge` example
 use rustic_backend::BackendOptions;
-use rustic_core::{last_modified_node, repofile::SnapshotFile, Repository, RepositoryOptions};
+use rustic_core::{
+    last_modified_node, repofile::SnapshotFile, Credentials, Repository, RepositoryOptions,
+};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,10 +16,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
 
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&Credentials::password("test"))?
         .to_indexed_ids()?;
 
     // Merge all snapshots using the latest entry for duplicate entries

--- a/examples/prune/examples/prune.rs
+++ b/examples/prune/examples/prune.rs
@@ -1,6 +1,6 @@
 //! `prune` example
 use rustic_backend::BackendOptions;
-use rustic_core::{PruneOptions, Repository, RepositoryOptions};
+use rustic_core::{Credentials, PruneOptions, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,9 +14,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
 
-    let repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let repo = Repository::new(&repo_opts, &backends)?.open(&Credentials::password("test"))?;
 
     let prune_opts = PruneOptions::default();
     let prune_plan = repo.prune_plan(&prune_opts)?;

--- a/examples/restore/examples/restore.rs
+++ b/examples/restore/examples/restore.rs
@@ -1,6 +1,8 @@
 //! `restore` example
 use rustic_backend::BackendOptions;
-use rustic_core::{LocalDestination, LsOptions, Repository, RepositoryOptions, RestoreOptions};
+use rustic_core::{
+    Credentials, LocalDestination, LsOptions, Repository, RepositoryOptions, RestoreOptions,
+};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -14,9 +16,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let repo_opts = RepositoryOptions::default();
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&Credentials::password("test"))?
         .to_indexed()?;
 
     // use latest snapshot without filtering snapshots

--- a/examples/tag/examples/tag.rs
+++ b/examples/tag/examples/tag.rs
@@ -1,6 +1,6 @@
 //! `tag` example
 use rustic_backend::BackendOptions;
-use rustic_core::{Repository, RepositoryOptions, StringList};
+use rustic_core::{Credentials, Repository, RepositoryOptions, StringList};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 use std::str::FromStr;
@@ -15,8 +15,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-    let repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let repo_opts = RepositoryOptions::default();
+    let repo = Repository::new(&repo_opts, &backends)?.open(&Credentials::password("test"))?;
 
     // Set tag "test" to all snapshots, filtering out unchanged (i.e. tag was already preset) snapshots
     let snaps = repo.get_all_snapshots()?;


### PR DESCRIPTION
Adds the possibility to use a master key directly as credential to open/initialize a repository.

Using the masterkey has the following advantages:
- no need anymore to save the masterkey (encrypted) in the repository. This increases security as it eliminates possible master key leaks due to insecure passwords or a vulnerability in the `scrypt` algorithm.
- by not using the `scrypt` algorithm, opening a repository is much faster and needs much less resources (CPU/Memory) making this option interesting for some use cases. 

Advantages of the still supported password credential are the possibility to backup the masterkey in the repository - and of course allowing to access the repo using a noticeable password.

Note that this change allows to use repositories with only the masterkey, but additionally allows to access a "normal" repository with keyfiles with either a password or the masterky.

As a side effect, most integration tests are now much faster as most now use the masterkey.

This is a breaking change as it changes `Repository` methods.