### PR TITLE
refactor!: Simplify Repository status

### DIFF
--- a/crates/core/src/commands/check.rs
+++ b/crates/core/src/commands/check.rs
@@ -228,7 +228,7 @@ pub(crate) fn check_repository<S: Open>(
     trees: Vec<TreeId>,
 ) -> RusticResult<CheckResults> {
     let be = repo.dbe();
-    let cache = &repo.open_status().cache;
+    let cache = repo.cache();
     let hot_be = &repo.be_hot;
     let raw_be = repo.dbe();
     let collector = CheckResultsCollector::default().log(true);

--- a/crates/core/src/commands/copy.rs
+++ b/crates/core/src/commands/copy.rs
@@ -17,7 +17,7 @@ use crate::{
     error::RusticResult,
     index::{ReadIndex, indexer::Indexer},
     repofile::SnapshotFile,
-    repository::{IndexedFull, IndexedIds, IndexedTree, Open, Repository},
+    repository::{IndexedFull, IndexedIds, Open, Repository},
 };
 
 /// This struct enhances `[SnapshotFile]` with the attribute `relevant`

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -17,7 +17,7 @@ use crate::{
     error::{ErrorKind, RusticError, RusticResult},
     index::{ReadGlobalIndex, ReadIndex, indexer::Indexer},
     repofile::{SnapshotFile, StringList, snapshotfile::SnapshotId},
-    repository::{IndexedFull, IndexedTree, Repository},
+    repository::{IndexedFull, Repository},
 };
 
 #[cfg_attr(feature = "clap", derive(clap::Parser))]

--- a/crates/core/src/commands/rewrite.rs
+++ b/crates/core/src/commands/rewrite.rs
@@ -10,7 +10,6 @@ use crate::{
         rewrite::{RewriteTreesOptions, Rewriter},
     },
     repofile::{SnapshotFile, SnapshotModification},
-    repository::IndexedTree,
 };
 
 /// Options for rewrite

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -169,8 +169,8 @@ pub use crate::{
         PathList, SnapshotGroup, SnapshotGroupCriterion, SnapshotOptions, StringList,
     },
     repository::{
-        FullIndex, IdIndex, IndexedFull, IndexedIds, IndexedStatus, IndexedTree, Open, OpenStatus,
-        Repository, RepositoryOptions,
+        IndexedFull, IndexedFullStatus, IndexedIds, IndexedIdsStatus, IndexedTree,
+        IndexedTreesStatus, Open, OpenStatus, Repository, RepositoryOptions,
         command_input::{CommandInput, CommandInputErrorKind},
         credentials::{CredentialOptions, Credentials},
     },

--- a/crates/core/src/repository/status.rs
+++ b/crates/core/src/repository/status.rs
@@ -1,0 +1,204 @@
+use bytes::Bytes;
+
+use crate::{
+    BlobId, RusticResult,
+    backend::{cache::Cache, decrypt::DecryptBackend},
+    crypto::aespoly1305::Key,
+    index::GlobalIndex,
+    repofile::{ConfigFile, KeyId},
+};
+
+/// A repository which is open, i.e. the password has been checked and the decryption key is available.
+pub trait Open {
+    /// Get the open status
+    fn open_status(&self) -> &OpenStatus;
+    /// Get the mutable open status
+    fn open_status_mut(&mut self) -> &mut OpenStatus;
+    /// Get the open status
+    fn into_open_status(self) -> OpenStatus;
+}
+
+/// A repository which is indexed such that all tree blobs are contained in the index.
+pub trait IndexedTree: Open {
+    /// Returns the used indexes
+    fn index(&self) -> &GlobalIndex;
+}
+
+/// A repository which is indexed such that all tree blobs are contained in the index
+/// and additionally the `Id`s of data blobs are also contained in the index.
+pub trait IndexedIds: IndexedTree {
+    /// Turn the repository into the `IndexedTree` state by reading and storing a size-optimized index
+    fn into_indexed_tree(self) -> IndexedTreesStatus;
+}
+
+/// A repository which is indexed such that all blob information is fully contained in the index.
+pub trait IndexedFull: IndexedIds {
+    /// Get a blob from the internal cache blob or insert it with the given function
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The [`Id`] of the blob to get
+    /// * `with` - The function which fetches the blob from the repository if it is not contained in the cache
+    ///
+    /// # Errors
+    ///
+    /// * If the blob could not be fetched from the repository.
+    ///
+    /// # Returns
+    ///
+    /// The blob with the given id or the result of the given function if the blob is not contained in the cache
+    /// and the function is called.
+    fn get_blob_or_insert_with(
+        &self,
+        id: &BlobId,
+        with: impl FnOnce() -> RusticResult<Bytes>,
+    ) -> RusticResult<Bytes>;
+}
+
+/// Open Status: This repository is open, i.e. the password has been checked and the decryption key is available.
+#[derive(Debug)]
+pub struct OpenStatus {
+    /// The cache
+    pub(super) cache: Option<Cache>,
+    /// The [`DecryptBackend`]
+    pub(super) dbe: DecryptBackend<Key>,
+    /// The [`ConfigFile`]
+    pub(super) config: ConfigFile,
+    /// The [`KeyId`] of the used key
+    pub(super) key_id: Option<KeyId>,
+}
+
+impl Open for OpenStatus {
+    fn open_status(&self) -> &OpenStatus {
+        self
+    }
+    fn open_status_mut(&mut self) -> &mut OpenStatus {
+        self
+    }
+    fn into_open_status(self) -> OpenStatus {
+        self
+    }
+}
+
+/// Indexed Tree Status: The repository is open and the index contains trees.
+#[derive(Debug)]
+pub struct IndexedTreesStatus {
+    /// The open status
+    pub(super) open: OpenStatus,
+    /// The index backend
+    pub(super) index: GlobalIndex,
+}
+
+impl Open for IndexedTreesStatus {
+    fn open_status(&self) -> &OpenStatus {
+        &self.open
+    }
+    fn open_status_mut(&mut self) -> &mut OpenStatus {
+        &mut self.open
+    }
+    fn into_open_status(self) -> OpenStatus {
+        self.open
+    }
+}
+
+impl IndexedTree for IndexedTreesStatus {
+    fn index(&self) -> &GlobalIndex {
+        &self.index
+    }
+}
+
+/// Indexed Tree Status: The repository is open and the index contains tree packs and the ids for data packs.
+#[derive(Debug)]
+pub struct IndexedIdsStatus {
+    /// The open status
+    pub(super) open: OpenStatus,
+    /// The index backend
+    pub(super) index: GlobalIndex,
+}
+
+impl Open for IndexedIdsStatus {
+    fn open_status(&self) -> &OpenStatus {
+        &self.open
+    }
+    fn open_status_mut(&mut self) -> &mut OpenStatus {
+        &mut self.open
+    }
+    fn into_open_status(self) -> OpenStatus {
+        self.open
+    }
+}
+
+impl IndexedTree for IndexedIdsStatus {
+    fn index(&self) -> &GlobalIndex {
+        &self.index
+    }
+}
+
+impl IndexedIds for IndexedIdsStatus {
+    fn into_indexed_tree(self) -> IndexedTreesStatus {
+        IndexedTreesStatus {
+            open: self.open,
+            index: self.index.drop_data(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+/// Defines a weighted cache with weight equal to the length of the blob size
+pub(crate) struct BytesWeighter;
+
+impl quick_cache::Weighter<BlobId, Bytes> for BytesWeighter {
+    fn weight(&self, _key: &BlobId, val: &Bytes) -> u64 {
+        u64::try_from(val.len())
+            .expect("weight overflow in cache should not happen")
+            // Be cautions out about zero weights!
+            .max(1)
+    }
+}
+/// Indexed Tree Status: The repository is open and the index contains trees.
+///
+#[derive(Debug)]
+pub struct IndexedFullStatus {
+    /// The open status
+    pub(super) open: OpenStatus,
+    /// The index backend
+    pub(super) index: GlobalIndex,
+    pub(super) cache: quick_cache::sync::Cache<BlobId, Bytes, BytesWeighter>,
+}
+
+impl Open for IndexedFullStatus {
+    fn open_status(&self) -> &OpenStatus {
+        &self.open
+    }
+    fn open_status_mut(&mut self) -> &mut OpenStatus {
+        &mut self.open
+    }
+    fn into_open_status(self) -> OpenStatus {
+        self.open
+    }
+}
+
+impl IndexedTree for IndexedFullStatus {
+    fn index(&self) -> &GlobalIndex {
+        &self.index
+    }
+}
+
+impl IndexedIds for IndexedFullStatus {
+    fn into_indexed_tree(self) -> IndexedTreesStatus {
+        IndexedTreesStatus {
+            open: self.open,
+            index: self.index.drop_data(),
+        }
+    }
+}
+
+impl IndexedFull for IndexedFullStatus {
+    fn get_blob_or_insert_with(
+        &self,
+        id: &BlobId,
+        with: impl FnOnce() -> RusticResult<Bytes>,
+    ) -> RusticResult<Bytes> {
+        self.cache.get_or_insert_with(id, with)
+    }
+}

--- a/crates/core/src/repository/warm_up.rs
+++ b/crates/core/src/repository/warm_up.rs
@@ -10,7 +10,7 @@ use crate::{
     backend::{FileType, ReadBackend},
     error::{ErrorKind, RusticError, RusticResult},
     repofile::packfile::PackId,
-    repository::{Repository, uses_plural_placeholders},
+    repository::Repository,
 };
 
 pub(super) mod constants {
@@ -115,7 +115,7 @@ fn warm_up_command<S>(
     batch_size: usize,
     backend: &impl ReadBackend,
 ) -> RusticResult<()> {
-    let use_plural = uses_plural_placeholders(command)?;
+    let use_plural = command.uses_plural_placeholders()?;
 
     let total = packs.len();
 

--- a/crates/core/src/vfs.rs
+++ b/crates/core/src/vfs.rs
@@ -15,7 +15,7 @@ use crate::{
     error::{ErrorKind, RusticError, RusticResult},
     index::ReadIndex,
     repofile::{BlobType, Metadata, Node, NodeType, SnapshotFile},
-    repository::{IndexedFull, IndexedTree, Repository},
+    repository::{IndexedFull, Repository},
     vfs::format::FormattedSnapshot,
 };
 

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -55,9 +55,9 @@ use tempfile::{TempDir, tempdir};
 // use simplelog::{Config, SimpleLogger};
 
 use rustic_core::{
-    CommandInput, ConfigOptions, CredentialOptions, Credentials, FullIndex, IndexedFull,
-    IndexedStatus, KeyOptions, OpenStatus, PathList, Repository, RepositoryBackends,
-    RepositoryOptions, repofile::MasterKey,
+    CommandInput, ConfigOptions, CredentialOptions, Credentials, IndexedFull, IndexedFullStatus,
+    KeyOptions, OpenStatus, PathList, Repository, RepositoryBackends, RepositoryOptions,
+    repofile::MasterKey,
 };
 use rustic_testing::backend::in_memory_backend::InMemoryBackend;
 
@@ -208,7 +208,7 @@ fn repo_with_commands() -> Result<()> {
 /// See issue #277 for more context.
 #[test]
 fn test_wrapping_in_new_type() -> Result<()> {
-    struct Wrapper(Repository<IndexedStatus<FullIndex, OpenStatus>>);
+    struct Wrapper(Repository<IndexedFullStatus>);
 
     impl Wrapper {
         fn new() -> Result<Self> {
@@ -218,7 +218,7 @@ fn test_wrapping_in_new_type() -> Result<()> {
 
     /// Fake function that "does something" with a fully indexed repo
     /// (without actually relying on any functionality for the test)
-    fn use_repo(_: &impl IndexedFull) {}
+    fn use_repo(_: &Repository<impl IndexedFull>) {}
 
     let collection: Vec<Wrapper> = vec![Wrapper::new()?, Wrapper::new()?];
 

--- a/crates/core/tests/integration/snapshots.rs
+++ b/crates/core/tests/integration/snapshots.rs
@@ -11,16 +11,11 @@ use jiff::Timestamp;
 use jiff::tz::TimeZone;
 use rstest::{fixture, rstest};
 use rustic_core::repofile::SnapshotFile;
-use rustic_core::{
-    BackupOptions, IdIndex, IndexedStatus, OpenStatus, Repository, SnapshotGroupCriterion,
-};
+use rustic_core::{BackupOptions, IndexedIdsStatus, Repository, SnapshotGroupCriterion};
 
 #[fixture]
 #[once]
-fn repo_and_snapshots() -> (
-    Repository<IndexedStatus<IdIndex, OpenStatus>>,
-    Vec<SnapshotFile>,
-) {
+fn repo_and_snapshots() -> (Repository<IndexedIdsStatus>, Vec<SnapshotFile>) {
     let repo = set_up_repo().unwrap().to_indexed_ids().unwrap();
     let source = tar_gz_testdata().unwrap();
 
@@ -58,10 +53,7 @@ fn repo_and_snapshots() -> (
 
 #[rstest]
 fn test_get_snapshot_group_no_ids(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) -> Result<()> {
     let (repo, snapshots) = repo_and_snapshots;
 
@@ -75,10 +67,7 @@ fn test_get_snapshot_group_no_ids(
 
 #[rstest]
 fn test_get_snapshot_group_wrong_id(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) {
     let (repo, _snapshots) = repo_and_snapshots;
 
@@ -97,10 +86,7 @@ fn test_get_snapshot_group_wrong_id(
 
 #[rstest]
 fn test_get_snapshot_group_latest_id(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) -> Result<()> {
     let (repo, snapshots) = repo_and_snapshots;
     let res = repo.get_snapshot_group(
@@ -118,10 +104,7 @@ fn test_get_snapshot_group_latest_id(
 
 #[rstest]
 fn test_get_snapshot_group_latest_n_id(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) -> Result<()> {
     let (repo, snapshots) = repo_and_snapshots;
 
@@ -151,10 +134,7 @@ fn test_get_snapshot_group_latest_n_id(
 
 #[rstest]
 fn test_get_snapshot_from_str_short_id(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) -> Result<()> {
     let (repo, _snapshots) = repo_and_snapshots;
 
@@ -171,10 +151,7 @@ fn test_get_snapshot_from_str_short_id(
 
 #[rstest]
 fn test_get_snapshot_from_str_latest(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) -> Result<()> {
     let (repo, snapshots) = repo_and_snapshots;
 
@@ -187,10 +164,7 @@ fn test_get_snapshot_from_str_latest(
 
 #[rstest]
 fn test_get_snapshots_from_strs_latest(
-    repo_and_snapshots: &(
-        Repository<IndexedStatus<IdIndex, OpenStatus>>,
-        Vec<SnapshotFile>,
-    ),
+    repo_and_snapshots: &(Repository<IndexedIdsStatus>, Vec<SnapshotFile>),
 ) -> Result<()> {
     let (repo, snapshots) = repo_and_snapshots;
 


### PR DESCRIPTION
Simplifies the `Repository` status.
Now, a repo always looks like `Repository<STATUS>` where `STATUS` can be:
- `()`
- `OpenStatus`
- `IndexedTreeStatus`
- `IndexedIdsStatus`
- `IndexedFullStatus`

This is a breaking change, however it should only affect users who use the actual type of a repository.