### PR TITLE
fix: race condition in warmup tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ version = "0.10.0"
 dependencies = [
  "aes256ctr_poly1305aes",
  "anyhow",
+ "backon",
  "binrw",
  "bytes",
  "bytesize",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -91,6 +91,7 @@ conflate = { version = "0.3.3", optional = true }
 runtime-format = "0.1.3"
 
 # other dependencies
+backon = "1.6.0"
 bytes = { workspace = true }
 bytesize = "2.3.1"
 ecow = "0.2.6"


### PR DESCRIPTION
There is a race condition caused by unit tests creating a script on the filesystem and trying to execute it too fast since creation; the operating system is not allowing execution yet. We don't know how long to wait, but waiting longer will solve it.

closes #480 