### PR TITLE
feat: stdio protocol between warmup program and rustic (#1782)

### DIFF
--- a/crates/core/src/repository/warm_up.rs
+++ b/crates/core/src/repository/warm_up.rs
@@ -1,12 +1,13 @@
-use std::io;
-use std::process::Command;
-use std::thread::sleep;
+use std::io::{self, BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::thread::{self, sleep};
 
 use backon::{BlockingRetryable, ExponentialBuilder};
 
 use itertools::Itertools;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use rayon::ThreadPoolBuilder;
+use serde::Deserialize;
 
 use crate::{
     CommandInput, Id, Progress,
@@ -26,6 +27,70 @@ pub(super) mod constants {
 
     /// Initial delay for exponential backoff for spawning commands.
     pub(crate) const INITIAL_DELAY: Duration = Duration::from_millis(10);
+}
+
+const PACK_PROGRESS_TYPE: &str = "pack-progress";
+
+/// A progress report emitted by a warm-up command on stdout.
+///
+/// The command must output JSON Lines. For now only `type: "pack-progress"` is supported.
+#[derive(Debug, Deserialize)]
+struct PackProgress {
+    /// The message type. Must be `"pack-progress"`.
+    #[serde(rename = "type")]
+    ty: String,
+
+    /// The number of packs the command reports as warm within this invocation.
+    warm: u64,
+}
+
+/// Read JSON Lines progress reports from the warm-up command's stdout.
+///
+/// Increments the shared progress bar by the delta between the last reported value and the new
+/// one. Reports are ignored if they are not of type `pack-progress` or if `warm` is not larger than
+/// the current value (progress is strictly increasing).
+///
+/// The `invocation_size` is used to clamp the reported value; a command must never report more
+/// packs than it received.
+///
+/// Returns the final `warm` value reported by the command, or `0` if it emitted no protocol lines.
+fn read_progress_output<R: io::Read>(reader: R, invocation_size: u64, progress: &Progress) -> u64 {
+    let reader = BufReader::new(reader);
+    let mut current: u64 = 0;
+
+    for line in reader.lines().map_while(Result::ok) {
+        let report: PackProgress = match serde_json::from_str(&line) {
+            Ok(report) => report,
+            Err(_) => {
+                // For debugging/auditing purposes, log non-JSON stdout lines at info level.
+                // Empty lines are ignored.
+                if !line.is_empty() {
+                    info!("[warmup] {line}");
+                }
+                continue;
+            }
+        };
+
+        if report.ty != PACK_PROGRESS_TYPE {
+            continue;
+        }
+
+        let warm = report.warm.min(invocation_size);
+        if warm > current {
+            progress.inc(warm - current);
+            current = warm;
+        }
+    }
+
+    current
+}
+
+/// On successful completion of a warm-up invocation, advance the progress bar by the packs that
+/// were not already reported via the protocol.
+fn finalize_progress(current: u64, invocation_size: u64, progress: &Progress) {
+    if current < invocation_size {
+        progress.inc(invocation_size - current);
+    }
 }
 
 /// Configuration for retrying executing a command that the operating system reports is busy.
@@ -177,7 +242,6 @@ fn warm_up_command<S>(
 /// * `tpe` - The filetype of the ids.
 /// * `batch` - The ids in this batch.
 /// * `command` - The command to execute.
-/// * `pb` - The progress bar to use.
 /// * `ty` - The type of warm-up operation.
 /// * `backend` - The backend to get id paths from.
 /// * `progress` - The progress bar to update.
@@ -194,49 +258,61 @@ fn warm_up_batch_singular(
     progress: &Progress,
 ) -> RusticResult<()> {
     let file_type = tpe.to_string();
-    let children: Vec<_> = batch
-        .iter()
-        .map(|id| {
-            let path = backend.warmup_path(tpe, id);
-            let id = id.to_hex().to_string();
 
-            let args: Vec<_> = command
-                .args()
-                .iter()
-                .map(|c| {
-                    c.replace("%tpe", &file_type)
-                        .replace("%id", &id)
-                        .replace("%path", &path)
-                })
-                .collect();
+    // Spawn a reader for each child's stdout while the commands run concurrently.
+    let mut readers = Vec::with_capacity(batch.len());
 
-            debug!("spawning {command:?} for id {id:?}...");
+    for id in batch {
+        let path = backend.warmup_path(tpe, id);
+        let id = id.to_hex().to_string();
 
-            let child = (|| Command::new(command.command()).args(&args).spawn())
-                .retry(execute_cmd_retry())
-                .when(|err| err.kind() == io::ErrorKind::ExecutableFileBusy)
-                .notify(|err, duration| {
-                    debug!("spawn failed with ETXTBSY, retrying in {duration:?}: {err}");
-                })
-                .call()
-                .map_err(|err| {
-                    RusticError::with_source(
-                        ErrorKind::ExternalCommand,
-                        "Error in spawning warm-up command `{command}`.",
-                        err,
-                    )
-                    .attach_context("command", command.to_string())
-                    .attach_context("id", &id)
-                    .attach_context("type", format!("{ty:?}"))
-                })?;
+        let args: Vec<_> = command
+            .args()
+            .iter()
+            .map(|c| {
+                c.replace("%tpe", &file_type)
+                    .replace("%id", &id)
+                    .replace("%path", &path)
+            })
+            .collect();
 
-            Ok((child, id))
+        debug!("spawning {command:?} for id {id:?}...");
+
+        let mut child = (|| {
+            Command::new(command.command())
+                .args(&args)
+                .stdout(Stdio::piped())
+                .spawn()
         })
-        .collect::<RusticResult<Vec<_>>>()?;
+        .retry(execute_cmd_retry())
+        .when(|err| err.kind() == io::ErrorKind::ExecutableFileBusy)
+        .notify(|err, duration| {
+            debug!("spawn failed with ETXTBSY, retrying in {duration:?}: {err}");
+        })
+        .call()
+        .map_err(|err| {
+            RusticError::with_source(
+                ErrorKind::ExternalCommand,
+                "Error in spawning warm-up command `{command}`.",
+                err,
+            )
+            .attach_context("command", command.to_string())
+            .attach_context("id", &id)
+            .attach_context("type", format!("{ty:?}"))
+        })?;
+
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let progress = progress.clone();
+        let handle = thread::spawn(move || {
+            // Singular mode handles one pack per command instance.
+            read_progress_output(stdout, 1, &progress)
+        });
+        readers.push((child, id, handle));
+    }
 
     let mut failed_ids = Vec::new();
 
-    for (mut child, id) in children {
+    for (mut child, id, handle) in readers {
         debug!("waiting for warm-up command for id {id}...");
 
         let status = child.wait().map_err(|err| {
@@ -250,11 +326,22 @@ fn warm_up_batch_singular(
             .attach_context("type", format!("{ty:?}"))
         })?;
 
+        let current = handle.join().map_err(|err| {
+            let msg = format!("Thread panicked: {:?}", err);
+            RusticError::new(
+                ErrorKind::ExternalCommand,
+                format!("Error joining warm-up command thread: {msg}"),
+            )
+            .attach_context("command", command.to_string())
+            .attach_context("id", &id)
+            .attach_context("type", format!("{ty:?}"))
+        })?;
+
         if !status.success() {
             failed_ids.push((id, status));
+        } else {
+            finalize_progress(current, 1, progress);
         }
-
-        progress.inc(1);
     }
 
     if !failed_ids.is_empty() {
@@ -325,22 +412,55 @@ fn warm_up_batch_plural(
 
     debug!("calling {command:?} with {} id(s)...", batch.len());
 
-    let status = (|| Command::new(command.command()).args(&args).status())
-        .retry(execute_cmd_retry())
-        .when(|err| err.kind() == io::ErrorKind::ExecutableFileBusy)
-        .notify(|err, duration| {
-            debug!("spawn failed with ETXTBSY, retrying in {duration:?}: {err}");
-        })
-        .call()
-        .map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::ExternalCommand,
-                "Error in executing warm-up command `{command}`.",
-                err,
-            )
-            .attach_context("command", command.to_string())
-            .attach_context("type", format!("{ty:?}"))
-        })?;
+    let invocation_size = batch.len() as u64;
+
+    let mut child = (|| {
+        Command::new(command.command())
+            .args(&args)
+            .stdout(Stdio::piped())
+            .spawn()
+    })
+    .retry(execute_cmd_retry())
+    .when(|err| err.kind() == io::ErrorKind::ExecutableFileBusy)
+    .notify(|err, duration| {
+        debug!("spawn failed with ETXTBSY, retrying in {duration:?}: {err}");
+    })
+    .call()
+    .map_err(|err| {
+        RusticError::with_source(
+            ErrorKind::ExternalCommand,
+            "Error in executing warm-up command `{command}`.",
+            err,
+        )
+        .attach_context("command", command.to_string())
+        .attach_context("type", format!("{ty:?}"))
+    })?;
+
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let progress_for_thread = progress.clone();
+    let handle =
+        thread::spawn(move || read_progress_output(stdout, invocation_size, &progress_for_thread));
+
+    let status = child.wait().map_err(|err| {
+        RusticError::with_source(
+            ErrorKind::ExternalCommand,
+            "Error waiting for warm-up command `{command}`.",
+            err,
+        )
+        .attach_context("command", command.to_string())
+        .attach_context("type", format!("{ty:?}"))
+    })?;
+
+    let current = handle.join().map_err(|err| {
+        let msg = format!("Thread panicked: {:?}", err);
+        RusticError::new(
+            ErrorKind::ExternalCommand,
+            format!("Error joining warm-up command thread: {msg}"),
+        )
+        .attach_context("command", command.to_string())
+        .attach_context("batch_size", batch.len().to_string())
+        .attach_context("type", format!("{ty:?}"))
+    })?;
 
     if !status.success() {
         return Err(RusticError::new(
@@ -356,7 +476,8 @@ fn warm_up_batch_plural(
         .attach_context("type", format!("{ty:?}")));
     }
 
-    progress.inc(batch.len() as u64);
+    finalize_progress(current, invocation_size, progress);
+
     Ok(())
 }
 

--- a/crates/core/src/repository/warm_up.rs
+++ b/crates/core/src/repository/warm_up.rs
@@ -59,16 +59,15 @@ fn read_progress_output<R: io::Read>(reader: R, invocation_size: u64, progress: 
     let mut current: u64 = 0;
 
     for line in reader.lines().map_while(Result::ok) {
-        let report: PackProgress = match serde_json::from_str(&line) {
-            Ok(report) => report,
-            Err(_) => {
-                // For debugging/auditing purposes, log non-JSON stdout lines at info level.
-                // Empty lines are ignored.
-                if !line.is_empty() {
-                    info!("[warmup] {line}");
-                }
-                continue;
+        let report: PackProgress = if let Ok(report) = serde_json::from_str(&line) {
+            report
+        } else {
+            // For debugging/auditing purposes, log non-JSON stdout lines at info level.
+            // Empty lines are ignored.
+            if !line.is_empty() {
+                info!("[warmup] {line}");
             }
+            continue;
         };
 
         if report.ty != PACK_PROGRESS_TYPE {
@@ -260,55 +259,56 @@ fn warm_up_batch_singular(
     let file_type = tpe.to_string();
 
     // Spawn a reader for each child's stdout while the commands run concurrently.
-    let mut readers = Vec::with_capacity(batch.len());
+    let readers: Vec<_> = batch
+        .iter()
+        .map(|id| {
+            let path = backend.warmup_path(tpe, id);
+            let id = id.to_hex().to_string();
 
-    for id in batch {
-        let path = backend.warmup_path(tpe, id);
-        let id = id.to_hex().to_string();
+            let args: Vec<_> = command
+                .args()
+                .iter()
+                .map(|c| {
+                    c.replace("%tpe", &file_type)
+                        .replace("%id", &id)
+                        .replace("%path", &path)
+                })
+                .collect();
 
-        let args: Vec<_> = command
-            .args()
-            .iter()
-            .map(|c| {
-                c.replace("%tpe", &file_type)
-                    .replace("%id", &id)
-                    .replace("%path", &path)
+            debug!("spawning {command:?} for id {id:?}...");
+
+            let mut child = (|| {
+                Command::new(command.command())
+                    .args(&args)
+                    .stdout(Stdio::piped())
+                    .spawn()
             })
-            .collect();
+            .retry(execute_cmd_retry())
+            .when(|err| err.kind() == io::ErrorKind::ExecutableFileBusy)
+            .notify(|err, duration| {
+                debug!("spawn failed with ETXTBSY, retrying in {duration:?}: {err}");
+            })
+            .call()
+            .map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::ExternalCommand,
+                    "Error in spawning warm-up command `{command}`.",
+                    err,
+                )
+                .attach_context("command", command.to_string())
+                .attach_context("id", &id)
+                .attach_context("type", format!("{ty:?}"))
+            })?;
 
-        debug!("spawning {command:?} for id {id:?}...");
-
-        let mut child = (|| {
-            Command::new(command.command())
-                .args(&args)
-                .stdout(Stdio::piped())
-                .spawn()
+            let stdout = child.stdout.take().expect("stdout was piped");
+            let progress = progress.clone();
+            let handle = thread::spawn(move || {
+                // Singular mode handles one pack per command instance.
+                read_progress_output(stdout, 1, &progress)
+            });
+            Ok((child, id, handle))
         })
-        .retry(execute_cmd_retry())
-        .when(|err| err.kind() == io::ErrorKind::ExecutableFileBusy)
-        .notify(|err, duration| {
-            debug!("spawn failed with ETXTBSY, retrying in {duration:?}: {err}");
-        })
-        .call()
-        .map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::ExternalCommand,
-                "Error in spawning warm-up command `{command}`.",
-                err,
-            )
-            .attach_context("command", command.to_string())
-            .attach_context("id", &id)
-            .attach_context("type", format!("{ty:?}"))
-        })?;
-
-        let stdout = child.stdout.take().expect("stdout was piped");
-        let progress = progress.clone();
-        let handle = thread::spawn(move || {
-            // Singular mode handles one pack per command instance.
-            read_progress_output(stdout, 1, &progress)
-        });
-        readers.push((child, id, handle));
-    }
+        .collect::<RusticResult<_>>()?;
 
     let mut failed_ids = Vec::new();
 
@@ -327,7 +327,7 @@ fn warm_up_batch_singular(
         })?;
 
         let current = handle.join().map_err(|err| {
-            let msg = format!("Thread panicked: {:?}", err);
+            let msg = format!("Thread panicked: {err:?}");
             RusticError::new(
                 ErrorKind::ExternalCommand,
                 format!("Error joining warm-up command thread: {msg}"),
@@ -337,10 +337,10 @@ fn warm_up_batch_singular(
             .attach_context("type", format!("{ty:?}"))
         })?;
 
-        if !status.success() {
-            failed_ids.push((id, status));
-        } else {
+        if status.success() {
             finalize_progress(current, 1, progress);
+        } else {
+            failed_ids.push((id, status));
         }
     }
 
@@ -452,7 +452,7 @@ fn warm_up_batch_plural(
     })?;
 
     let current = handle.join().map_err(|err| {
-        let msg = format!("Thread panicked: {:?}", err);
+        let msg = format!("Thread panicked: {err:?}");
         RusticError::new(
             ErrorKind::ExternalCommand,
             format!("Error joining warm-up command thread: {msg}"),

--- a/crates/core/tests/warm_up.rs
+++ b/crates/core/tests/warm_up.rs
@@ -5,6 +5,7 @@ use std::{
     io::Read,
     path::Path,
     sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use anyhow::Result;
@@ -12,7 +13,10 @@ use rstest::rstest;
 use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
 
-use rustic_core::{CommandInput, Id, RepositoryBackends, RepositoryOptions, repofile::PackId};
+use rustic_core::{
+    CommandInput, Id, Progress, ProgressBars, ProgressType, RepositoryBackends, RepositoryOptions,
+    RusticProgress, repofile::PackId,
+};
 use rustic_testing::backend::in_memory_backend::InMemoryBackend;
 
 // Test constants
@@ -59,31 +63,7 @@ done
 "#,
     );
 
-    // Write the script and sync to disk to avoid "Text file busy" errors
-    {
-        use std::io::Write;
-        let mut file = File::create(&script_path)?;
-        file.write_all(script_content.as_bytes())?;
-        file.sync_all()?;
-        // Explicitly drop the file handle before setting permissions
-        drop(file);
-    }
-
-    // Make script executable
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&script_path)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&script_path, perms)?;
-
-        // Sync the parent directory to ensure metadata changes are committed
-        if let Some(parent) = script_path.parent()
-            && let Ok(dir_file) = File::open(parent)
-        {
-            let _ = dir_file.sync_all();
-        }
-    }
+    write_executable_script(&script_path, &script_content)?;
 
     let command: CommandInput = script_path.to_string_lossy().to_string().parse()?;
 
@@ -100,6 +80,33 @@ fn create_test_script(log_dir: &Path) -> Result<(tempfile::TempDir, CommandInput
 #[cfg(not(windows))]
 fn create_failing_script(log_dir: &Path) -> Result<(tempfile::TempDir, CommandInput)> {
     create_test_script_with_exit_code(log_dir, 1)
+}
+
+/// Write a script to disk and mark it executable.
+#[cfg(not(windows))]
+fn write_executable_script(path: &Path, content: &str) -> Result<()> {
+    {
+        use std::io::Write;
+        let mut file = File::create(path)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+
+        if let Some(parent) = path.parent()
+            && let Ok(dir_file) = File::open(parent)
+        {
+            let _ = dir_file.sync_all();
+        }
+    }
+
+    Ok(())
 }
 
 /// Helper to parse log files in a directory and extract call count and arguments
@@ -711,6 +718,174 @@ fn test_warm_up_backend_path_mode() -> Result<()> {
             "Third part should be 64-character hex ID"
         );
     }
+
+    Ok(())
+}
+
+/// Progress implementation that records total increments.
+#[derive(Debug, Clone)]
+struct RecordingProgressBars {
+    pos: Arc<AtomicU64>,
+}
+
+impl ProgressBars for RecordingProgressBars {
+    fn progress(&self, _progress_type: ProgressType, _prefix: &str) -> Progress {
+        Progress::new(RecordingProgress {
+            pos: self.pos.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RecordingProgress {
+    pos: Arc<AtomicU64>,
+}
+
+impl RusticProgress for RecordingProgress {
+    fn is_hidden(&self) -> bool {
+        false
+    }
+    fn set_length(&self, _len: u64) {}
+    fn set_title(&self, _title: &str) {}
+    fn inc(&self, inc: u64) {
+        let _ = self.pos.fetch_add(inc, Ordering::Relaxed);
+    }
+    fn finish(&self) {}
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_warm_up_progress_protocol_plural() -> Result<()> {
+    let dir = tempdir()?;
+    let script_path = dir.path().join("progress.sh");
+
+    let script_content = r#"#!/usr/bin/env bash
+warm=0
+for arg in "$@"; do
+  warm=$((warm+1))
+  echo "{\"type\":\"pack-progress\",\"warm\":$warm}"
+done
+"#;
+    write_executable_script(&script_path, script_content)?;
+
+    let cmd_str = format!("{} %ids", script_path.to_string_lossy());
+    let command: CommandInput = cmd_str.parse()?;
+
+    let pos = Arc::new(AtomicU64::new(0));
+    let repo = rustic_core::Repository::new_with_progress(
+        &RepositoryOptions::default()
+            .warm_up_command(command)
+            .warm_up_batch(5usize),
+        &RepositoryBackends::new(Arc::new(InMemoryBackend::new()), None),
+        RecordingProgressBars { pos: pos.clone() },
+    )?;
+
+    let num_packs = 12;
+    let pack_ids = create_test_ids(num_packs);
+
+    repo.warm_up(pack_ids.iter().copied())?;
+
+    assert_eq!(pos.load(Ordering::Relaxed), num_packs as u64);
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_warm_up_progress_protocol_singular() -> Result<()> {
+    let dir = tempdir()?;
+    let script_path = dir.path().join("progress.sh");
+
+    let script_content = r#"#!/usr/bin/env bash
+echo '{"type":"pack-progress","warm":1}'
+"#;
+    write_executable_script(&script_path, script_content)?;
+
+    let cmd_str = format!("{} %id", script_path.to_string_lossy());
+    let command: CommandInput = cmd_str.parse()?;
+
+    let pos = Arc::new(AtomicU64::new(0));
+    let repo = rustic_core::Repository::new_with_progress(
+        &RepositoryOptions::default()
+            .warm_up_command(command)
+            .warm_up_batch(1usize),
+        &RepositoryBackends::new(Arc::new(InMemoryBackend::new()), None),
+        RecordingProgressBars { pos: pos.clone() },
+    )?;
+
+    let num_packs = 5;
+    let pack_ids = create_test_ids(num_packs);
+
+    repo.warm_up(pack_ids.iter().copied())?;
+
+    assert_eq!(pos.load(Ordering::Relaxed), num_packs as u64);
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_warm_up_progress_protocol_fallback() -> Result<()> {
+    let dir = tempdir()?;
+    let script_path = dir.path().join("silent.sh");
+
+    let script_content = "#!/usr/bin/env bash\n";
+    write_executable_script(&script_path, script_content)?;
+
+    let cmd_str = format!("{} %ids", script_path.to_string_lossy());
+    let command: CommandInput = cmd_str.parse()?;
+
+    let pos = Arc::new(AtomicU64::new(0));
+    let repo = rustic_core::Repository::new_with_progress(
+        &RepositoryOptions::default()
+            .warm_up_command(command)
+            .warm_up_batch(4usize),
+        &RepositoryBackends::new(Arc::new(InMemoryBackend::new()), None),
+        RecordingProgressBars { pos: pos.clone() },
+    )?;
+
+    let num_packs = 9;
+    let pack_ids = create_test_ids(num_packs);
+
+    repo.warm_up(pack_ids.iter().copied())?;
+
+    assert_eq!(pos.load(Ordering::Relaxed), num_packs as u64);
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_warm_up_progress_protocol_ignores_invalid_lines() -> Result<()> {
+    let dir = tempdir()?;
+    let script_path = dir.path().join("noisy.sh");
+
+    let script_content = r#"#!/usr/bin/env bash
+echo 'this is not json'
+echo '{}'
+echo '{"type":"other","warm":100}'
+echo '{"type":"pack-progress","warm":999}'
+"#;
+    write_executable_script(&script_path, script_content)?;
+
+    let cmd_str = format!("{} %ids", script_path.to_string_lossy());
+    let command: CommandInput = cmd_str.parse()?;
+
+    let pos = Arc::new(AtomicU64::new(0));
+    let repo = rustic_core::Repository::new_with_progress(
+        &RepositoryOptions::default()
+            .warm_up_command(command)
+            .warm_up_batch(3usize),
+        &RepositoryBackends::new(Arc::new(InMemoryBackend::new()), None),
+        RecordingProgressBars { pos: pos.clone() },
+    )?;
+
+    let num_packs = 3;
+    let pack_ids = create_test_ids(num_packs);
+
+    repo.warm_up(pack_ids.iter().copied())?;
+
+    assert_eq!(pos.load(Ordering::Relaxed), num_packs as u64);
 
     Ok(())
 }


### PR DESCRIPTION
[JSON Lines](https://jsonlines.org). Each line must be a single JSON object. The object must contain at least a `type` field that identifies the message.

```json
{"type":"pack-progress","warm":42}
```

A `pack-progress` message tells *rustic* how many of the packs in the current command invocation are expected to be warm now.

| Field | Type    | Meaning |
|-------|---------|---------|
| `type` | string | Must be exactly `"pack-progress"`. |
| `warm` | integer | Number of packs from this invocation expected to be warm. |

*rustic* advances its shared progress bar using these updates.

`warm` is **monotonically non-decreasing** within a single invocation. If your program reports a lower value than a previous report, the lower value is ignored.

If your command exits successfully but never emits a `pack-progress` message, *rustic* still counts the whole invocation as complete. If it reports some progress but the final `warm` is less than the number of packs in the invocation, *rustic* counts the remaining packs as done when the command exits.

So the protocol is strictly an enhancement: emitting it gives users accurate progress; omitting it preserves the pre-protocol behavior of jumping from 0% to 100%.

*rustic* now captures and parses warmup program's stdout. This is a change from older versions, where the warm-up command's stdout was inherited and printed directly to the terminal.

Any stdout line that is not valid JSON is logged by *rustic* at info level, prefixed with `[warmup]`, so that it is still available for debugging. Empty lines are ignored.

I plan to update rustic's documentation with this, once this change is accepted.