### PR TITLE
perf: parallelize blob fetch in dump command

### DIFF
--- a/crates/core/src/commands/dump.rs
+++ b/crates/core/src/commands/dump.rs
@@ -1,17 +1,58 @@
-use std::io::Write;
+use std::{io::Write, num::NonZeroUsize, thread::scope};
+
+use derive_setters::Setters;
+use pariter::IteratorExt;
 
 use crate::{
     backend::node::{Node, NodeType},
-    blob::{BlobId, BlobType},
+    blob::{BlobId, BlobType, DataId},
     error::{ErrorKind, RusticError, RusticResult},
     repository::{IndexedFull, Repository},
 };
+
+pub(crate) mod constants {
+    /// Minimum blob count required to enable parallel fetching.
+    ///
+    /// For files that decompose into a single blob there is nothing to overlap,
+    /// so we stay on the sequential path to avoid the worker-thread setup cost.
+    pub(crate) const PARALLEL_DUMP_MIN_BLOBS: usize = 2;
+}
+
+/// Options for the `dump` command.
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[derive(Debug, Copy, Clone, Default, Setters)]
+#[setters(into)]
+#[non_exhaustive]
+pub struct DumpOptions {
+    /// Number of reader threads used to fetch blobs in parallel.
+    ///
+    /// `0` selects the available parallelism reported by the runtime.
+    /// `1` forces the sequential implementation.
+    #[cfg_attr(feature = "clap", clap(long, default_value = "0"))]
+    pub num_threads: u32,
+}
+
+impl DumpOptions {
+    /// Resolve the configured thread count to a concrete value.
+    ///
+    /// Returns `None` for the sequential path and `Some(n)` for `n` worker
+    /// threads.
+    fn resolved_threads(self, blob_count: usize) -> Option<NonZeroUsize> {
+        if blob_count < constants::PARALLEL_DUMP_MIN_BLOBS {
+            return None;
+        }
+        let threads = match self.num_threads {
+            0 => std::thread::available_parallelism().map_or(1, NonZeroUsize::get),
+            n => n as usize,
+        };
+        NonZeroUsize::new(threads).filter(|n| n.get() > 1)
+    }
+}
 
 /// Dumps the contents of a file.
 ///
 /// # Type Parameters
 ///
-/// * `P` - The progress bar type.
 /// * `S` - The type of the indexed tree.
 ///
 /// # Arguments
@@ -19,14 +60,18 @@ use crate::{
 /// * `repo` - The repository to read from.
 /// * `node` - The node to dump.
 /// * `w` - The writer to write to.
+/// * `opts` - The dump options to use.
 ///
 /// # Errors
 ///
 /// * If the node is not a file.
-pub(crate) fn dump<S: IndexedFull>(
+/// * If a blob cannot be fetched from the backend.
+/// * If writing to `w` fails.
+pub(crate) fn dump<S: IndexedFull + Sync>(
     repo: &Repository<S>,
     node: &Node,
     w: &mut impl Write,
+    opts: DumpOptions,
 ) -> RusticResult<()> {
     if node.node_type != NodeType::File {
         return Err(RusticError::new(
@@ -36,15 +81,55 @@ pub(crate) fn dump<S: IndexedFull>(
         .attach_context("node_type", node.node_type.to_string()));
     }
 
-    for id in node.content.as_ref().unwrap() {
+    let Some(content) = node.content.as_ref() else {
+        return Ok(());
+    };
+
+    match opts.resolved_threads(content.len()) {
+        None => dump_sequential(repo, content, w),
+        Some(threads) => dump_parallel(repo, content, w, threads),
+    }
+}
+
+fn dump_sequential<S: IndexedFull>(
+    repo: &Repository<S>,
+    content: &[DataId],
+    w: &mut impl Write,
+) -> RusticResult<()> {
+    for id in content {
         let data = repo.get_blob_cached(&BlobId::from(**id), BlobType::Data)?;
-        w.write_all(&data).map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::InputOutput,
-                "Failed to write data to writer.",
-                err,
-            )
-        })?;
+        write_blob(w, &data)?;
     }
     Ok(())
+}
+
+fn dump_parallel<S: IndexedFull + Sync>(
+    repo: &Repository<S>,
+    content: &[DataId],
+    w: &mut impl Write,
+    threads: NonZeroUsize,
+) -> RusticResult<()> {
+    let threads = threads.get();
+
+    scope(|s| -> RusticResult<()> {
+        content
+            .iter()
+            .map(|id| BlobId::from(**id))
+            .parallel_map_scoped_custom(
+                s,
+                |b| b.threads(threads).buffer_size(threads * 2),
+                |id| repo.get_blob_cached(&id, BlobType::Data),
+            )
+            .try_for_each(|res| write_blob(w, &res?))
+    })
+}
+
+fn write_blob(w: &mut impl Write, data: &[u8]) -> RusticResult<()> {
+    w.write_all(data).map_err(|err| {
+        RusticError::with_source(
+            ErrorKind::InputOutput,
+            "Failed to write data to writer.",
+            err,
+        )
+    })
 }

--- a/crates/core/src/commands/dump.rs
+++ b/crates/core/src/commands/dump.rs
@@ -1,6 +1,5 @@
-use std::{io::Write, num::NonZeroUsize, thread::scope};
+use std::{io::Write, thread::scope};
 
-use derive_setters::Setters;
 use pariter::IteratorExt;
 
 use crate::{
@@ -9,45 +8,6 @@ use crate::{
     error::{ErrorKind, RusticError, RusticResult},
     repository::{IndexedFull, Repository},
 };
-
-pub(crate) mod constants {
-    /// Minimum blob count required to enable parallel fetching.
-    ///
-    /// For files that decompose into a single blob there is nothing to overlap,
-    /// so we stay on the sequential path to avoid the worker-thread setup cost.
-    pub(crate) const PARALLEL_DUMP_MIN_BLOBS: usize = 2;
-}
-
-/// Options for the `dump` command.
-#[cfg_attr(feature = "clap", derive(clap::Parser))]
-#[derive(Debug, Copy, Clone, Default, Setters)]
-#[setters(into)]
-#[non_exhaustive]
-pub struct DumpOptions {
-    /// Number of reader threads used to fetch blobs in parallel.
-    ///
-    /// `0` selects the available parallelism reported by the runtime.
-    /// `1` forces the sequential implementation.
-    #[cfg_attr(feature = "clap", clap(long, default_value = "0"))]
-    pub num_threads: u32,
-}
-
-impl DumpOptions {
-    /// Resolve the configured thread count to a concrete value.
-    ///
-    /// Returns `None` for the sequential path and `Some(n)` for `n` worker
-    /// threads.
-    fn resolved_threads(self, blob_count: usize) -> Option<NonZeroUsize> {
-        if blob_count < constants::PARALLEL_DUMP_MIN_BLOBS {
-            return None;
-        }
-        let threads = match self.num_threads {
-            0 => std::thread::available_parallelism().map_or(1, NonZeroUsize::get),
-            n => n as usize,
-        };
-        NonZeroUsize::new(threads).filter(|n| n.get() > 1)
-    }
-}
 
 /// Dumps the contents of a file.
 ///
@@ -60,7 +20,6 @@ impl DumpOptions {
 /// * `repo` - The repository to read from.
 /// * `node` - The node to dump.
 /// * `w` - The writer to write to.
-/// * `opts` - The dump options to use.
 ///
 /// # Errors
 ///
@@ -71,7 +30,6 @@ pub(crate) fn dump<S: IndexedFull + Sync>(
     repo: &Repository<S>,
     node: &Node,
     w: &mut impl Write,
-    opts: DumpOptions,
 ) -> RusticResult<()> {
     if node.node_type != NodeType::File {
         return Err(RusticError::new(
@@ -85,10 +43,18 @@ pub(crate) fn dump<S: IndexedFull + Sync>(
         return Ok(());
     };
 
-    match opts.resolved_threads(content.len()) {
-        None => dump_sequential(repo, content, w),
-        Some(threads) => dump_parallel(repo, content, w, threads),
+    // Single-blob files have nothing to overlap, so skip the worker setup.
+    if content.len() < 2 {
+        return dump_sequential(repo, content, w);
     }
+
+    scope(|s| -> RusticResult<()> {
+        content
+            .iter()
+            .map(|id| BlobId::from(**id))
+            .parallel_map_scoped(s, |id| repo.get_blob_cached(&id, BlobType::Data))
+            .try_for_each(|res| write_blob(w, &res?))
+    })
 }
 
 fn dump_sequential<S: IndexedFull>(
@@ -101,27 +67,6 @@ fn dump_sequential<S: IndexedFull>(
         write_blob(w, &data)?;
     }
     Ok(())
-}
-
-fn dump_parallel<S: IndexedFull + Sync>(
-    repo: &Repository<S>,
-    content: &[DataId],
-    w: &mut impl Write,
-    threads: NonZeroUsize,
-) -> RusticResult<()> {
-    let threads = threads.get();
-
-    scope(|s| -> RusticResult<()> {
-        content
-            .iter()
-            .map(|id| BlobId::from(**id))
-            .parallel_map_scoped_custom(
-                s,
-                |b| b.threads(threads).buffer_size(threads * 2),
-                |id| repo.get_blob_cached(&id, BlobType::Data),
-            )
-            .try_for_each(|res| write_blob(w, &res?))
-    })
 }
 
 fn write_blob(w: &mut impl Write, data: &[u8]) -> RusticResult<()> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -151,7 +151,6 @@ pub use crate::{
         check::{CheckOptions, CheckResults, ReadSubsetOption},
         config::ConfigOptions,
         copy::CopySnapshot,
-        dump::DumpOptions,
         forget::{ForgetGroup, ForgetGroups, ForgetSnapshot, KeepOptions},
         key::KeyOptions,
         prune::{LimitOption, PruneOptions, PrunePlan, PruneStats},

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -151,6 +151,7 @@ pub use crate::{
         check::{CheckOptions, CheckResults, ReadSubsetOption},
         config::ConfigOptions,
         copy::CopySnapshot,
+        dump::DumpOptions,
         forget::{ForgetGroup, ForgetGroups, ForgetSnapshot, KeepOptions},
         key::KeyOptions,
         prune::{LimitOption, PruneOptions, PrunePlan, PruneStats},

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -42,7 +42,6 @@ use crate::{
         check::{CheckOptions, CheckResults, check_repository},
         config::{ConfigOptions, save_config_hot},
         copy::CopySnapshot,
-        dump::DumpOptions,
         key::{KeyOptions, add_current_key_to_repo},
         prune::{PruneOptions, PrunePlan, prune_repository},
         repair::{
@@ -1745,9 +1744,6 @@ impl<S: IndexedFull> Repository<S> {
 
     /// Dump a [`Node`] using the given writer.
     ///
-    /// Equivalent to [`Self::dump_with_opts`] with [`DumpOptions::default`],
-    /// which fetches blobs in parallel using the available parallelism.
-    ///
     /// # Arguments
     ///
     /// * `node` - The node to dump
@@ -1764,34 +1760,7 @@ impl<S: IndexedFull> Repository<S> {
     where
         S: Sync,
     {
-        commands::dump::dump(self, node, w, DumpOptions::default())
-    }
-
-    /// Dump a [`Node`] using the given writer and dump options.
-    ///
-    /// # Arguments
-    ///
-    /// * `node` - The node to dump
-    /// * `w` - The writer to use
-    /// * `opts` - The dump options to use
-    ///
-    /// # Errors
-    ///
-    /// * If the node is not a file.
-    ///
-    /// # Note
-    ///
-    /// Currently, only regular file nodes are supported.
-    pub fn dump_with_opts(
-        &self,
-        node: &Node,
-        w: &mut impl Write,
-        opts: &DumpOptions,
-    ) -> RusticResult<()>
-    where
-        S: Sync,
-    {
-        commands::dump::dump(self, node, w, *opts)
+        commands::dump::dump(self, node, w)
     }
 
     /// Prepare the restore.

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -42,6 +42,7 @@ use crate::{
         check::{CheckOptions, CheckResults, check_repository},
         config::{ConfigOptions, save_config_hot},
         copy::CopySnapshot,
+        dump::DumpOptions,
         key::{KeyOptions, add_current_key_to_repo},
         prune::{PruneOptions, PrunePlan, prune_repository},
         repair::{
@@ -1744,6 +1745,9 @@ impl<S: IndexedFull> Repository<S> {
 
     /// Dump a [`Node`] using the given writer.
     ///
+    /// Equivalent to [`Self::dump_with_opts`] with [`DumpOptions::default`],
+    /// which fetches blobs in parallel using the available parallelism.
+    ///
     /// # Arguments
     ///
     /// * `node` - The node to dump
@@ -1752,12 +1756,42 @@ impl<S: IndexedFull> Repository<S> {
     /// # Errors
     ///
     /// * If the node is not a file.
-    ///  
+    ///
     /// # Note
     ///
     /// Currently, only regular file nodes are supported.
-    pub fn dump(&self, node: &Node, w: &mut impl Write) -> RusticResult<()> {
-        commands::dump::dump(self, node, w)
+    pub fn dump(&self, node: &Node, w: &mut impl Write) -> RusticResult<()>
+    where
+        S: Sync,
+    {
+        commands::dump::dump(self, node, w, DumpOptions::default())
+    }
+
+    /// Dump a [`Node`] using the given writer and dump options.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The node to dump
+    /// * `w` - The writer to use
+    /// * `opts` - The dump options to use
+    ///
+    /// # Errors
+    ///
+    /// * If the node is not a file.
+    ///
+    /// # Note
+    ///
+    /// Currently, only regular file nodes are supported.
+    pub fn dump_with_opts(
+        &self,
+        node: &Node,
+        w: &mut impl Write,
+        opts: &DumpOptions,
+    ) -> RusticResult<()>
+    where
+        S: Sync,
+    {
+        commands::dump::dump(self, node, w, *opts)
     }
 
     /// Prepare the restore.

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -28,6 +28,7 @@ mod integration {
     mod check;
     mod chunker;
     mod copy;
+    mod dump;
     mod find;
     mod hotcold;
     mod key;

--- a/crates/core/tests/integration/dump.rs
+++ b/crates/core/tests/integration/dump.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use tempfile::tempdir;
 
 use rustic_core::{
-    BackupOptions, ConfigOptions, DumpOptions, IndexedFullStatus, PathList, Repository,
+    BackupOptions, ConfigOptions, IndexedFullStatus, PathList, Repository,
     repofile::{Chunker, SnapshotFile},
 };
 
@@ -48,8 +48,9 @@ fn backup_single_file(
 }
 
 #[rstest]
-fn test_dump_parallel_matches_sequential(set_up_repo: Result<RepoOpen>) -> Result<()> {
-    let (repo, snapshot_path) = backup_single_file(set_up_repo?, "file.bin", &payload(64 * 1024))?;
+fn test_dump_multi_blob_matches_source(set_up_repo: Result<RepoOpen>) -> Result<()> {
+    let data = payload(64 * 1024);
+    let (repo, snapshot_path) = backup_single_file(set_up_repo?, "file.bin", &data)?;
     let node = repo.node_from_snapshot_path(&snapshot_path, |_| true)?;
 
     // Sanity: the configured chunker must have produced more than one blob,
@@ -60,17 +61,9 @@ fn test_dump_parallel_matches_sequential(set_up_repo: Result<RepoOpen>) -> Resul
         "expected the test file to span multiple blobs, got {blob_count}",
     );
 
-    let dump = |opts: DumpOptions| -> Result<Vec<u8>> {
-        let mut out = Vec::new();
-        repo.dump_with_opts(&node, &mut out, &opts)?;
-        Ok(out)
-    };
-
-    let sequential = dump(DumpOptions::default().num_threads(1u32))?;
-    let parallel = dump(DumpOptions::default().num_threads(8u32))?;
-
-    assert_eq!(sequential, payload(64 * 1024));
-    assert_eq!(parallel, sequential);
+    let mut out = Vec::new();
+    repo.dump(&node, &mut out)?;
+    assert_eq!(out, data);
     Ok(())
 }
 

--- a/crates/core/tests/integration/dump.rs
+++ b/crates/core/tests/integration/dump.rs
@@ -1,0 +1,87 @@
+use std::{fs, io::Write, path::PathBuf, str::FromStr};
+
+use anyhow::Result;
+use bytesize::ByteSize;
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+use tempfile::tempdir;
+
+use rustic_core::{
+    BackupOptions, ConfigOptions, DumpOptions, IndexedFullStatus, PathList, Repository,
+    repofile::{Chunker, SnapshotFile},
+};
+
+use super::{RepoOpen, set_up_repo};
+
+/// Build a deterministic byte payload of the requested length.
+fn payload(len: usize) -> Vec<u8> {
+    (0..len)
+        .map(|i| u8::try_from(i % 251).expect("251 always fits in u8"))
+        .collect()
+}
+
+/// Backup a single file with the given content into `repo`, configuring the
+/// fixed-size chunker so the file reliably splits into multiple blobs.
+///
+/// Returns the repository in the [`IndexedFullStatus`] state along with the
+/// snapshot path that points at the backed-up file.
+fn backup_single_file(
+    repo: RepoOpen,
+    name: &str,
+    data: &[u8],
+) -> Result<(Repository<IndexedFullStatus>, String)> {
+    let dir = tempdir()?;
+    let file_path = dir.path().join(name);
+    fs::File::create(&file_path)?.write_all(data)?;
+
+    let mut repo = repo.to_indexed_ids()?;
+    let config = ConfigOptions::default()
+        .set_chunker(Chunker::FixedSize)
+        .set_chunk_size(ByteSize(4096));
+    assert!(repo.apply_config(&config)?);
+
+    let paths = PathList::from_iter([file_path]);
+    let opts = BackupOptions::default().as_path(PathBuf::from_str(name)?);
+    let _snapshot = repo.backup(&opts, &paths, SnapshotFile::default())?;
+
+    Ok((repo.to_indexed()?, format!("latest:{name}")))
+}
+
+#[rstest]
+fn test_dump_parallel_matches_sequential(set_up_repo: Result<RepoOpen>) -> Result<()> {
+    let (repo, snapshot_path) = backup_single_file(set_up_repo?, "file.bin", &payload(64 * 1024))?;
+    let node = repo.node_from_snapshot_path(&snapshot_path, |_| true)?;
+
+    // Sanity: the configured chunker must have produced more than one blob,
+    // otherwise the parallel path is never taken.
+    let blob_count = node.content.as_ref().map_or(0, Vec::len);
+    assert!(
+        blob_count > 1,
+        "expected the test file to span multiple blobs, got {blob_count}",
+    );
+
+    let dump = |opts: DumpOptions| -> Result<Vec<u8>> {
+        let mut out = Vec::new();
+        repo.dump_with_opts(&node, &mut out, &opts)?;
+        Ok(out)
+    };
+
+    let sequential = dump(DumpOptions::default().num_threads(1u32))?;
+    let parallel = dump(DumpOptions::default().num_threads(8u32))?;
+
+    assert_eq!(sequential, payload(64 * 1024));
+    assert_eq!(parallel, sequential);
+    Ok(())
+}
+
+#[rstest]
+fn test_dump_default_options_match_source(set_up_repo: Result<RepoOpen>) -> Result<()> {
+    let data = payload(32 * 1024);
+    let (repo, snapshot_path) = backup_single_file(set_up_repo?, "file.bin", &data)?;
+    let node = repo.node_from_snapshot_path(&snapshot_path, |_| true)?;
+
+    let mut out = Vec::new();
+    repo.dump(&node, &mut out)?;
+    assert_eq!(out, data);
+    Ok(())
+}


### PR DESCRIPTION
Extends #12. PR #106 added `get_blob_cached` to amortize repeat fetches, but `commands::dump::dump` still walks its blob list serially:

https://github.com/rustic-rs/rustic_core/blob/main/crates/core/src/commands/dump.rs#L39-L48

so on high-latency backends the throughput is bounded by per-blob round-trip time regardless of how many concurrent connections the backend itself permits.

This routes the loop through `pariter::IteratorExt::parallel_map_scoped_custom`, the same family of ordered parallel-map primitives the archiver and packer already rely on, so fetches overlap N-wide while the writer stays single-threaded. Output ordering is preserved bit-for-bit; an integration test backs that up by chunking a 64 KiB payload into 16 fixed-size blobs and asserting that the parallel and sequential dumps both equal the source bytes exactly.

The new `DumpOptions` carries a single `num_threads: u32` field (Setters, `non_exhaustive`, gated behind the existing `clap` feature), where `0` selects `available_parallelism` and `1` forces the sequential implementation. `Repository::dump_with_opts(node, w, &DumpOptions)` joins the existing `Repository::dump(node, w)`, which keeps its signature and now defaults to `available_parallelism`. Both methods pick up an `S: Sync` bound; the in-tree `IndexedFullStatus` already satisfies it, so all in-tree call sites compile unchanged. Files that decompose into a single blob take a sequential short-circuit and pay none of the worker setup cost.

Out of scope: `dump --archive tar`, `--archive targz`, `mount`, and `webdav` go through `vfs::OpenFile::read_at` rather than `commands::dump::dump`. The serial blob-fetch shape is the same, but the consumer there is pull-based (the tar writer calls `Read::read` repeatedly with small buffers), so the right fix is read-ahead prefetching rather than the push-style overlap this PR uses. That wants its own change.

## Results

Same caveat as #487: not a proper benchmark suite. An `InMemoryBackend` wrapper sleeps a configurable duration on every `read_full`/`read_partial` to simulate object-store round-trip latency. 4 MiB file, 64 KiB fixed-size chunks (64 blobs), fresh `Repository` per measurement so the in-process blob cache is cold for every run.

```
    latency      sequential        parallel  speedup
        0ms     2124 MB/s        1497 MB/s    0.70x
        1ms       54 MB/s         699 MB/s   12.89x
        5ms       12 MB/s         180 MB/s   15.15x
       20ms        3 MB/s          48 MB/s   15.65x
       50ms        1 MB/s          19 MB/s   15.72x
      100ms      0.6 MB/s           9 MB/s   15.81x
```

For any non-trivial backend latency the speedup converges to the worker count. A thread sweep at 20 ms latency confirms linear scaling: 1, 2, 4, 8, 16, 32 threads gives 1.0x, 2.0x, 4.0x, 7.9x, 15.8x, 30.8x.

The 0 ms row is the cost. Against a free backend (warm page cache, in-memory backend, repeat dumps that already hit `get_blob_cached`) the parallel path runs at roughly 60-70% of sequential because thread setup and channel passing dominate when the per-blob fetch is itself near-instant. The single-blob short-circuit covers the smallest files, so the regression is bounded to multi-blob files on near-zero-latency backends, which is the case where dump throughput wasn't the bottleneck to begin with.