### PR TITLE
optimize: Use Smallvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,6 +4360,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.9",
  "shell-words",
+ "smallvec",
  "strum",
  "tar",
  "tempfile",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -102,6 +102,7 @@ itertools = "0.14.0"
 jiff = { version = "0.2.19", features = ["logging", "serde"] }
 quick_cache = "0.6.18"
 shell-words = "1.1.1"
+smallvec = { version = "1.15.1", features = ["union"] }
 strum = { version = "0.28.0", features = ["derive"] }
 zstd = "0.13.3"
 

--- a/crates/core/src/blob.rs
+++ b/crates/core/src/blob.rs
@@ -5,6 +5,7 @@ use std::{cmp::Ordering, num::NonZeroU32};
 
 use enum_map::{Enum, EnumMap};
 use serde_derive::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
 
 use crate::define_new_id_struct;
 
@@ -154,7 +155,7 @@ impl BlobLocation {
 pub struct BlobLocations<T> {
     pub offset: u32,
     pub length: u32,
-    pub blobs: Vec<(BlobLocation, T)>,
+    pub blobs: SmallVec<[(BlobLocation, T); 1]>,
 }
 
 impl<T: Eq + PartialEq> PartialOrd<Self> for BlobLocations<T> {
@@ -178,7 +179,7 @@ impl<T> BlobLocations<T> {
         Self {
             offset: location.offset,
             length: location.length,
-            blobs: vec![(location, target)],
+            blobs: smallvec![(location, target)],
         }
     }
     pub fn can_coalesce(&self, other: &Self) -> bool {

--- a/crates/core/src/commands/restore.rs
+++ b/crates/core/src/commands/restore.rs
@@ -3,6 +3,7 @@
 use derive_setters::Setters;
 use jiff::Timestamp;
 use log::{debug, error, info, trace, warn};
+use smallvec::SmallVec;
 
 use std::{cmp::Ordering, collections::BTreeMap, path::PathBuf, sync::Mutex};
 
@@ -28,8 +29,8 @@ pub(crate) mod constants {
     pub(crate) const MAX_READER_THREADS_NUM: usize = 20;
 }
 
-type RestoreInfo = BTreeMap<(PackId, BlobLocation), Vec<FileLocation>>;
 type Filenames = Vec<PathBuf>;
+type RestoreInfo = BTreeMap<(PackId, BlobLocation), SmallVec<[FileLocation; 1]>>;
 
 #[allow(clippy::struct_excessive_bools)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
@@ -470,7 +471,7 @@ pub(crate) fn set_metadata(
 struct PackInfo {
     pack_id: PackId,
     from_file: Option<(usize, u64, u32)>,
-    locations: BlobLocations<Vec<(usize, u64)>>,
+    locations: BlobLocations<SmallVec<[(usize, u64); 1]>>,
 }
 
 impl PackInfo {
@@ -550,7 +551,7 @@ fn restore_contents<S: Open>(
                 .find(|fl| fl.matches)
                 .map(|fl| (fl.file_idx, fl.file_start, bl.data_length()));
 
-            let name_dests: Vec<_> = fls
+            let name_dests = fls
                 .iter()
                 .filter(|fl| !fl.matches)
                 .map(|fl| (fl.file_idx, fl.file_start))


### PR DESCRIPTION
Optimize `BlobLocations` for the case that this contains only a single blob - which can be ofthen the case.
In this case, this PR reduces memory allocations and size.

This affects the `restore`,  `prune` and `copy` command.