### PR TITLE
refactor!: Simplify Progress

### DIFF
--- a/crates/core/src/archiver.rs
+++ b/crates/core/src/archiver.rs
@@ -130,7 +130,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
         as_path: Option<&PathBuf>,
         skip_identical_parent: bool,
         no_scan: bool,
-        p: &impl Progress,
+        p: &Progress,
     ) -> RusticResult<SnapshotFile>
     where
         R: ReadSource + 'static,

--- a/crates/core/src/archiver/file_archiver.rs
+++ b/crates/core/src/archiver/file_archiver.rs
@@ -94,7 +94,7 @@ impl<'a, BE: DecryptWriteBackend, I: ReadGlobalIndex> FileArchiver<'a, BE, I> {
     pub(crate) fn process<O: ReadSourceOpen>(
         &self,
         item: ItemWithParent<Option<O>>,
-        p: &impl Progress,
+        p: &Progress,
     ) -> RusticResult<TreeItem> {
         Ok(match item {
             TreeType::NewTree(item) => TreeType::NewTree(item),
@@ -139,7 +139,7 @@ impl<'a, BE: DecryptWriteBackend, I: ReadGlobalIndex> FileArchiver<'a, BE, I> {
         &self,
         r: impl Read + Send + 'static,
         node: Node,
-        p: &impl Progress,
+        p: &Progress,
     ) -> RusticResult<(Node, u64)> {
         let chunks: Vec<_> = ChunkIter::from_config(
             &self.config,

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -160,7 +160,7 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     /// # Errors
     ///
     /// If the files could not be read.
-    fn stream_all<F: RepoFile>(&self, p: &impl Progress) -> StreamResult<F::Id, F> {
+    fn stream_all<F: RepoFile>(&self, p: &Progress) -> StreamResult<F::Id, F> {
         let list = self.list(F::TYPE)?;
         let list: Vec<_> = list.into_iter().map(F::Id::from).collect();
         self.stream_list(&list, p)
@@ -178,11 +178,7 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     /// # Errors
     ///
     /// If the files could not be read.
-    fn stream_list<F: RepoFile>(
-        &self,
-        list: &[F::Id],
-        p: &impl Progress,
-    ) -> StreamResult<F::Id, F> {
+    fn stream_list<F: RepoFile>(&self, list: &[F::Id], p: &Progress) -> StreamResult<F::Id, F> {
         p.set_length(list.len() as u64);
         let (tx, rx) = unbounded();
 
@@ -319,7 +315,7 @@ pub trait DecryptWriteBackend: WriteBackend + Clone + 'static {
     fn save_list<'a, F: RepoFile, I: ExactSizeIterator<Item = &'a F> + Send>(
         &self,
         list: I,
-        p: impl Progress,
+        p: Progress,
     ) -> RusticResult<()> {
         p.set_length(list.len() as u64);
         list.par_bridge().try_for_each(|file| -> RusticResult<_> {
@@ -343,7 +339,7 @@ pub trait DecryptWriteBackend: WriteBackend + Clone + 'static {
         &self,
         cacheable: bool,
         list: I,
-        p: impl Progress,
+        p: Progress,
     ) -> RusticResult<()> {
         p.set_length(list.len() as u64);
         list.par_bridge().try_for_each(|id| -> RusticResult<_> {

--- a/crates/core/src/blob/packer.rs
+++ b/crates/core/src/blob/packer.rs
@@ -917,7 +917,7 @@ impl<BE: DecryptFullBackend> BlobCopier<BE> {
     ///
     /// * If the blob could not be added
     /// * If reading the blob from the backend fails
-    pub fn copy_fast(&self, pack_blobs: CopyPackBlobs, p: &impl Progress) -> RusticResult<()> {
+    pub fn copy_fast(&self, pack_blobs: CopyPackBlobs, p: &Progress) -> RusticResult<()> {
         let offset = pack_blobs.locations.offset;
         let data = self.be_src.read_partial(
             FileType::Pack,
@@ -964,7 +964,7 @@ impl<BE: DecryptFullBackend> BlobCopier<BE> {
     ///
     /// * If the blob could not be added
     /// * If reading the blob from the backend fails
-    pub fn copy(&self, pack_blobs: CopyPackBlobs, p: &impl Progress) -> RusticResult<()> {
+    pub fn copy(&self, pack_blobs: CopyPackBlobs, p: &Progress) -> RusticResult<()> {
         let offset = pack_blobs.locations.offset;
         let read_data = self.be_src.read_partial(
             FileType::Pack,

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -642,7 +642,7 @@ where
 ///
 /// * `P` - The progress indicator
 #[derive(Debug)]
-pub struct TreeStreamerOnce<P> {
+pub struct TreeStreamerOnce {
     /// The visited tree IDs
     visited: BTreeSet<TreeId>,
     /// The queue to send tree IDs to
@@ -650,14 +650,14 @@ pub struct TreeStreamerOnce<P> {
     /// The queue to receive trees from
     queue_out: Receiver<RusticResult<(PathBuf, Tree, usize)>>,
     /// The progress indicator
-    p: P,
+    p: Progress,
     /// The number of trees that are not yet finished
     counter: Vec<usize>,
     /// The number of finished trees
     finished_ids: usize,
 }
 
-impl<P: Progress> TreeStreamerOnce<P> {
+impl TreeStreamerOnce {
     /// Creates a new `TreeStreamerOnce`.
     ///
     /// # Type Parameters
@@ -678,7 +678,7 @@ impl<P: Progress> TreeStreamerOnce<P> {
         be: &BE,
         index: &I,
         ids: Vec<TreeId>,
-        p: P,
+        p: Progress,
     ) -> RusticResult<Self> {
         p.set_length(ids.len() as u64);
 
@@ -765,7 +765,7 @@ impl<P: Progress> TreeStreamerOnce<P> {
     }
 }
 
-impl<P: Progress> Iterator for TreeStreamerOnce<P> {
+impl Iterator for TreeStreamerOnce {
     type Item = TreeStreamItem;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/core/src/commands/backup.rs
+++ b/crates/core/src/commands/backup.rs
@@ -19,7 +19,6 @@ use crate::{
         stdin::StdinSource,
     },
     error::{ErrorKind, RusticError, RusticResult},
-    progress::ProgressBars,
     repofile::{
         PathList, SnapshotFile,
         snapshotfile::{SnapshotGroup, SnapshotGroupCriterion, SnapshotId},
@@ -93,9 +92,9 @@ impl ParentOptions {
     /// # Returns
     ///
     /// The parent snapshot id and the parent object or `None` if no parent is used.
-    pub(crate) fn get_parent<P: ProgressBars, S: IndexedTree>(
+    pub(crate) fn get_parent<S: IndexedTree>(
         &self,
-        repo: &Repository<P, S>,
+        repo: &Repository<S>,
         snap: &SnapshotFile,
         backup_stdin: bool,
     ) -> (Vec<SnapshotId>, Parent) {
@@ -107,7 +106,7 @@ impl ParentOptions {
             SnapshotFile::latest(
                 repo.dbe(),
                 |snap| snap.has_group(&group),
-                &repo.pb.progress_counter(""),
+                &repo.progress_counter(""),
             )
             .ok()
             .into_iter()
@@ -117,7 +116,7 @@ impl ParentOptions {
                 repo.dbe(),
                 &self.parents,
                 |snap| snap.has_group(&group),
-                &repo.pb.progress_counter(""),
+                &repo.progress_counter(""),
             )
             .unwrap_or_default()
         };
@@ -223,8 +222,8 @@ pub struct BackupOptions {
 ///
 /// The snapshot pointing to the backup'ed data.
 #[allow(clippy::too_many_lines)]
-pub(crate) fn backup<P: ProgressBars, S: IndexedIds>(
-    repo: &Repository<P, S>,
+pub(crate) fn backup<S: IndexedIds>(
+    repo: &Repository<S>,
     opts: &BackupOptions,
     source: &PathList,
     mut snap: SnapshotFile,
@@ -287,7 +286,7 @@ pub(crate) fn backup<P: ProgressBars, S: IndexedIds>(
     let be = DryRunBackend::new(repo.dbe().clone(), opts.dry_run);
     info!("starting to backup {source} ...");
     let archiver = Archiver::new(be, index, repo.config(), parent, snap)?;
-    let p = repo.pb.progress_bytes("backing up...");
+    let p = repo.progress_bytes("backing up...");
 
     let snap = if backup_stdin {
         let path = &backup_path[0];

--- a/crates/core/src/commands/cat.rs
+++ b/crates/core/src/commands/cat.rs
@@ -7,7 +7,6 @@ use crate::{
     blob::{BlobId, BlobType, tree::Tree},
     error::{ErrorKind, RusticError, RusticResult},
     index::ReadIndex,
-    progress::ProgressBars,
     repofile::SnapshotFile,
     repository::{IndexedFull, IndexedTree, Open, Repository},
 };
@@ -34,8 +33,8 @@ use crate::{
 /// # Returns
 ///
 /// The data read.
-pub(crate) fn cat_file<P, S: Open>(
-    repo: &Repository<P, S>,
+pub(crate) fn cat_file<S: Open>(
+    repo: &Repository<S>,
     tpe: FileType,
     id: &str,
 ) -> RusticResult<Bytes> {
@@ -60,8 +59,8 @@ pub(crate) fn cat_file<P, S: Open>(
 /// # Errors
 ///
 /// * If the string is not a valid hexadecimal string
-pub(crate) fn cat_blob<P, S: IndexedFull>(
-    repo: &Repository<P, S>,
+pub(crate) fn cat_blob<S: IndexedFull>(
+    repo: &Repository<S>,
     tpe: BlobType,
     id: &str,
 ) -> RusticResult<Bytes> {
@@ -91,8 +90,8 @@ pub(crate) fn cat_blob<P, S: IndexedFull>(
 /// # Returns
 ///
 /// The data read.
-pub(crate) fn cat_tree<P: ProgressBars, S: IndexedTree>(
-    repo: &Repository<P, S>,
+pub(crate) fn cat_tree<S: IndexedTree>(
+    repo: &Repository<S>,
     snap: &str,
     sn_filter: impl FnMut(&SnapshotFile) -> bool + Send + Sync,
 ) -> RusticResult<Bytes> {
@@ -101,7 +100,7 @@ pub(crate) fn cat_tree<P: ProgressBars, S: IndexedTree>(
         repo.dbe(),
         id,
         sn_filter,
-        &repo.pb.progress_counter("getting snapshot..."),
+        &repo.progress_counter("getting snapshot..."),
     )?;
     let node = Tree::node_from_path(repo.dbe(), repo.index(), snap.tree, Path::new(path))?;
     let id = node.subtree.ok_or_else(|| {

--- a/crates/core/src/commands/config.rs
+++ b/crates/core/src/commands/config.rs
@@ -37,8 +37,8 @@ use crate::{
 /// # Returns
 ///
 /// Whether the config was changed
-pub(crate) fn apply_config<P, S: Open>(
-    repo: &mut Repository<P, S>,
+pub(crate) fn apply_config<S: Open>(
+    repo: &mut Repository<S>,
     opts: &ConfigOptions,
 ) -> RusticResult<bool> {
     if repo.config().append_only == Some(true) && opts.set_append_only != Some(false) {
@@ -75,8 +75,8 @@ pub(crate) fn apply_config<P, S: Open>(
 /// # Errors
 ///
 /// * If the file could not be serialized to json.
-pub(crate) fn save_config<P, S>(
-    repo: &Repository<P, S>,
+pub(crate) fn save_config<S>(
+    repo: &Repository<S>,
     mut new_config: ConfigFile,
     key: impl CryptoKey,
 ) -> RusticResult<()> {

--- a/crates/core/src/commands/dump.rs
+++ b/crates/core/src/commands/dump.rs
@@ -23,8 +23,8 @@ use crate::{
 /// # Errors
 ///
 /// * If the node is not a file.
-pub(crate) fn dump<P, S: IndexedFull>(
-    repo: &Repository<P, S>,
+pub(crate) fn dump<S: IndexedFull>(
+    repo: &Repository<S>,
     node: &Node,
     w: &mut impl Write,
 ) -> RusticResult<()> {

--- a/crates/core/src/commands/forget.rs
+++ b/crates/core/src/commands/forget.rs
@@ -7,7 +7,6 @@ use serde_with::{DisplayFromStr, serde_as, skip_serializing_none};
 
 use crate::{
     error::{ErrorKind, RusticError, RusticResult},
-    progress::ProgressBars,
     repofile::{
         SnapshotFile, StringList,
         snapshotfile::{SnapshotGroup, SnapshotGroupCriterion, SnapshotId},
@@ -77,8 +76,8 @@ impl ForgetGroups {
 /// # Returns
 ///
 /// The list of snapshot groups with the corresponding snapshots and forget information
-pub(crate) fn get_forget_snapshots<P: ProgressBars, S: Open>(
-    repo: &Repository<P, S>,
+pub(crate) fn get_forget_snapshots<S: Open>(
+    repo: &Repository<S>,
     keep: &KeepOptions,
     group_by: SnapshotGroupCriterion,
     filter: impl FnMut(&SnapshotFile) -> bool + Send + Sync,

--- a/crates/core/src/commands/init.rs
+++ b/crates/core/src/commands/init.rs
@@ -37,8 +37,8 @@ use crate::{
 /// # Returns
 ///
 /// A tuple of the key and the config file.
-pub(crate) fn init<P, S>(
-    repo: &Repository<P, S>,
+pub(crate) fn init<S>(
+    repo: &Repository<S>,
     credentials: &Credentials,
     key_opts: &KeyOptions,
     config_opts: &ConfigOptions,
@@ -77,8 +77,8 @@ pub(crate) fn init<P, S>(
 /// # Returns
 ///
 /// The key used to encrypt the config.
-pub(crate) fn init_with_config<P, S>(
-    repo: &Repository<P, S>,
+pub(crate) fn init_with_config<S>(
+    repo: &Repository<S>,
     credentials: &Credentials,
     key_opts: &KeyOptions,
     config: &ConfigFile,

--- a/crates/core/src/commands/key.rs
+++ b/crates/core/src/commands/key.rs
@@ -48,8 +48,8 @@ pub struct KeyOptions {
 /// # Returns
 ///
 /// The id of the key.
-pub(crate) fn add_current_key_to_repo<P, S: Open>(
-    repo: &Repository<P, S>,
+pub(crate) fn add_current_key_to_repo<S: Open>(
+    repo: &Repository<S>,
     opts: &KeyOptions,
     pass: &str,
 ) -> RusticResult<KeyId> {
@@ -73,8 +73,8 @@ pub(crate) fn add_current_key_to_repo<P, S: Open>(
 /// # Returns
 ///
 /// A tuple of the key and the id of the key.
-pub(crate) fn init_key<P, S>(
-    repo: &Repository<P, S>,
+pub(crate) fn init_key<S>(
+    repo: &Repository<S>,
     opts: &KeyOptions,
     pass: &str,
 ) -> RusticResult<(Key, KeyId)> {
@@ -99,8 +99,8 @@ pub(crate) fn init_key<P, S>(
 /// # Returns
 ///
 /// The id of the key.
-pub(crate) fn add_key_to_repo<P, S>(
-    repo: &Repository<P, S>,
+pub(crate) fn add_key_to_repo<S>(
+    repo: &Repository<S>,
     opts: &KeyOptions,
     pass: &str,
     key: Key,

--- a/crates/core/src/commands/merge.rs
+++ b/crates/core/src/commands/merge.rs
@@ -13,7 +13,6 @@ use crate::{
     },
     error::{ErrorKind, RusticError, RusticResult},
     index::{ReadIndex, indexer::Indexer},
-    progress::{Progress, ProgressBars},
     repofile::{PathList, SnapshotFile, SnapshotSummary},
     repository::{IndexedTree, Repository},
 };
@@ -30,8 +29,8 @@ use crate::{
 /// # Returns
 ///
 /// The merged snapshot
-pub(crate) fn merge_snapshots<P: ProgressBars, S: IndexedTree>(
-    repo: &Repository<P, S>,
+pub(crate) fn merge_snapshots<S: IndexedTree>(
+    repo: &Repository<S>,
     snapshots: &[SnapshotFile],
     cmp: &impl Fn(&Node, &Node) -> Ordering,
     mut snap: SnapshotFile,
@@ -93,8 +92,8 @@ pub(crate) fn merge_snapshots<P: ProgressBars, S: IndexedTree>(
 /// # Returns
 ///
 /// The merged tree
-pub(crate) fn merge_trees<P: ProgressBars, S: IndexedTree>(
-    repo: &Repository<P, S>,
+pub(crate) fn merge_trees<S: IndexedTree>(
+    repo: &Repository<S>,
     trees: &[TreeId],
     cmp: &impl Fn(&Node, &Node) -> Ordering,
     summary: &mut SnapshotSummary,
@@ -135,7 +134,7 @@ pub(crate) fn merge_trees<P: ProgressBars, S: IndexedTree>(
         Ok((new_id, size))
     };
 
-    let p = repo.pb.progress_spinner("merging snapshots...");
+    let p = repo.progress_spinner("merging snapshots...");
     let tree_merged = tree::merge_trees(be, index, trees, cmp, &save, summary)?;
     let stats = packer.finalize()?;
     indexer.write().unwrap().finalize()?;

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -16,7 +16,6 @@ use crate::{
     },
     error::{ErrorKind, RusticError, RusticResult},
     index::{ReadGlobalIndex, ReadIndex, indexer::Indexer},
-    progress::ProgressBars,
     repofile::{SnapshotFile, StringList, snapshotfile::SnapshotId},
     repository::{IndexedFull, IndexedTree, Repository},
 };
@@ -88,8 +87,8 @@ pub(crate) struct RepairState {
 /// * `opts` - The repair options to use
 /// * `snapshots` - The snapshots to repair
 /// * `dry_run` - Whether to actually modify the repository or just print what would be done
-pub(crate) fn repair_snapshots<P: ProgressBars, S: IndexedFull>(
-    repo: &Repository<P, S>,
+pub(crate) fn repair_snapshots<S: IndexedFull>(
+    repo: &Repository<S>,
     opts: &RepairSnapshotsOptions,
     snapshots: Vec<SnapshotFile>,
     dry_run: bool,
@@ -168,7 +167,7 @@ pub(crate) fn repair_snapshots<P: ProgressBars, S: IndexedFull>(
             be.delete_list(
                 true,
                 state.delete.iter(),
-                repo.pb.progress_counter("remove defect snapshots"),
+                repo.progress_counter("remove defect snapshots"),
             )?;
         }
     }

--- a/crates/core/src/commands/rewrite.rs
+++ b/crates/core/src/commands/rewrite.rs
@@ -4,7 +4,7 @@ use derive_setters::Setters;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ErrorKind, IndexedFull, Open, ProgressBars, Repository, RusticError, RusticResult, StringList,
+    ErrorKind, IndexedFull, Open, Repository, RusticError, RusticResult, StringList,
     blob::tree::{
         modify::ModifierChange,
         rewrite::{RewriteTreesOptions, Rewriter},
@@ -41,8 +41,8 @@ pub struct RewriteOptions {
     pub dry_run: bool,
 }
 
-pub(crate) fn rewrite_snapshots_and_trees<P: ProgressBars, S: IndexedFull>(
-    repo: &Repository<P, S>,
+pub(crate) fn rewrite_snapshots_and_trees<S: IndexedFull>(
+    repo: &Repository<S>,
     snapshots: Vec<SnapshotFile>,
     opts: &RewriteOptions,
     tree_opts: &RewriteTreesOptions,
@@ -94,8 +94,8 @@ pub(crate) fn rewrite_snapshots_and_trees<P: ProgressBars, S: IndexedFull>(
     process_snapshots(repo, snapshots, opts)
 }
 
-pub(crate) fn rewrite_snapshots<P: ProgressBars, S: Open>(
-    repo: &Repository<P, S>,
+pub(crate) fn rewrite_snapshots<S: Open>(
+    repo: &Repository<S>,
     snapshots: Vec<SnapshotFile>,
     opts: &RewriteOptions,
 ) -> RusticResult<Vec<SnapshotFile>> {
@@ -115,8 +115,8 @@ pub(crate) fn rewrite_snapshots<P: ProgressBars, S: Open>(
     process_snapshots(repo, snapshots, opts)
 }
 
-fn process_snapshots<P: ProgressBars, S: Open>(
-    repo: &Repository<P, S>,
+fn process_snapshots<S: Open>(
+    repo: &Repository<S>,
     mut snapshots: Vec<SnapshotFile>,
     opts: &RewriteOptions,
 ) -> RusticResult<Vec<SnapshotFile>> {

--- a/crates/core/src/commands/snapshots.rs
+++ b/crates/core/src/commands/snapshots.rs
@@ -3,9 +3,7 @@
 use itertools::Itertools;
 
 use crate::{
-    Progress,
     error::RusticResult,
-    progress::ProgressBars,
     repofile::{
         SnapshotFile,
         snapshotfile::{SnapshotGroup, SnapshotGroupCriterion},
@@ -31,15 +29,14 @@ use crate::{
 /// # Returns
 ///
 /// The snapshots grouped by the given criterion.
-pub(crate) fn get_snapshot_group<P: ProgressBars, S: Open>(
-    repo: &Repository<P, S>,
+pub(crate) fn get_snapshot_group<S: Open>(
+    repo: &Repository<S>,
     ids: &[String],
     group_by: SnapshotGroupCriterion,
     filter: impl FnMut(&SnapshotFile) -> bool + Send + Sync,
 ) -> RusticResult<Vec<(SnapshotGroup, Vec<SnapshotFile>)>> {
-    let pb = &repo.pb;
     let dbe = repo.dbe();
-    let p = pb.progress_counter("getting snapshots...");
+    let p = repo.progress_counter("getting snapshots...");
     let groups = if ids.is_empty() {
         SnapshotFile::group_from_backend(dbe, filter, group_by, &p)?
     } else {

--- a/crates/core/src/index.rs
+++ b/crates/core/src/index.rs
@@ -264,7 +264,7 @@ impl GlobalIndex {
     /// * If the index could not be read
     fn new_from_collector(
         be: &impl DecryptReadBackend,
-        p: &impl Progress,
+        p: &Progress,
         mut collector: IndexCollector,
     ) -> RusticResult<Self> {
         p.set_title("reading index...");
@@ -283,7 +283,7 @@ impl GlobalIndex {
     ///
     /// * `be` - The backend to read from
     /// * `p` - The progress tracker
-    pub fn new(be: &impl DecryptReadBackend, p: &impl Progress) -> RusticResult<Self> {
+    pub fn new(be: &impl DecryptReadBackend, p: &Progress) -> RusticResult<Self> {
         Self::new_from_collector(be, p, IndexCollector::new(IndexType::Full))
     }
 
@@ -297,7 +297,7 @@ impl GlobalIndex {
     /// # Errors
     ///
     /// * If the index could not be read
-    pub fn only_full_trees(be: &impl DecryptReadBackend, p: &impl Progress) -> RusticResult<Self> {
+    pub fn only_full_trees(be: &impl DecryptReadBackend, p: &Progress) -> RusticResult<Self> {
         Self::new_from_collector(be, p, IndexCollector::new(IndexType::DataIds))
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -161,7 +161,10 @@ pub use crate::{
     },
     error::{ErrorKind, RusticError, RusticResult, Severity, Status},
     id::{HexId, Id},
-    progress::{NoProgress, NoProgressBars, Progress, ProgressBars},
+    progress::{
+        HiddenProgress, NoProgress, NoProgressBars, Progress, ProgressBars, ProgressType,
+        RusticProgress,
+    },
     repofile::snapshotfile::{
         PathList, SnapshotGroup, SnapshotGroupCriterion, SnapshotOptions, StringList,
     },

--- a/crates/core/src/progress.rs
+++ b/crates/core/src/progress.rs
@@ -1,11 +1,66 @@
-use std::borrow::Cow;
+use std::sync::Arc;
 
 use log::info;
+
+/// A progress used to indicate/update the status of something which is being processed
+#[derive(Debug)]
+pub struct Progress(Arc<dyn RusticProgress>);
+
+impl Progress {
+    /// Create a new `Progress` from a suitable trait implementation
+    pub fn new<P: RusticProgress>(p: P) -> Self {
+        Self(Arc::new(p))
+    }
+
+    /// Create a new hidden `Progress`
+    #[must_use]
+    pub fn hidden() -> Self {
+        Self(Arc::new(HiddenProgress))
+    }
+
+    /// Check if progress is hidden
+    #[must_use]
+    pub fn is_hidden(&self) -> bool {
+        self.0.is_hidden()
+    }
+
+    /// Set total length for this progress
+    ///
+    /// # Arguments
+    ///
+    /// * `len` - The total length of this progress
+    pub fn set_length(&self, len: u64) {
+        self.0.set_length(len);
+    }
+
+    /// Set title for this progress
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - The title of this progress
+    pub fn set_title(&self, title: &str) {
+        self.0.set_title(title);
+    }
+
+    /// Advance progress by given increment
+    ///
+    /// # Arguments
+    ///
+    /// * `inc` - The increment to advance this progress
+    pub fn inc(&self, inc: u64) {
+        self.0.inc(inc);
+    }
+
+    /// Finish the progress
+    pub fn finish(&self) {
+        self.0.finish();
+    }
+}
 
 /// Trait to report progress information for any rustic action which supports that.
 ///
 /// Implement this trait when you want to display this progress to your users.
-pub trait Progress: Send + Sync + Clone {
+pub trait RusticProgress: Send + Sync + 'static + std::fmt::Debug {
     /// Check if progress is hidden
     fn is_hidden(&self) -> bool;
 
@@ -21,7 +76,7 @@ pub trait Progress: Send + Sync + Clone {
     /// # Arguments
     ///
     /// * `title` - The title of this progress
-    fn set_title(&self, title: &'static str);
+    fn set_title(&self, title: &str);
 
     /// Advance progress by given increment
     ///
@@ -34,48 +89,53 @@ pub trait Progress: Send + Sync + Clone {
     fn finish(&self);
 }
 
+/// Type of progress
+#[derive(Debug, Clone, Copy)]
+pub enum ProgressType {
+    /// a progress spinner. Note that this progress doesn't get a length and is not advanced, only finished.
+    Spinner,
+    /// a progress which counts something
+    Counter,
+    /// a progress which counts bytes
+    Bytes,
+}
+
 /// Trait to start progress information report progress information for any rustic action which supports that.
 ///
 /// Implement this trait when you want to display this progress to your users.
-pub trait ProgressBars {
-    /// The actual type which is able to show the progress
-    type P: Progress;
-
-    /// Start a new progress, which is hidden
-    fn progress_hidden(&self) -> Self::P;
-
-    /// Start a new progress spinner. Note that this progress doesn't get a length and is not advanced, only finished.
+pub trait ProgressBars: std::fmt::Debug + Send + Sync + 'static {
+    /// Start a new progress.
     ///
     /// # Arguments
     ///
+    /// * `progress_type` - The type of the progress
     /// * `prefix` - The prefix of the progress
-    fn progress_spinner(&self, prefix: impl Into<Cow<'static, str>>) -> Self::P;
+    fn progress(&self, progress_type: ProgressType, prefix: &str) -> Progress;
+}
 
-    /// Start a new progress which counts something
-    ///
-    /// # Arguments
-    ///
-    /// * `prefix` - The prefix of the progress
-    fn progress_counter(&self, prefix: impl Into<Cow<'static, str>>) -> Self::P;
-
-    /// Start a new progress which counts bytes
-    ///
-    /// # Arguments
-    ///
-    /// * `prefix` - The prefix of the progress
-    fn progress_bytes(&self, prefix: impl Into<Cow<'static, str>>) -> Self::P;
+/// A Progress showing nothing at all
+#[derive(Clone, Copy, Debug)]
+pub struct HiddenProgress;
+impl RusticProgress for HiddenProgress {
+    fn is_hidden(&self) -> bool {
+        true
+    }
+    fn set_length(&self, _len: u64) {}
+    fn set_title(&self, _title: &str) {}
+    fn inc(&self, _inc: u64) {}
+    fn finish(&self) {}
 }
 
 /// A dummy struct which shows no progress but only logs titles and end of a progress.
 #[derive(Clone, Copy, Debug)]
 pub struct NoProgress;
 
-impl Progress for NoProgress {
+impl RusticProgress for NoProgress {
     fn is_hidden(&self) -> bool {
         true
     }
     fn set_length(&self, _len: u64) {}
-    fn set_title(&self, title: &'static str) {
+    fn set_title(&self, title: &str) {
         info!("{title}");
     }
     fn inc(&self, _inc: u64) {}
@@ -89,20 +149,8 @@ impl Progress for NoProgress {
 pub struct NoProgressBars;
 
 impl ProgressBars for NoProgressBars {
-    type P = NoProgress;
-    fn progress_spinner(&self, prefix: impl Into<Cow<'static, str>>) -> Self::P {
-        info!("{}", prefix.into());
-        NoProgress
-    }
-    fn progress_counter(&self, prefix: impl Into<Cow<'static, str>>) -> Self::P {
-        info!("{}", prefix.into());
-        NoProgress
-    }
-    fn progress_hidden(&self) -> Self::P {
-        NoProgress
-    }
-    fn progress_bytes(&self, prefix: impl Into<Cow<'static, str>>) -> Self::P {
-        info!("{}", prefix.into());
-        NoProgress
+    fn progress(&self, _progress_type: ProgressType, prefix: &str) -> Progress {
+        info!("{prefix}");
+        Progress::new(NoProgress)
     }
 }

--- a/crates/core/src/vfs.rs
+++ b/crates/core/src/vfs.rs
@@ -357,9 +357,9 @@ impl Vfs {
     /// The [`Node`] at the specified path
     ///
     /// [`Tree`]: crate::repofile::Tree
-    pub fn node_from_path<P, S: IndexedFull>(
+    pub fn node_from_path<S: IndexedFull>(
         &self,
-        repo: &Repository<P, S>,
+        repo: &Repository<S>,
         path: &Path,
     ) -> RusticResult<Node> {
         let meta = Metadata::default();
@@ -406,9 +406,9 @@ impl Vfs {
     /// # Panics
     ///
     /// * Panics if the path is not a directory.
-    pub fn dir_entries_from_path<P, S: IndexedFull>(
+    pub fn dir_entries_from_path<S: IndexedFull>(
         &self,
-        repo: &Repository<P, S>,
+        repo: &Repository<S>,
         path: &Path,
     ) -> RusticResult<Vec<Node>> {
         let result = match self.tree.get_path(path).map_err(|err| {
@@ -473,8 +473,8 @@ impl OpenFile {
     /// # Returns
     ///
     /// The created `OpenFile`
-    pub(crate) fn from_node<P, S: IndexedFull>(
-        repo: &Repository<P, S>,
+    pub(crate) fn from_node<S: IndexedFull>(
+        repo: &Repository<S>,
         node: &Node,
     ) -> RusticResult<Self> {
         let content: Vec<_> = node.content.clone().unwrap_or_default();
@@ -513,9 +513,9 @@ impl OpenFile {
     /// The read bytes from the given offset and length.
     /// If offset is behind the end of the file, an empty `Bytes` is returned.
     /// If length is too large, the result up to the end of the file is returned.
-    pub fn read_at<P, S: IndexedFull>(
+    pub fn read_at<S: IndexedFull>(
         &self,
-        repo: &Repository<P, S>,
+        repo: &Repository<S>,
         offset: usize,
         mut length: usize,
     ) -> RusticResult<Bytes> {

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -56,12 +56,12 @@ use tempfile::{TempDir, tempdir};
 
 use rustic_core::{
     CommandInput, ConfigOptions, CredentialOptions, Credentials, FullIndex, IndexedFull,
-    IndexedStatus, KeyOptions, NoProgressBars, OpenStatus, PathList, Repository,
-    RepositoryBackends, RepositoryOptions, repofile::MasterKey,
+    IndexedStatus, KeyOptions, OpenStatus, PathList, Repository, RepositoryBackends,
+    RepositoryOptions, repofile::MasterKey,
 };
 use rustic_testing::backend::in_memory_backend::InMemoryBackend;
 
-type RepoOpen = Repository<NoProgressBars, OpenStatus>;
+type RepoOpen = Repository<OpenStatus>;
 
 #[derive(Debug)]
 struct TestSource(TempDir);
@@ -208,7 +208,7 @@ fn repo_with_commands() -> Result<()> {
 /// See issue #277 for more context.
 #[test]
 fn test_wrapping_in_new_type() -> Result<()> {
-    struct Wrapper(Repository<NoProgressBars, IndexedStatus<FullIndex, OpenStatus>>);
+    struct Wrapper(Repository<IndexedStatus<FullIndex, OpenStatus>>);
 
     impl Wrapper {
         fn new() -> Result<Self> {

--- a/crates/core/tests/integration/snapshots.rs
+++ b/crates/core/tests/integration/snapshots.rs
@@ -12,14 +12,13 @@ use jiff::tz::TimeZone;
 use rstest::{fixture, rstest};
 use rustic_core::repofile::SnapshotFile;
 use rustic_core::{
-    BackupOptions, IdIndex, IndexedStatus, NoProgressBars, OpenStatus, Repository,
-    SnapshotGroupCriterion,
+    BackupOptions, IdIndex, IndexedStatus, OpenStatus, Repository, SnapshotGroupCriterion,
 };
 
 #[fixture]
 #[once]
 fn repo_and_snapshots() -> (
-    Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+    Repository<IndexedStatus<IdIndex, OpenStatus>>,
     Vec<SnapshotFile>,
 ) {
     let repo = set_up_repo().unwrap().to_indexed_ids().unwrap();
@@ -60,7 +59,7 @@ fn repo_and_snapshots() -> (
 #[rstest]
 fn test_get_snapshot_group_no_ids(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) -> Result<()> {
@@ -77,7 +76,7 @@ fn test_get_snapshot_group_no_ids(
 #[rstest]
 fn test_get_snapshot_group_wrong_id(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) {
@@ -99,7 +98,7 @@ fn test_get_snapshot_group_wrong_id(
 #[rstest]
 fn test_get_snapshot_group_latest_id(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) -> Result<()> {
@@ -120,7 +119,7 @@ fn test_get_snapshot_group_latest_id(
 #[rstest]
 fn test_get_snapshot_group_latest_n_id(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) -> Result<()> {
@@ -153,7 +152,7 @@ fn test_get_snapshot_group_latest_n_id(
 #[rstest]
 fn test_get_snapshot_from_str_short_id(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) -> Result<()> {
@@ -173,7 +172,7 @@ fn test_get_snapshot_from_str_short_id(
 #[rstest]
 fn test_get_snapshot_from_str_latest(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) -> Result<()> {
@@ -189,7 +188,7 @@ fn test_get_snapshot_from_str_latest(
 #[rstest]
 fn test_get_snapshots_from_strs_latest(
     repo_and_snapshots: &(
-        Repository<NoProgressBars, IndexedStatus<IdIndex, OpenStatus>>,
+        Repository<IndexedStatus<IdIndex, OpenStatus>>,
         Vec<SnapshotFile>,
     ),
 ) -> Result<()> {

--- a/crates/core/tests/warm_up.rs
+++ b/crates/core/tests/warm_up.rs
@@ -12,12 +12,10 @@ use rstest::rstest;
 use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
 
-use rustic_core::{
-    CommandInput, Id, NoProgressBars, RepositoryBackends, RepositoryOptions, repofile::PackId,
-};
+use rustic_core::{CommandInput, Id, RepositoryBackends, RepositoryOptions, repofile::PackId};
 use rustic_testing::backend::in_memory_backend::InMemoryBackend;
 
-type RepoOpen = rustic_core::Repository<NoProgressBars, rustic_core::OpenStatus>;
+type RepoOpen = rustic_core::Repository<rustic_core::OpenStatus>;
 
 // Test constants
 const DEFAULT_BATCH_SIZE: usize = 1;
@@ -173,7 +171,7 @@ fn create_test_ids(count: usize) -> Vec<PackId> {
 fn create_test_repo(
     command: CommandInput,
     batch_size: usize,
-) -> Result<rustic_core::Repository<NoProgressBars, ()>> {
+) -> Result<rustic_core::Repository<()>> {
     let be = InMemoryBackend::new();
     let be = RepositoryBackends::new(Arc::new(be), None);
     let options = RepositoryOptions::default()
@@ -400,7 +398,7 @@ fn test_validation_requires_placeholder() -> Result<()> {
     let command: CommandInput = "echo test".parse()?;
     let options = RepositoryOptions::default().warm_up_command(command);
 
-    let result = rustic_core::Repository::<NoProgressBars, ()>::new(&options, &be);
+    let result = rustic_core::Repository::new(&options, &be);
 
     assert!(
         result.is_err(),
@@ -424,7 +422,7 @@ fn test_validation_mixing_singular_and_plural() -> Result<()> {
     let command: CommandInput = "echo %ids %path".parse()?;
     let options = RepositoryOptions::default().warm_up_command(command);
 
-    let result = rustic_core::Repository::<NoProgressBars, ()>::new(&options, &be);
+    let result = rustic_core::Repository::new(&options, &be);
 
     assert!(
         result.is_err(),
@@ -452,7 +450,7 @@ fn test_validation_valid_singular_placeholders() -> Result<()> {
         let command: CommandInput = cmd_str.parse()?;
         let options = RepositoryOptions::default().warm_up_command(command);
 
-        let result = rustic_core::Repository::<NoProgressBars, ()>::new(&options, &be);
+        let result = rustic_core::Repository::new(&options, &be);
         assert!(result.is_ok(), "Command with '{cmd_str}' should succeed");
     }
 
@@ -475,7 +473,7 @@ fn test_validation_valid_plural_placeholders() -> Result<()> {
         let command: CommandInput = cmd_str.parse()?;
         let options = RepositoryOptions::default().warm_up_command(command);
 
-        let result = rustic_core::Repository::<NoProgressBars, ()>::new(&options, &be);
+        let result = rustic_core::Repository::new(&options, &be);
         assert!(result.is_ok(), "Command with '{cmd_str}' should succeed");
     }
 


### PR DESCRIPTION
This PR simplifies the progress used in rustic_core.
It now also uses dynamic dispatch and therefore removes the generic parameter `P` for `Repository` making this a breaking change.

