### PR TITLE
feat!: scope destination scan to snapshot-relevant paths for restore

### DIFF
--- a/crates/core/src/commands/restore.rs
+++ b/crates/core/src/commands/restore.rs
@@ -4,16 +4,11 @@ use derive_setters::Setters;
 use jiff::Timestamp;
 use log::{debug, error, info, trace, warn};
 
-use std::{
-    cmp::Ordering,
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-    sync::Mutex,
-};
+use std::{cmp::Ordering, collections::BTreeMap, path::PathBuf, sync::Mutex};
 
-use ignore::{DirEntry, WalkBuilder};
 use itertools::Itertools;
 use rayon::ThreadPoolBuilder;
+use walkdir::WalkDir;
 
 use crate::{
     backend::{
@@ -157,21 +152,20 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
     let mut stats = RestoreStats::default();
     let mut restore_infos = RestorePlan::default();
     let mut additional_existing = false;
-    let mut removed_dir = None;
 
-    let mut process_existing = |entry: &DirEntry| -> RusticResult<_> {
+    let mut process_existing = |entry: &walkdir::DirEntry| -> RusticResult<_> {
         if entry.depth() == 0 {
             // don't process the root dir which should be existing
             return Ok(());
         }
 
         debug!("additional {}", entry.path().display());
-        if entry.file_type().unwrap().is_dir() {
+        if entry.file_type().is_dir() {
             stats.dirs.additional += 1;
         } else {
             stats.files.additional += 1;
         }
-        match (opts.delete, dry_run, entry.file_type().unwrap().is_dir()) {
+        match (opts.delete, dry_run, entry.file_type().is_dir()) {
             (true, true, true) => {
                 info!(
                     "would have removed the additional dir: {}",
@@ -185,17 +179,8 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
                 );
             }
             (true, false, true) => {
-                let path = entry.path();
-                match &removed_dir {
-                    Some(dir) if path.starts_with(dir) => {}
-                    _ => match dest.remove_dir(path) {
-                        Ok(()) => {
-                            removed_dir = Some(path.to_path_buf());
-                        }
-                        Err(err) => {
-                            error!("error removing {}: {err}", path.display());
-                        }
-                    },
+                if let Err(err) = dest.remove_dir(entry.path()) {
+                    error!("error removing {}: {err}", entry.path().display());
                 }
             }
             (true, false, false) => {
@@ -266,20 +251,21 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
         Ok(())
     };
 
-    let mut dst_iter = WalkBuilder::new(dest_path)
+    let mut walker = WalkDir::new(&dest_path)
         .follow_links(false)
-        .hidden(false)
-        .ignore(false)
-        .sort_by_file_path(Path::cmp)
-        .build()
-        .inspect(|r| {
-            if let Err(err) = r {
-                error!("Error during collection of files: {err:?}");
-            }
-        })
-        .filter_map(Result::ok);
+        .sort_by_file_name()
+        .into_iter();
 
-    let mut next_dst = dst_iter.next();
+    let next_entry = |walker: &mut walkdir::IntoIter| -> Option<walkdir::DirEntry> {
+        loop {
+            match walker.next()? {
+                Ok(entry) => return Some(entry),
+                Err(err) => error!("Error during collection of files: {err:?}"),
+            }
+        }
+    };
+
+    let mut next_dst = next_entry(&mut walker);
 
     let mut next_node = node_streamer.next().transpose()?;
 
@@ -289,25 +275,37 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
 
             (Some(destination), None) => {
                 process_existing(destination)?;
-                next_dst = dst_iter.next();
+                // don't descend into extra dirs
+                if destination.file_type().is_dir() {
+                    walker.skip_current_dir();
+                }
+                next_dst = next_entry(&mut walker);
             }
             (Some(destination), Some((path, node))) => {
                 match destination.path().cmp(&dest.path(path)) {
                     Ordering::Less => {
                         process_existing(destination)?;
-                        next_dst = dst_iter.next();
+                        // don't descend into extra dirs
+                        if destination.file_type().is_dir() {
+                            walker.skip_current_dir();
+                        }
+                        next_dst = next_entry(&mut walker);
                     }
                     Ordering::Equal => {
                         // process existing node
-                        if (node.is_dir() && !destination.file_type().unwrap().is_dir())
-                            || (node.is_file() && !destination.metadata().unwrap().is_file())
+                        if (node.is_dir() && !destination.file_type().is_dir())
+                            || (node.is_file() && !destination.file_type().is_file())
                             || node.is_special()
                         {
                             // if types do not match, first remove the existing file
                             process_existing(destination)?;
+                            // removed a dir — don't descend into its former children
+                            if destination.file_type().is_dir() {
+                                walker.skip_current_dir();
+                            }
                         }
                         process_node(path, node, true)?;
-                        next_dst = dst_iter.next();
+                        next_dst = next_entry(&mut walker);
                         next_node = node_streamer.next().transpose()?;
                     }
                     Ordering::Greater => {

--- a/crates/core/src/commands/restore.rs
+++ b/crates/core/src/commands/restore.rs
@@ -8,7 +8,7 @@ use std::{cmp::Ordering, collections::BTreeMap, path::PathBuf, sync::Mutex};
 
 use itertools::Itertools;
 use rayon::ThreadPoolBuilder;
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 use crate::{
     backend::{
@@ -153,48 +153,64 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
     let mut restore_infos = RestorePlan::default();
     let mut additional_existing = false;
 
-    let mut process_existing = |entry: &walkdir::DirEntry| -> RusticResult<_> {
-        if entry.depth() == 0 {
-            // don't process the root dir which should be existing
-            return Ok(());
-        }
-
-        debug!("additional {}", entry.path().display());
-        if entry.file_type().is_dir() {
-            stats.dirs.additional += 1;
-        } else {
-            stats.files.additional += 1;
-        }
-        match (opts.delete, dry_run, entry.file_type().is_dir()) {
-            (true, true, true) => {
-                info!(
-                    "would have removed the additional dir: {}",
-                    entry.path().display()
-                );
-            }
-            (true, true, false) => {
-                info!(
-                    "would have removed the additional file: {}",
-                    entry.path().display()
-                );
-            }
-            (true, false, true) => {
-                if let Err(err) = dest.remove_dir(entry.path()) {
-                    error!("error removing {}: {err}", entry.path().display());
+    let next_entry = |walker: &mut walkdir::IntoIter| -> Option<DirEntry> {
+        walker
+            .inspect(|r| {
+                if let Err(err) = r {
+                    error!("Error during collection of files: {err:?}");
                 }
-            }
-            (true, false, false) => {
-                if let Err(err) = dest.remove_file(entry.path()) {
-                    error!("error removing {}: {err}", entry.path().display());
-                }
-            }
-            (false, _, _) => {
-                additional_existing = true;
-            }
-        }
-
-        Ok(())
+            })
+            .find_map(Result::ok)
     };
+
+    let mut process_existing =
+        |walker: &mut walkdir::IntoIter, entry: &DirEntry| -> RusticResult<Option<DirEntry>> {
+            if entry.depth() == 0 {
+                // don't process the root dir which should be existing
+                return Ok(next_entry(walker));
+            }
+
+            debug!("additional {}", entry.path().display());
+            let is_dir = entry.file_type().is_dir();
+            if is_dir {
+                stats.dirs.additional += 1;
+            } else {
+                stats.files.additional += 1;
+            }
+            match (opts.delete, dry_run, is_dir) {
+                (true, true, true) => {
+                    info!(
+                        "would have removed the additional dir: {}",
+                        entry.path().display()
+                    );
+                }
+                (true, true, false) => {
+                    info!(
+                        "would have removed the additional file: {}",
+                        entry.path().display()
+                    );
+                }
+                (true, false, true) => {
+                    if let Err(err) = dest.remove_dir(entry.path()) {
+                        error!("error removing {}: {err}", entry.path().display());
+                    }
+                }
+                (true, false, false) => {
+                    if let Err(err) = dest.remove_file(entry.path()) {
+                        error!("error removing {}: {err}", entry.path().display());
+                    }
+                }
+                (false, _, _) => {
+                    additional_existing = true;
+                }
+            }
+
+            // don't descend into extra dirs
+            if is_dir {
+                walker.skip_current_dir();
+            }
+            Ok(next_entry(walker))
+        };
 
     let mut process_node = |path: &PathBuf, node: &Node, exists: bool| -> RusticResult<_> {
         match node.node_type {
@@ -256,15 +272,6 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
         .sort_by_file_name()
         .into_iter();
 
-    let next_entry = |walker: &mut walkdir::IntoIter| -> Option<walkdir::DirEntry> {
-        loop {
-            match walker.next()? {
-                Ok(entry) => return Some(entry),
-                Err(err) => error!("Error during collection of files: {err:?}"),
-            }
-        }
-    };
-
     let mut next_dst = next_entry(&mut walker);
 
     let mut next_node = node_streamer.next().transpose()?;
@@ -274,22 +281,12 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
             (None, None) => break,
 
             (Some(destination), None) => {
-                process_existing(destination)?;
-                // don't descend into extra dirs
-                if destination.file_type().is_dir() {
-                    walker.skip_current_dir();
-                }
-                next_dst = next_entry(&mut walker);
+                next_dst = process_existing(&mut walker, destination)?;
             }
             (Some(destination), Some((path, node))) => {
                 match destination.path().cmp(&dest.path(path)) {
                     Ordering::Less => {
-                        process_existing(destination)?;
-                        // don't descend into extra dirs
-                        if destination.file_type().is_dir() {
-                            walker.skip_current_dir();
-                        }
-                        next_dst = next_entry(&mut walker);
+                        next_dst = process_existing(&mut walker, destination)?;
                     }
                     Ordering::Equal => {
                         // process existing node
@@ -298,14 +295,11 @@ pub(crate) fn collect_and_prepare<S: IndexedFull>(
                             || node.is_special()
                         {
                             // if types do not match, first remove the existing file
-                            process_existing(destination)?;
-                            // removed a dir — don't descend into its former children
-                            if destination.file_type().is_dir() {
-                                walker.skip_current_dir();
-                            }
+                            next_dst = process_existing(&mut walker, destination)?;
+                        } else {
+                            next_dst = next_entry(&mut walker);
                         }
                         process_node(path, node, true)?;
-                        next_dst = next_entry(&mut walker);
                         next_node = node_streamer.next().transpose()?;
                     }
                     Ordering::Greater => {


### PR DESCRIPTION
When restoring to a destination that already contains files (e.g., `rustic restore <snap> /Volumes/Macintosh/`), the destination scan walks the **entire** destination tree before writing anything. This causes two problems:

1. **Permission errors on unrelated directories** — the walk enters directories the user may not have permission to read (e.g., `/System`, `/private`), causing the restore to fail even in `--dry-run` mode.
2. **`--delete` affects unrelated files** — because the snapshot only has sparse entries in ancestor directories (single path components leading to the backed-up content), the merge-join treats everything else in those directories as "additional" and tries to delete it.

This PR replaces the `ignore::WalkBuilder` full-tree walk with a `walkdir::WalkDir` walk that applies two layers of filtering:

1. **Descent filtering** — only enter directories that are part of the snapshot or are ancestors leading to snapshot directories. Irrelevant subtrees are skipped entirely via `skip_current_dir()`, avoiding permission errors and unnecessary I/O.

2. **Content scope filtering** — only yield entries to the merge-join if their parent directory is "within content scope" (the parent or an ancestor directly contains non-directory entries in the snapshot). Entries in pass-through ancestor directories are only yielded if they are navigation targets, preventing `--delete` from removing unrelated files in directories the snapshot only traverses as path components.

### Behavioral changes

- **Without `--delete`:** Restoring to a broad destination (e.g., a whole volume) no longer fails with permission errors on unrelated directories. The "additional entries" warning and stats now only reflect entries within the snapshot's content scope.
- **With `--delete`:** Only files within directories the snapshot fully describes are eligible for deletion. Files in pass-through ancestor directories (e.g., `.VolumeIcon.icns` at the volume root) are no longer touched.