### PR TITLE
backend/opendal: enable pcloud backend feature

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -91,11 +91,11 @@ typed-path = { version = "0.12.2", optional = true }
 [target.'cfg(not(windows))'.dependencies]
 # opendal backend
 # - sftp is not supported on windows, see https://github.com/apache/incubator-opendal/issues/2963
-opendal = { version = "0.56.0", features = ["blocking", "services-b2", "services-ftp", "services-sftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
+opendal = { version = "0.56.0", features = ["blocking", "services-b2", "services-ftp", "services-sftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-pcloud", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # opendal backend
-opendal = { version = "0.56.0", features = ["blocking", "services-b2", "services-ftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
+opendal = { version = "0.56.0", features = ["blocking", "services-b2", "services-ftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-pcloud", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/backend/tests/fixtures/opendal/pcloud.toml
+++ b/crates/backend/tests/fixtures/opendal/pcloud.toml
@@ -1,0 +1,6 @@
+path = "pcloud"
+[options]
+endpoint = "https://api.pcloud.com"
+username = "user@example.com"
+password = "secret"
+root = "/path/to/repo"


### PR DESCRIPTION
## Summary
Enable OpenDAL pCloud support in `rustic_core` so pCloud repositories can be used natively through the OpenDAL backend.

## Motivation
`rustic_core` already supports multiple OpenDAL-backed services. This change enables pCloud in the backend feature set to make pCloud repositories usable without external workarounds.

## Changes
- Enable the pCloud service feature in backend OpenDAL dependency configuration.

## Dependency / Release Note (Important)
- This PR depends on the corresponding OpenDAL pCloud fixes and performance improvements:
  - apache/opendal#7617
- For production usage in rustic/rustic_core, this should be merged together with (or after) an OpenDAL release that includes those changes.

## Validation
- Compiles and links with the updated OpenDAL pCloud implementation.
- Rebased onto current `main` and conflict-resolved in `crates/backend/Cargo.toml` (keeping upstream `opendal = 0.56.0` updates while adding `services-pcloud`).
- `cargo check -p rustic_backend --features opendal` passes.

## Notes
- This PR is intentionally minimal and scoped to feature enablement in `rustic_core`.
- Runtime behavior improvements are implemented in the corresponding OpenDAL PR.