### PR TITLE
feat(packer): upload pack files concurrently

### DIFF
--- a/crates/core/src/archiver.rs
+++ b/crates/core/src/archiver.rs
@@ -83,13 +83,22 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
         config: &ConfigFile,
         parent: Parent,
         mut snap: SnapshotFile,
+        upload_concurrency: usize,
     ) -> RusticResult<Self> {
         let indexer = Indexer::new(be.clone()).into_shared();
         let mut summary = snap.summary.take().unwrap_or_default();
         summary.backup_start = Zoned::now();
 
-        let file_archiver = FileArchiver::new(be.clone(), index, indexer.clone(), config)?;
-        let tree_archiver = TreeArchiver::new(be.clone(), index, indexer.clone(), config, summary)?;
+        let file_archiver =
+            FileArchiver::new(be.clone(), index, indexer.clone(), config, upload_concurrency)?;
+        let tree_archiver = TreeArchiver::new(
+            be.clone(),
+            index,
+            indexer.clone(),
+            config,
+            summary,
+            upload_concurrency,
+        )?;
 
         Ok(Self {
             file_archiver,

--- a/crates/core/src/archiver/file_archiver.rs
+++ b/crates/core/src/archiver/file_archiver.rs
@@ -61,10 +61,11 @@ impl<'a, BE: DecryptWriteBackend, I: ReadGlobalIndex> FileArchiver<'a, BE, I> {
         index: &'a I,
         indexer: SharedIndexer<BE>,
         config: &ConfigFile,
+        upload_concurrency: usize,
     ) -> RusticResult<Self> {
         let pack_sizer =
             PackSizer::from_config(config, BlobType::Data, index.total_size(BlobType::Data));
-        let data_packer = Packer::new(be, BlobType::Data, indexer, pack_sizer)?;
+        let data_packer = Packer::new(be, BlobType::Data, indexer, pack_sizer, upload_concurrency)?;
 
         Ok(Self {
             index,

--- a/crates/core/src/archiver/tree_archiver.rs
+++ b/crates/core/src/archiver/tree_archiver.rs
@@ -65,10 +65,11 @@ impl<'a, BE: DecryptWriteBackend, I: ReadGlobalIndex> TreeArchiver<'a, BE, I> {
         indexer: SharedIndexer<BE>,
         config: &ConfigFile,
         summary: SnapshotSummary,
+        upload_concurrency: usize,
     ) -> RusticResult<Self> {
         let pack_sizer =
             PackSizer::from_config(config, BlobType::Tree, index.total_size(BlobType::Tree));
-        let tree_packer = Packer::new(be, BlobType::Tree, indexer, pack_sizer)?;
+        let tree_packer = Packer::new(be, BlobType::Tree, indexer, pack_sizer, upload_concurrency)?;
 
         Ok(Self {
             tree: Tree::new(),

--- a/crates/core/src/blob/packer.rs
+++ b/crates/core/src/blob/packer.rs
@@ -241,12 +241,14 @@ impl<BE: DecryptWriteBackend> Packer<BE> {
         blob_type: BlobType,
         indexer: SharedIndexer<BE>,
         pack_sizer: PackSizer,
+        upload_concurrency: usize,
     ) -> RusticResult<Self> {
         let raw_packer = Arc::new(RwLock::new(RawPacker::new(
             be.clone(),
             blob_type,
             indexer.clone(),
             pack_sizer,
+            upload_concurrency,
         )));
 
         let (tx, rx) = bounded(0);
@@ -446,15 +448,22 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
     /// * `indexer` - The indexer to write to.
     /// * `config` - The config file.
     /// * `total_size` - The total size of the pack file.
-    fn new(be: BE, blob_type: BlobType, indexer: SharedIndexer<BE>, pack_sizer: PackSizer) -> Self {
+    fn new(
+        be: BE,
+        blob_type: BlobType,
+        indexer: SharedIndexer<BE>,
+        pack_sizer: PackSizer,
+        upload_concurrency: usize,
+    ) -> Self {
         let file_writer = Some(Actor::new(
             FileWriterHandle {
                 be: be.clone(),
                 indexer,
                 cacheable: blob_type.is_cacheable(),
             },
-            1,
-            1,
+            // Buffer enough packs to keep every upload worker fed.
+            upload_concurrency,
+            upload_concurrency,
         ));
 
         Self {
@@ -748,8 +757,9 @@ impl Actor {
     fn new<BE: DecryptWriteBackend>(
         fwh: FileWriterHandle<BE>,
         queue_len: usize,
-        _par: usize,
+        par: usize,
     ) -> Self {
+        let par = par.max(1);
         let (tx, rx) = bounded(queue_len);
         let (finish_tx, finish_rx) = bounded::<RusticResult<()>>(0);
 
@@ -763,7 +773,11 @@ impl Actor {
                         (file, PackId::from(id), index)
                     })
                     .readahead_scoped(scope)
-                    .map(|load| fwh.process(load))
+                    // Upload up to `par` packs concurrently. `process` is the
+                    // backend `write_bytes` call, so this opens `par` backend
+                    // connections instead of one. Results are yielded in input
+                    // order, so the first upload error still propagates.
+                    .parallel_map_scoped_custom(scope, |o| o.threads(par), |load| fwh.process(load))
                     .readahead_scoped(scope)
                     .try_for_each(|index| fwh.index(index?));
                 _ = finish_tx.send(status);
@@ -879,8 +893,9 @@ impl<BE: DecryptFullBackend> BlobCopier<BE> {
         blob_type: BlobType,
         indexer: SharedIndexer<BE>,
         pack_sizer: PackSizer,
+        upload_concurrency: usize,
     ) -> RusticResult<Self> {
-        let packer = Packer::new(be_dst, blob_type, indexer, pack_sizer)?;
+        let packer = Packer::new(be_dst, blob_type, indexer, pack_sizer, upload_concurrency)?;
         Ok(Self {
             be_src,
             packer,

--- a/crates/core/src/blob/tree/modify.rs
+++ b/crates/core/src/blob/tree/modify.rs
@@ -84,11 +84,23 @@ pub struct TreeModifier<'a, BE: DecryptWriteBackend, I: ReadGlobalIndex> {
 }
 
 impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> TreeModifier<'a, BE, I> {
-    pub fn new(be: &'a BE, index: &'a I, config: &ConfigFile, dry_run: bool) -> RusticResult<Self> {
+    pub fn new(
+        be: &'a BE,
+        index: &'a I,
+        config: &ConfigFile,
+        dry_run: bool,
+        upload_concurrency: usize,
+    ) -> RusticResult<Self> {
         let indexer = Indexer::new(be.clone()).into_shared();
         let pack_sizer =
             PackSizer::from_config(config, BlobType::Tree, index.total_size(BlobType::Tree));
-        let packer = Packer::new(be.clone(), BlobType::Tree, indexer.clone(), pack_sizer)?;
+        let packer = Packer::new(
+            be.clone(),
+            BlobType::Tree,
+            indexer.clone(),
+            pack_sizer,
+            upload_concurrency,
+        )?;
 
         Ok(Self {
             be,

--- a/crates/core/src/blob/tree/rewrite.rs
+++ b/crates/core/src/blob/tree/rewrite.rs
@@ -133,8 +133,9 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Rewriter<'a, BE, I> {
         config: &ConfigFile,
         opts: &RewriteTreesOptions,
         dry_run: bool,
+        upload_concurrency: usize,
     ) -> RusticResult<Self> {
-        let modifier = TreeModifier::new(be, index, config, dry_run)?;
+        let modifier = TreeModifier::new(be, index, config, dry_run, upload_concurrency)?;
         let visitor = RewriteVisitor::new(opts)?;
         Ok(Self { modifier, visitor })
     }

--- a/crates/core/src/commands/backup.rs
+++ b/crates/core/src/commands/backup.rs
@@ -284,7 +284,14 @@ where
 
     let be = DryRunBackend::new(repo.dbe().clone(), opts.dry_run);
     info!("starting to backup {backup_paths:?} ...");
-    let archiver = Archiver::new(be, index, repo.config(), parent, snap)?;
+    let archiver = Archiver::new(
+        be,
+        index,
+        repo.config(),
+        parent,
+        snap,
+        repo.upload_concurrency(),
+    )?;
     let p = repo.progress_bytes("backing up...");
 
     archiver.archive(

--- a/crates/core/src/commands/copy.rs
+++ b/crates/core/src/commands/copy.rs
@@ -102,6 +102,7 @@ pub(crate) fn copy<'a, R: IndexedFull, S: IndexedIds>(
         BlobType::Data,
         indexer.clone(),
         pack_sizer,
+        repo_dest.upload_concurrency(),
     )?;
     let data_blobs: Vec<_> = data_ids
         .into_iter()
@@ -126,6 +127,7 @@ pub(crate) fn copy<'a, R: IndexedFull, S: IndexedIds>(
         BlobType::Tree,
         indexer.clone(),
         pack_sizer,
+        repo_dest.upload_concurrency(),
     )?;
 
     let trees: Vec<_> = tree_ids

--- a/crates/core/src/commands/merge.rs
+++ b/crates/core/src/commands/merge.rs
@@ -111,6 +111,7 @@ pub(crate) fn merge_trees<S: IndexedTree>(
         BlobType::Tree,
         indexer.clone(),
         pack_sizer,
+        repo.upload_concurrency(),
     )?;
 
     let save = |tree: Tree| -> RusticResult<_> {

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -1387,6 +1387,7 @@ pub(crate) fn prune_repository<S: Open>(
             BlobType::Tree,
             indexer.clone(),
             pack_sizer[BlobType::Tree],
+            repo.upload_concurrency(),
         )?;
 
         let data_repacker = BlobCopier::new(
@@ -1395,6 +1396,7 @@ pub(crate) fn prune_repository<S: Open>(
             BlobType::Data,
             indexer.clone(),
             pack_sizer[BlobType::Data],
+            repo.upload_concurrency(),
         )?;
 
         // write new pack files and index files

--- a/crates/core/src/commands/repair/snapshots.rs
+++ b/crates/core/src/commands/repair/snapshots.rs
@@ -174,7 +174,8 @@ pub(crate) fn repair_snapshots<S: IndexedFull>(
     }
 
     let mut state = RepairState::new(opts, repo.index());
-    let modifier = TreeModifier::new(be, repo.index(), config_file, dry_run)?;
+    let modifier =
+        TreeModifier::new(be, repo.index(), config_file, dry_run, repo.upload_concurrency())?;
 
     for mut snap in snapshots {
         let snap_id = snap.id;

--- a/crates/core/src/commands/rewrite.rs
+++ b/crates/core/src/commands/rewrite.rs
@@ -59,6 +59,7 @@ pub(crate) fn rewrite_snapshots_and_trees<S: IndexedFull>(
         repo.config(),
         tree_opts,
         opts.dry_run,
+        repo.upload_concurrency(),
     )?;
 
     let snapshots: Vec<_> = snapshots

--- a/crates/core/src/repository.rs
+++ b/crates/core/src/repository.rs
@@ -144,7 +144,21 @@ pub struct RepositoryOptions {
     #[cfg_attr(feature = "clap", clap(long, global = true))]
     #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
     pub warm_up_batch: Option<usize>,
+
+    /// Number of pack files to upload concurrently when writing to the backend
+    /// (backup, copy, repack). Each in-flight upload holds a full pack in
+    /// memory, so peak memory scales with this value. It is tuned for network
+    /// throughput (a single connection cannot saturate a high-latency link),
+    /// not CPU cores. Defaults to 8.
+    #[cfg_attr(feature = "clap", clap(long, global = true, value_name = "N"))]
+    #[cfg_attr(feature = "merge", merge(strategy = conflate::option::overwrite_none))]
+    pub upload_concurrency: Option<usize>,
 }
+
+/// Default number of pack files uploaded concurrently.
+///
+/// See [`RepositoryOptions::upload_concurrency`].
+pub(crate) const DEFAULT_UPLOAD_CONCURRENCY: usize = 8;
 
 #[derive(Debug, Clone)]
 /// A `Repository` allows all kind of actions to be performed.
@@ -260,6 +274,15 @@ impl<S> Repository<S> {
     /// Start a new progress, which is hidden
     pub fn progress_hidden(&self) -> Progress {
         Progress::new(HiddenProgress)
+    }
+
+    /// The number of pack files to upload concurrently, with the default
+    /// applied. See [`RepositoryOptions::upload_concurrency`].
+    pub(crate) fn upload_concurrency(&self) -> usize {
+        self.opts
+            .upload_concurrency
+            .unwrap_or(DEFAULT_UPLOAD_CONCURRENCY)
+            .max(1)
     }
 
     /// Start a new progress spinner. Note that this progress doesn't get a length and is not advanced, only finished.

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -38,6 +38,7 @@ mod integration {
     mod restore;
     mod rewrite;
     mod snapshots;
+    mod upload;
     mod vfs;
     use super::*;
 }

--- a/crates/core/tests/integration/upload.rs
+++ b/crates/core/tests/integration/upload.rs
@@ -1,0 +1,261 @@
+//! Exercises the parallel pack-file upload path in `blob::packer`.
+//!
+//! The writer actor uploads several packs concurrently. These tests force many
+//! small packs (far more than the upload concurrency) and then verify, end to
+//! end, that every pack actually landed and that the data round-trips
+//! bit-for-bit — i.e. the concurrent uploads and the finalize barrier are
+//! correct.
+
+use std::{
+    fs,
+    path::PathBuf,
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use anyhow::Result;
+use bytes::Bytes;
+use bytesize::ByteSize;
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+use tempfile::{TempDir, tempdir};
+
+use rustic_core::{
+    BackupOptions, CheckOptions, ConfigOptions, Credentials, ErrorKind, FileType, Id, KeyOptions,
+    LocalDestination, LsOptions, OpenStatus, ReadBackend, Repository, RepositoryBackends,
+    RepositoryOptions, RestoreOptions, RusticError, RusticResult, WriteBackend,
+    repofile::{MasterKey, PackId, SnapshotFile},
+};
+use rustic_testing::backend::in_memory_backend::InMemoryBackend;
+
+use super::RepoOpen;
+
+/// A backend that delegates to an in-memory backend but fails the
+/// `write_bytes` of the Nth (1-based) pack file, to exercise the upload error
+/// path. Everything else is transparent.
+#[derive(Debug)]
+struct FailNthPackBackend {
+    inner: InMemoryBackend,
+    packs_written: AtomicUsize,
+    fail_on_pack: usize,
+}
+
+impl FailNthPackBackend {
+    fn new(fail_on_pack: usize) -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            packs_written: AtomicUsize::new(0),
+            fail_on_pack,
+        }
+    }
+}
+
+impl ReadBackend for FailNthPackBackend {
+    fn location(&self) -> String {
+        self.inner.location()
+    }
+    fn list_with_size(&self, tpe: FileType) -> RusticResult<Vec<(Id, u32)>> {
+        self.inner.list_with_size(tpe)
+    }
+    fn read_full(&self, tpe: FileType, id: &Id) -> RusticResult<Bytes> {
+        self.inner.read_full(tpe, id)
+    }
+    fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> RusticResult<Bytes> {
+        self.inner.read_partial(tpe, id, cacheable, offset, length)
+    }
+    fn warmup_path(&self, tpe: FileType, id: &Id) -> String {
+        self.inner.warmup_path(tpe, id)
+    }
+}
+
+impl WriteBackend for FailNthPackBackend {
+    fn create(&self) -> RusticResult<()> {
+        self.inner.create()
+    }
+    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
+        if tpe == FileType::Pack {
+            let n = self.packs_written.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == self.fail_on_pack {
+                return Err(RusticError::new(
+                    ErrorKind::Backend,
+                    "injected upload failure for testing",
+                ));
+            }
+        }
+        self.inner.write_bytes(tpe, id, cacheable, buf)
+    }
+    fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {
+        self.inner.remove(tpe, id, cacheable)
+    }
+}
+
+/// A tiny deterministic PRNG so we can generate incompressible, distinct file
+/// content without pulling in the `rand` crate. (Also keeps the test
+/// reproducible.)
+fn fill_pseudo_random(buf: &mut [u8], seed: u64) {
+    // splitmix64
+    let mut state = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    for chunk in buf.chunks_mut(8) {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        let bytes = z.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+}
+
+/// Init an in-memory repo with a deliberately tiny data packsize, so a modest
+/// amount of data produces many packs (well above the upload concurrency).
+///
+/// `upload_concurrency` is wired through [`RepositoryOptions`] exactly as it
+/// would be from `rustic.toml`, so this also exercises the config plumbing.
+fn small_packsize_repo(upload_concurrency: usize) -> Result<RepoOpen> {
+    let be = InMemoryBackend::new();
+    let be = RepositoryBackends::new(Arc::new(be), None);
+    let options = RepositoryOptions::default().upload_concurrency(upload_concurrency);
+    let repo: Repository<OpenStatus> = Repository::new(&options, &be)?.init(
+        &Credentials::Masterkey(MasterKey::new()),
+        &KeyOptions::default(),
+        &ConfigOptions::default()
+            // ~256 KiB packs, no growth: forces lots of small packs.
+            .set_datapack_size(Some(ByteSize::kib(256)))
+            .set_datapack_size_limit(Some(ByteSize::kib(256)))
+            .set_datapack_growfactor(Some(0)),
+    )?;
+    Ok(repo)
+}
+
+/// Write `num_files` files of `file_size` bytes of distinct pseudo-random data.
+fn make_source(num_files: usize, file_size: usize) -> Result<TempDir> {
+    let dir = tempdir()?;
+    let mut buf = vec![0u8; file_size];
+    for i in 0..num_files {
+        fill_pseudo_random(&mut buf, i as u64 + 1);
+        fs::write(dir.path().join(format!("file_{i:04}.bin")), &buf)?;
+    }
+    Ok(dir)
+}
+
+/// `backup` -> `check(read_data)` -> `restore` -> compare, with enough data to
+/// span many packs. If the parallel writer dropped, reordered, or failed to
+/// finalize any upload, `check --read-data` or the byte comparison catches it.
+///
+/// Parametrized over the upload concurrency: `1` proves the sequential edge
+/// case still round-trips, and higher values exercise the concurrent path.
+#[rstest]
+#[case(1)]
+#[case(4)]
+#[case(16)]
+fn test_parallel_upload_roundtrip(#[case] upload_concurrency: usize) -> Result<()> {
+    // 64 files x 256 KiB = 16 MiB of incompressible data. With ~256 KiB packs
+    // that is on the order of 60+ data packs vs. the upload concurrency.
+    let num_files = 64;
+    let file_size = 256 * 1024;
+    let source = make_source(num_files, file_size)?;
+    let source_paths =
+        rustic_core::PathList::from_iter(Some(source.path().to_path_buf()));
+
+    let repo = small_packsize_repo(upload_concurrency)?.to_indexed_ids()?;
+    let backup_opts = BackupOptions::default().as_path(PathBuf::from_str("src")?);
+    let snapshot = repo.backup(&backup_opts, &source_paths, SnapshotFile::default())?;
+
+    // Sanity: we really did produce many more packs than the upload
+    // concurrency (8), so the concurrent path was genuinely exercised. If this
+    // ever drops to a handful, the test has degraded and is no longer a
+    // meaningful concurrency test.
+    assert!(
+        snapshot.summary.as_ref().unwrap().data_added_files_packed > 0,
+        "expected data to be added"
+    );
+    let pack_count = repo.list::<PackId>()?.count();
+    assert!(
+        pack_count >= 16,
+        "expected many packs to exercise concurrency, got {pack_count}"
+    );
+
+    // Full integrity check including re-reading + hashing every pack.
+    let repo = repo.to_indexed()?;
+    repo.check(CheckOptions::default().read_data(true))?
+        .is_ok()?;
+
+    // Restore and compare every file byte-for-byte against the source.
+    let node = repo.node_from_snapshot_path("latest", |_| true)?;
+    let ls = repo.ls(&node, &LsOptions::default())?;
+    let restore_dir = tempdir()?;
+    let dest = LocalDestination::new(
+        restore_dir.path().to_str().unwrap(),
+        true,
+        !node.is_dir(),
+    )?;
+    let restore_opts = RestoreOptions::default();
+    let plan = repo.prepare_restore(&restore_opts, ls.clone(), &dest, false)?;
+    repo.restore(plan, &restore_opts, ls, &dest)?;
+
+    let restored_root = restore_dir.path().join("src");
+    for i in 0..num_files {
+        let name = format!("file_{i:04}.bin");
+        let original = fs::read(source.path().join(&name))?;
+        let restored = fs::read(restored_root.join(&name))?;
+        assert_eq!(original, restored, "content mismatch for {name}");
+    }
+
+    Ok(())
+}
+
+/// If a pack upload fails mid-stream while several uploads are in flight, the
+/// backup must abort with an error and must NOT commit a snapshot — otherwise a
+/// snapshot could reference a pack that never landed. This is the corruption
+/// scenario the parallel writer must not introduce.
+#[rstest]
+fn test_upload_failure_aborts_without_snapshot() -> Result<()> {
+    let source = make_source(64, 256 * 1024)?;
+    let source_paths = rustic_core::PathList::from_iter(Some(source.path().to_path_buf()));
+
+    // Fail the 3rd pack upload, with 8 uploads potentially in flight.
+    let be = FailNthPackBackend::new(3);
+    let be = RepositoryBackends::new(Arc::new(be), None);
+    let repo: Repository<OpenStatus> = Repository::new(
+        &RepositoryOptions::default().upload_concurrency(8usize),
+        &be,
+    )?
+    .init(
+        &Credentials::Masterkey(MasterKey::new()),
+        &KeyOptions::default(),
+        &ConfigOptions::default()
+            .set_datapack_size(Some(ByteSize::kib(256)))
+            .set_datapack_size_limit(Some(ByteSize::kib(256)))
+            .set_datapack_growfactor(Some(0)),
+    )?;
+    let repo = repo.to_indexed_ids()?;
+
+    let backup_opts = BackupOptions::default().as_path(PathBuf::from_str("src")?);
+    let result = repo.backup(&backup_opts, &source_paths, SnapshotFile::default());
+
+    // The backup must surface the injected error...
+    assert!(
+        result.is_err(),
+        "backup should fail when a pack upload fails"
+    );
+
+    // ...and must not have committed any snapshot referencing the missing data.
+    let snapshots = repo.get_all_snapshots()?;
+    assert!(
+        snapshots.is_empty(),
+        "no snapshot must be committed on upload failure, found {}",
+        snapshots.len()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The pack file writer (`Actor`) uploaded packs strictly one at a time: it was constructed with `par = 1` and its `par` argument was ignored, so the upload stage was a sequential `.map(|load| fwh.process(load))`. On a high-latency backend link a single connection cannot fill the pipe, so backup/copy/repack throughput was capped regardless of configuration.

Make the writer upload up to N packs concurrently by turning the upload stage into a bounded `parallel_map_scoped_custom` with an explicit thread count (tracks the network, not CPU cores). Only `write_bytes` is parallelized; hashing stays sequential and indexing stays serialized in the final `try_for_each`, so the indexer and `PackerStats` need no new synchronization. pariter yields in input order, so the finalize barrier and first-error propagation are preserved: a snapshot can never reference a pack whose upload has not completed.

Expose the concurrency as `RepositoryOptions::upload_concurrency` (`upload-concurrency` in config, `--upload-concurrency` flag), defaulting to 8, threaded through the archiver, BlobCopier, and tree modifier/rewriter.

Tests (crates/core/tests/integration/upload.rs):
- round-trip (backup -> check --read-data -> restore -> byte compare) across many packs at concurrency 1/4/16
- injected mid-stream upload failure aborts the backup without committing a snapshot

Refs rustic issues #980, #981, #1215.