### PR TITLE
fix: sort blobs before repacking

### DIFF
--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -1319,6 +1319,8 @@ pub(crate) fn prune_repository<S: Open>(
                     }
                     pack.blobs
                         .retain(|blob| used_ids.remove(&blob.id).is_some()); // don't save duplicate blobs
+                    // sort blobs to later allow coalescing
+                    pack.blobs.sort_unstable();
                     repack_packs.push(pack);
                 }
                 PackToDo::MarkDelete => {


### PR DESCRIPTION
closes https://github.com/rustic-rs/rustic/issues/1680:
- sort blobs-to-repack in prune
- assert that no overlaps occur when coalescing `BlobLocations`.
- added unit tests for the coalescing.