### PR TITLE
feat!: refactor packer and optimize memory allocations

### DIFF
--- a/crates/backend/src/local.rs
+++ b/crates/backend/src/local.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     fs::{self, File, Metadata},
-    io::{Read, Seek, SeekFrom, Write},
+    io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -12,8 +12,8 @@ use log::{debug, error, trace, warn};
 use walkdir::WalkDir;
 
 use rustic_core::{
-    ALL_FILE_TYPES, CommandInput, ErrorKind, FileType, Id, ReadBackend, RusticError, RusticResult,
-    WriteBackend,
+    ALL_FILE_TYPES, BytesList, CommandInput, ErrorKind, FileType, Id, ReadBackend, RusticError,
+    RusticResult, WriteBackend,
 };
 
 /// A local backend.
@@ -470,19 +470,13 @@ impl WriteBackend for LocalBackend {
         tpe: FileType,
         id: &Id,
         _cacheable: bool,
-        buf: Bytes,
+        content: BytesList,
     ) -> RusticResult<()> {
-        fn write_local_file(filename: &Path, buf: &[u8]) -> RusticResult<()> {
-            let length = buf.len().try_into().map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Internal,
-                    "Failed to convert length `{length}` to u64.",
-                    err,
-                )
-                .attach_context("length", buf.len().to_string())
-                .ask_report()
-            })?;
-
+        fn write_local_file(
+            filename: &Path,
+            mut reader: impl Read,
+            length: u64,
+        ) -> RusticResult<()> {
             let mut file = fs::OpenOptions::new()
                 .create(true)
                 .truncate(true)
@@ -507,7 +501,7 @@ impl WriteBackend for LocalBackend {
                     .attach_context("path", filename.to_string_lossy())
             })?;
 
-            file.write_all(buf).map_err(|err| {
+            _ = std::io::copy(&mut reader, &mut file).map_err(|err| {
                 RusticError::with_source(
                     ErrorKind::InputOutput,
                     "Failed to write to the buffer: `{path}`. Please check the file and try again.",
@@ -526,7 +520,7 @@ impl WriteBackend for LocalBackend {
             Ok(())
         }
 
-        trace!("writing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("writing tpe: {tpe:?}, id: {id}");
         let filename = self.path(tpe, id);
 
         let parent = self.base_path(tpe, id);
@@ -545,7 +539,13 @@ impl WriteBackend for LocalBackend {
 
         // Write to temporary file
         let filename_tmp = parent.join(Self::filename(tpe, id) + "-tmp-");
-        match write_local_file(&filename_tmp, &buf) {
+        let size = content.size();
+        let reader = content.reader();
+        match write_local_file(
+            &filename_tmp,
+            reader,
+            size.try_into().expect("size too large for u64"), // should not happen
+        ) {
             Ok(file) => file,
             Err(err) => {
                 // Clean-up in case of error
@@ -585,7 +585,7 @@ impl WriteBackend for LocalBackend {
     ///
     /// * If the file could not be removed.
     fn remove(&self, tpe: FileType, id: &Id, _cacheable: bool) -> RusticResult<()> {
-        trace!("removing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("removing tpe: {tpe:?}, id: {id}");
         let filename = self.path(tpe, id);
         fs::remove_file(&filename).map_err(|err|
             RusticError::with_source(

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -21,7 +21,7 @@ use tokio::runtime::Runtime;
 use typed_path::UnixPathBuf;
 
 use rustic_core::{
-    ALL_FILE_TYPES, ErrorKind, FileType, Id, ReadBackend, ReadSource, ReadSourceEntry,
+    ALL_FILE_TYPES, BytesList, ErrorKind, FileType, Id, ReadBackend, ReadSource, ReadSourceEntry,
     ReadSourceOpen, RusticError, RusticResult, WriteBackend,
     repofile::{Node, NodeType},
 };
@@ -498,11 +498,11 @@ impl WriteBackend for OpenDALBackend {
         tpe: FileType,
         id: &Id,
         _cacheable: bool,
-        buf: Bytes,
+        content: BytesList,
     ) -> RusticResult<()> {
-        trace!("writing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("writing tpe: {tpe:?}, id: {id}");
         let filename = self.path(tpe, id);
-        _ = self.operator.write(&filename, buf).map_err(|err| {
+        _ = self.operator.write(&filename, content.into_vec()).map_err(|err| {
             RusticError::with_source(
                 ErrorKind::Backend,
                 "Writing file `{path}` failed in the backend. Please check if the given path is correct.",
@@ -524,7 +524,7 @@ impl WriteBackend for OpenDALBackend {
     /// * `id` - The id of the file.
     /// * `cacheable` - Whether the file is cacheable.
     fn remove(&self, tpe: FileType, id: &Id, _cacheable: bool) -> RusticResult<()> {
-        trace!("removing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("removing tpe: {tpe:?}, id: {id}");
         let filename = self.path(tpe, id);
         self.operator.delete(&filename).map_err(|err| {
             RusticError::with_source(

--- a/crates/backend/src/rclone.rs
+++ b/crates/backend/src/rclone.rs
@@ -376,8 +376,14 @@ impl WriteBackend for RcloneBackend {
     /// * `id` - The id of the file.
     /// * `cacheable` - Whether the data should be cached.
     /// * `buf` - The data to write.
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
-        self.rest.write_bytes(tpe, id, cacheable, buf)
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: rustic_core::BytesList,
+    ) -> RusticResult<()> {
+        self.rest.write_bytes(tpe, id, cacheable, content)
     }
 
     /// Removes the given file.

--- a/crates/backend/src/rest.rs
+++ b/crates/backend/src/rest.rs
@@ -8,12 +8,14 @@ use jiff::SignedDuration;
 use log::{trace, warn};
 use reqwest::{
     Url,
-    blocking::{Client, ClientBuilder},
+    blocking::{Body, Client, ClientBuilder},
     header::{HeaderMap, HeaderValue},
 };
 use serde::Deserialize;
 
-use rustic_core::{ErrorKind, FileType, Id, ReadBackend, RusticError, RusticResult, WriteBackend};
+use rustic_core::{
+    BytesList, ErrorKind, FileType, Id, ReadBackend, RusticError, RusticResult, WriteBackend,
+};
 
 /// joining URL failed on: `{0}`
 #[derive(thiserror::Error, Clone, Copy, Debug, displaydoc::Display)]
@@ -463,22 +465,19 @@ impl WriteBackend for RestBackend {
         tpe: FileType,
         id: &Id,
         _cacheable: bool,
-        buf: Bytes,
+        content: BytesList,
     ) -> RusticResult<()> {
-        trace!("writing tpe: {:?}, id: {}", &tpe, &id);
-        let req_builder = self
-            .client
-            .post(
-                self.url(tpe, id)
-                    .map_err(|err| construct_join_url_error(err, tpe, id, &self.url))?,
-            )
-            .body(buf);
+        trace!("writing tpe: {tpe:?}, id: {id}");
+        let url = self
+            .url(tpe, id)
+            .map_err(|err| construct_join_url_error(err, tpe, id, &self.url))?;
 
         self.retry_notify(|| {
-            // Note: try_clone() always gives Some(_) as the body is Bytes which is cloneable
-            _ = req_builder
-                .try_clone()
-                .unwrap()
+            let body = Body::new(content.clone().reader());
+            _ = self
+                .client
+                .post(url.clone())
+                .body(body)
                 .send()?
                 .error_for_status()?;
             Ok(())
@@ -498,7 +497,7 @@ impl WriteBackend for RestBackend {
     ///
     /// * If the backoff failed.
     fn remove(&self, tpe: FileType, id: &Id, _cacheable: bool) -> RusticResult<()> {
-        trace!("removing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("removing tpe: {tpe:?}, id: {id}");
         let url = self
             .url(tpe, id)
             .map_err(|err| construct_join_url_error(err, tpe, id, &self.url))?;

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -12,7 +12,7 @@ pub(crate) mod warm_up;
 
 use std::{io::Read, ops::Deref, path::PathBuf, sync::Arc};
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes, buf::Reader};
 use enum_map::Enum;
 use log::trace;
 
@@ -272,6 +272,73 @@ pub trait FindInBackend: ReadBackend {
 
 impl<T: ReadBackend> FindInBackend for T {}
 
+/// A list of Bytes - used to write to backend
+#[derive(Debug, Clone, Default)]
+pub struct BytesList(Vec<Bytes>);
+
+impl From<Bytes> for BytesList {
+    fn from(value: Bytes) -> Self {
+        Self(vec![value])
+    }
+}
+impl From<Vec<u8>> for BytesList {
+    fn from(value: Vec<u8>) -> Self {
+        Self(vec![value.into()])
+    }
+}
+
+impl BytesList {
+    /// Turn this `BytesList` into  `Vec<Bytes>`
+    #[must_use]
+    pub fn into_vec(self) -> Vec<Bytes> {
+        self.0
+    }
+
+    /// Get a `Bytes` slice
+    #[must_use]
+    pub fn slice(&self) -> &[Bytes] {
+        &self.0
+    }
+
+    /// Returns the total size of the `BytesList`
+    pub fn size(&self) -> usize {
+        self.0.iter().map(Bytes::len).sum()
+    }
+
+    /// Add new `Bytes` to the `BytesList`
+    pub fn add(&mut self, bytes: Bytes) {
+        self.0.push(bytes);
+    }
+
+    /// Turn this `BytesList` into a `Read`er
+    #[must_use]
+    pub fn reader(self) -> BytesListReader {
+        let mut remaining = self.0.into_iter();
+        let reader = remaining.next().unwrap_or_default().reader();
+        BytesListReader { remaining, reader }
+    }
+}
+
+#[derive(Debug)]
+pub struct BytesListReader {
+    remaining: std::vec::IntoIter<Bytes>,
+    reader: Reader<Bytes>,
+}
+
+impl Read for BytesListReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            match self.reader.read(buf) {
+                Ok(0) => match self.remaining.next() {
+                    None => break Ok(0),
+                    Some(bytes) => self.reader = bytes.reader(),
+                },
+                result => break result,
+            }
+        }
+    }
+}
+
 /// Trait for backends that can write.
 /// This trait is implemented by all backends that can write data.
 pub trait WriteBackend: ReadBackend {
@@ -304,7 +371,13 @@ pub trait WriteBackend: ReadBackend {
     /// # Returns
     ///
     /// The result of the write.
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()>;
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()>;
 
     /// Removes the given file.
     ///
@@ -345,7 +418,7 @@ mock! {
 
     impl WriteBackend for Backend {
         fn create(&self) -> RusticResult<()>;
-        fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()>;
+        fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, content: BytesList) -> RusticResult<()>;
         fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()>;
     }
 }
@@ -354,8 +427,14 @@ impl WriteBackend for Arc<dyn WriteBackend> {
     fn create(&self) -> RusticResult<()> {
         self.deref().create()
     }
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
-        self.deref().write_bytes(tpe, id, cacheable, buf)
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()> {
+        self.deref().write_bytes(tpe, id, cacheable, content)
     }
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {
         self.deref().remove(tpe, id, cacheable)

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fs::{self, File},
-    io::{self, Read, Seek, SeekFrom, Write},
+    io::{self, Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -12,7 +12,7 @@ use log::{trace, warn};
 use walkdir::WalkDir;
 
 use crate::{
-    backend::{FileType, ReadBackend, WriteBackend},
+    backend::{BytesList, FileType, ReadBackend, WriteBackend},
     error::{ErrorKind, RusticError, RusticResult},
     id::Id,
     repofile::configfile::RepositoryId,
@@ -105,7 +105,7 @@ impl ReadBackend for CachedBackend {
             }
             let res = self.be.read_full(tpe, id);
             if let Ok(data) = &res
-                && let Err(err) = self.cache.write_bytes(tpe, id, data)
+                && let Err(err) = self.cache.write_bytes(tpe, id, &data.clone().into())
             {
                 warn!(
                     "Error in cache backend writing {tpe:?},{id}: {}",
@@ -156,7 +156,7 @@ impl ReadBackend for CachedBackend {
             match self.be.read_full(tpe, id) {
                 Ok(data) => {
                     let range = offset as usize..(offset + length) as usize;
-                    if let Err(err) = self.cache.write_bytes(tpe, id, &data) {
+                    if let Err(err) = self.cache.write_bytes(tpe, id, &data.clone().into()) {
                         warn!(
                             "Error in cache backend writing {tpe:?},{id}: {}",
                             err.display_log()
@@ -200,16 +200,22 @@ impl WriteBackend for CachedBackend {
     /// * `id` - The id of the file.
     /// * `cacheable` - Whether the file is cacheable.
     /// * `buf` - The data to write.
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()> {
         if (cacheable || tpe.is_cacheable())
-            && let Err(err) = self.cache.write_bytes(tpe, id, &buf)
+            && let Err(err) = self.cache.write_bytes(tpe, id, &content)
         {
             warn!(
                 "Error in cache backend writing {tpe:?},{id}: {}",
                 err.display_log()
             );
         }
-        self.be.write_bytes(tpe, id, cacheable, buf)
+        self.be.write_bytes(tpe, id, cacheable, content)
     }
 
     /// Removes the given file.
@@ -430,7 +436,7 @@ impl Cache {
     ///
     /// * If the file could not be read.
     pub fn read_full(&self, tpe: FileType, id: &Id) -> RusticResult<Option<Bytes>> {
-        trace!("cache reading tpe: {:?}, id: {}", &tpe, &id);
+        trace!("cache reading tpe: {tpe:?}, id: {id}");
 
         let path = self.path(tpe, id);
 
@@ -470,10 +476,7 @@ impl Cache {
         offset: u32,
         length: u32,
     ) -> RusticResult<Option<Bytes>> {
-        trace!(
-            "cache reading tpe: {:?}, id: {}, offset: {}",
-            &tpe, &id, &offset
-        );
+        trace!("cache reading tpe: {tpe:?}, id: {id}, offset: {offset}");
 
         let path = self.path(tpe, id);
 
@@ -537,8 +540,8 @@ impl Cache {
     /// # Errors
     ///
     /// * If the file could not be written.
-    pub fn write_bytes(&self, tpe: FileType, id: &Id, buf: &Bytes) -> RusticResult<()> {
-        fn write_local_file(filename: &Path, buf: &[u8]) -> RusticResult<()> {
+    pub fn write_bytes(&self, tpe: FileType, id: &Id, content: &BytesList) -> RusticResult<()> {
+        fn write_local_file(filename: &Path, mut reader: impl Read) -> RusticResult<()> {
             let mut file = fs::OpenOptions::new()
                 .create(true)
                 .truncate(true)
@@ -553,7 +556,7 @@ impl Cache {
                     .attach_context("path", filename.to_string_lossy())
                 })?;
 
-            file.write_all(buf).map_err(|err| {
+            _ = io::copy(&mut reader, &mut file).map_err(|err| {
                 RusticError::with_source(
                     ErrorKind::InputOutput,
                     "Failed to write to the buffer: `{path}`.",
@@ -564,7 +567,7 @@ impl Cache {
             Ok(())
         }
 
-        trace!("cache writing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("cache writing tpe: {tpe:?}, id: {id}");
 
         let dir = self.dir(tpe, id);
 
@@ -582,7 +585,7 @@ impl Cache {
 
         let filename = self.path(tpe, id);
         let filename_tmp = dir.join(id.to_hex().to_string() + "-tmp-");
-        match write_local_file(&filename_tmp, buf) {
+        match write_local_file(&filename_tmp, content.clone().reader()) {
             Ok(file) => file,
             Err(err) => {
                 // Clean-up in case of error
@@ -616,7 +619,7 @@ impl Cache {
     ///
     /// * If the file could not be removed.
     pub fn remove(&self, tpe: FileType, id: &Id) -> RusticResult<()> {
-        trace!("cache writing tpe: {:?}, id: {}", &tpe, &id);
+        trace!("cache writing tpe: {tpe:?}, id: {id}");
         let filename = self.path(tpe, id);
         fs::remove_file(&filename).map_err(|err| {
             RusticError::with_source(

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -8,7 +8,7 @@ use zstd::stream::{copy_encode, decode_all, encode_all};
 pub use zstd::compression_level_range;
 
 use crate::{
-    Progress,
+    BytesList, Progress,
     backend::{FileType, ReadBackend, WriteBackend},
     blob::BlobLocation,
     crypto::{CryptoKey, hasher::hash},
@@ -674,8 +674,14 @@ impl<C: CryptoKey> WriteBackend for DecryptBackend<C> {
         self.be.create()
     }
 
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
-        self.be.write_bytes(tpe, id, cacheable, buf)
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()> {
+        self.be.write_bytes(tpe, id, cacheable, content)
     }
 
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {

--- a/crates/core/src/backend/dry_run.rs
+++ b/crates/core/src/backend/dry_run.rs
@@ -3,7 +3,7 @@ use zstd::decode_all;
 
 use crate::{
     backend::{
-        FileType, ReadBackend, WriteBackend,
+        BytesList, FileType, ReadBackend, WriteBackend,
         decrypt::{DecryptFullBackend, DecryptReadBackend, DecryptWriteBackend},
     },
     error::{ErrorKind, RusticError, RusticResult},
@@ -159,11 +159,17 @@ impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
         }
     }
 
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()> {
         if self.dry_run {
             Ok(())
         } else {
-            self.be.write_bytes(tpe, id, cacheable, buf)
+            self.be.write_bytes(tpe, id, cacheable, content)
         }
     }
 

--- a/crates/core/src/backend/hotcold.rs
+++ b/crates/core/src/backend/hotcold.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use crate::{
-    backend::{FileType, ReadBackend, WriteBackend},
+    backend::{BytesList, FileType, ReadBackend, WriteBackend},
     error::RusticResult,
     id::Id,
 };
@@ -87,11 +87,18 @@ impl WriteBackend for HotColdBackend {
         self.be_hot.create()
     }
 
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()> {
         if tpe != FileType::Config && (cacheable || tpe != FileType::Pack) {
-            self.be_hot.write_bytes(tpe, id, cacheable, buf.clone())?;
+            self.be_hot
+                .write_bytes(tpe, id, cacheable, content.clone())?;
         }
-        self.be.write_bytes(tpe, id, cacheable, buf)
+        self.be.write_bytes(tpe, id, cacheable, content)
     }
 
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {

--- a/crates/core/src/backend/warm_up.rs
+++ b/crates/core/src/backend/warm_up.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use crate::{
-    backend::{FileType, ReadBackend, WriteBackend},
+    backend::{BytesList, FileType, ReadBackend, WriteBackend},
     error::RusticResult,
     id::Id,
 };
@@ -71,8 +71,14 @@ impl WriteBackend for WarmUpAccessBackend {
         self.be.create()
     }
 
-    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> RusticResult<()> {
-        self.be.write_bytes(tpe, id, cacheable, buf)
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        content: BytesList,
+    ) -> RusticResult<()> {
+        self.be.write_bytes(tpe, id, cacheable, content)
     }
 
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> RusticResult<()> {

--- a/crates/core/src/blob/packer.rs
+++ b/crates/core/src/blob/packer.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender, bounded};
 use integer_sqrt::IntegerSquareRoot;
 use jiff::Timestamp;
@@ -15,11 +15,11 @@ use pariter::IteratorExt;
 use crate::{
     Progress,
     backend::{
-        FileType,
+        BytesList, FileType,
         decrypt::{DecryptFullBackend, DecryptWriteBackend},
     },
     blob::{BlobId, BlobLocations, BlobType},
-    crypto::{CryptoKey, hasher::hash},
+    crypto::{CryptoKey, hasher::hash_reader},
     error::{ErrorKind, RusticError, RusticResult},
     index::{IndexEntry, indexer::SharedIndexer},
     repofile::{
@@ -40,11 +40,9 @@ pub enum PackerErrorKind {
         from: &'static str,
         source: std::num::TryFromIntError,
     },
-    /// Sending crossbeam data message failed: `data`: `{data:?}`, `index_pack`: `{index_pack:?}` : `{source}`
+    /// Sending crossbeam data message failed: `{source}`
     SendingCrossbeamDataMessage {
-        data: Bytes,
-        index_pack: Box<IndexPack>,
-        source: crossbeam_channel::SendError<(Bytes, IndexPack)>,
+        source: crossbeam_channel::SendError<(BytesList, IndexPack)>,
     },
 }
 
@@ -283,7 +281,7 @@ impl<BE: DecryptWriteBackend> Packer<BE> {
                         raw_packer
                             .write()
                             .unwrap()
-                            .add_raw(&data, &id, data_len, ul)
+                            .add_raw(data.into(), &id, data_len, ul)
                     })
                     .and_then(|()| raw_packer.write().unwrap().finalize());
                 _ = finish_tx.send(status);
@@ -332,7 +330,7 @@ impl<BE: DecryptWriteBackend> Packer<BE> {
     /// * If sending the message to the raw packer fails.
     fn add_raw(
         &self,
-        data: &[u8],
+        data: Bytes,
         id: &BlobId,
         data_len: u64,
         uncompressed_length: Option<NonZeroU32>,
@@ -410,26 +408,12 @@ impl PackerStats {
 /// * `BE` - The backend type.
 #[allow(missing_debug_implementations, clippy::module_name_repetitions)]
 pub(crate) struct RawPacker<BE: DecryptWriteBackend> {
+    /// The basic packer
+    basic: BasicPacker,
     /// The backend to write to.
     be: BE,
-    /// The blob type to pack.
-    blob_type: BlobType,
-    /// The file to write to
-    file: BytesMut,
-    /// The size of the file
-    size: u32,
-    /// The number of blobs in the pack
-    count: u32,
-    /// The time the pack was created
-    created: SystemTime,
-    /// The index of the pack
-    index: IndexPack,
     /// The actor to write the pack file
     file_writer: Option<Actor>,
-    /// The pack sizer
-    pack_sizer: PackSizer,
-    /// The packer stats
-    stats: PackerStats,
 }
 
 impl<BE: DecryptWriteBackend> RawPacker<BE> {
@@ -458,16 +442,9 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
         ));
 
         Self {
+            basic: BasicPacker::new(blob_type, pack_sizer),
             be,
-            blob_type,
-            file: BytesMut::new(),
-            size: 0,
-            count: 0,
-            created: SystemTime::now(),
-            index: IndexPack::default(),
             file_writer,
-            pack_sizer,
-            stats: PackerStats::default(),
         }
     }
 
@@ -477,38 +454,13 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
     ///
     /// * If the packfile could not be saved
     fn finalize(&mut self) -> RusticResult<PackerStats> {
-        self.save().map_err(|err| {
-            err.overwrite_kind(ErrorKind::Internal)
-                .prepend_guidance_line("Failed to save packfile. Data may be lost.")
-                .ask_report()
-        })?;
+        if !self.basic.is_empty() {
+            self.save()?;
+        }
 
         self.file_writer.take().unwrap().finalize()?;
 
-        Ok(std::mem::take(&mut self.stats))
-    }
-
-    /// Writes the given data to the packfile.
-    ///
-    /// # Arguments
-    ///
-    /// * `data` - The data to write.
-    ///
-    /// # Returns
-    ///
-    /// The number of bytes written.
-    fn write_data(&mut self, data: &[u8]) -> PackerResult<u32> {
-        let len = data
-            .len()
-            .try_into()
-            .map_err(|err| PackerErrorKind::Conversion {
-                to: "u32",
-                from: "usize",
-                source: err,
-            })?;
-        self.file.extend_from_slice(data);
-        self.size += len;
-        Ok(len)
+        Ok(self.basic.take_stats())
     }
 
     /// Adds the already compressed/encrypted blob to the packfile without any check
@@ -526,7 +478,143 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
     /// * If converting the data length to u64 fails
     fn add_raw(
         &mut self,
-        data: &[u8],
+        data: Bytes,
+        id: &BlobId,
+        data_len: u64,
+        uncompressed_length: Option<NonZeroU32>,
+    ) -> RusticResult<()> {
+        self.basic
+            .add_raw(data, id, data_len, uncompressed_length)?;
+
+        if self.basic.should_save() {
+            self.save()?;
+        }
+        Ok(())
+    }
+
+    /// Saves the packfile
+    ///
+    /// # Errors
+    ///
+    /// If the header could not be written
+    ///
+    /// # Errors
+    ///
+    /// * If converting the header length to u32 fails
+    /// * If the header could not be written
+    fn save(&mut self) -> RusticResult<()> {
+        // write header
+        let data = self.basic.header_bytes()?;
+        // encrypt and write to pack file
+        let data = self.be.key().encrypt_data(&data)?.into();
+        self.basic.write_header(data)?;
+
+        // write file to backend
+        let (file, index) = self.basic.take_data();
+        self.file_writer
+            .as_ref()
+            .unwrap()
+            .send((file, index))
+            .map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "Failed to send packfile to file writer.",
+                    err,
+                )
+            })?;
+
+        Ok(())
+    }
+
+    fn has(&self, id: &BlobId) -> bool {
+        self.basic.has(id)
+    }
+}
+
+/// The `BasicPacker` is responsible for packing blobs into pack files. It is a basic version providing the functionality without any I/O or encryption involved
+#[allow(missing_debug_implementations, clippy::module_name_repetitions)]
+#[derive(Debug)]
+pub(crate) struct BasicPacker {
+    /// The blob type to pack.
+    blob_type: BlobType,
+    /// The file to write to
+    file: BytesList,
+    /// The size of the file
+    size: u32,
+    /// The number of blobs in the pack
+    count: u32,
+    /// The time the pack was created
+    created: SystemTime,
+    /// The index of the pack
+    index: IndexPack,
+    /// The pack sizer
+    pack_sizer: PackSizer,
+    /// The packer stats
+    stats: PackerStats,
+}
+
+impl BasicPacker {
+    /// Creates a new `RawPacker`.
+    ///
+    /// # Arguments
+    ///
+    /// * `blob_type` - The blob type.
+    /// * `pack_sizer` - pack sizer to use
+    pub fn new(blob_type: BlobType, pack_sizer: PackSizer) -> Self {
+        Self {
+            blob_type,
+            file: BytesList::default(),
+            size: 0,
+            count: 0,
+            created: SystemTime::now(),
+            index: IndexPack::default(),
+            pack_sizer,
+            stats: PackerStats::default(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Writes the given data to the packfile.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to write.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written.
+    fn write_data(&mut self, data: Bytes) -> PackerResult<u32> {
+        let len = data
+            .len()
+            .try_into()
+            .map_err(|err| PackerErrorKind::Conversion {
+                to: "u32",
+                from: "usize",
+                source: err,
+            })?;
+        self.file.add(data);
+        self.size += len;
+        Ok(len)
+    }
+
+    /// Adds the already compressed/encrypted blob to the packfile without any check
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The blob data
+    /// * `id` - The blob id
+    /// * `data_len` - The length of the blob data
+    /// * `uncompressed_length` - The length of the blob data before compression
+    ///
+    /// # Errors
+    ///
+    /// * If converting the data length to u64 fails
+    pub fn add_raw(
+        &mut self,
+        data: Bytes,
         id: &BlobId,
         data_len: u64,
         uncompressed_length: Option<NonZeroU32>,
@@ -549,8 +637,6 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
 
         self.stats.data_packed += data_len_packed;
 
-        let size_limit = self.pack_sizer.pack_size();
-
         let offset = self.size;
 
         let len = self.write_data(data).map_err(|err| {
@@ -560,14 +646,18 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
                 err,
             )
             .attach_context("id", id.to_string())
-            .attach_context("size_limit", size_limit.to_string())
             .attach_context("data_length_packed", data_len_packed.to_string())
         })?;
 
         self.index
             .add(*id, self.blob_type, offset, len, uncompressed_length);
-
         self.count += 1;
+
+        Ok(())
+    }
+
+    pub fn should_save(&self) -> bool {
+        let size_limit = self.pack_sizer.pack_size();
 
         // check if PackFile needs to be saved
         let elapsed = self.created.elapsed().unwrap_or_else(|err| {
@@ -575,28 +665,13 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
             Duration::ZERO
         });
 
-        if self.count >= constants::MAX_COUNT
+        self.count >= constants::MAX_COUNT
             || self.size >= size_limit
             || elapsed >= constants::MAX_AGE
-        {
-            self.pack_sizer.add_size(self.index.pack_size());
-            self.save()?;
-            self.size = 0;
-            self.count = 0;
-            self.created = SystemTime::now();
-        }
-        Ok(())
     }
 
-    /// Writes header and length of header to packfile
-    ///
-    /// # Errors
-    ///
-    /// * If converting the header length to u32 fails
-    /// * If the header could not be written
-    fn write_header(&mut self) -> RusticResult<()> {
-        // compute the pack header
-        let data = PackHeaderRef::from_index_pack(&self.index)
+    pub fn header_bytes(&self) -> RusticResult<Bytes> {
+        PackHeaderRef::from_index_pack(&self.index)
             .to_binary()
             .map_err(|err| -> Box<RusticError> {
                 RusticError::with_source(
@@ -605,22 +680,28 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
                     err,
                 )
                 .attach_context("index_pack_id", self.index.id.to_string())
-            })?;
+            })
+            .map(Into::into)
+    }
 
-        // encrypt and write to pack file
-        let data = self.be.key().encrypt_data(&data)?;
-
-        let headerlen: u32 = data.len().try_into().map_err(|err| {
+    /// Writes the already encrypted header to the packfile
+    ///
+    /// # Errors
+    ///
+    /// * If converting the header length to u32 fails
+    /// * If the header could not be written
+    pub fn write_header(&mut self, header: Bytes) -> RusticResult<()> {
+        let headerlen: u32 = header.len().try_into().map_err(|err| {
             RusticError::with_source(
                 ErrorKind::Internal,
                 "Failed to convert header length `{length}` to u32.",
                 err,
             )
-            .attach_context("length", data.len().to_string())
+            .attach_context("length", header.len().to_string())
         })?;
 
         // write header to pack file
-        _ = self.write_data(&data).map_err(|err| {
+        _ = self.write_data(header).map_err(|err| {
             RusticError::with_source(
                 ErrorKind::Internal,
                 "Failed to write header with length `{length}` to packfile.",
@@ -642,7 +723,7 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
             })?;
 
         // finally write length of header unencrypted to pack file
-        _ = self.write_data(&binary_repr).map_err(|err| {
+        _ = self.write_data(binary_repr.into()).map_err(|err| {
             RusticError::with_source(
                 ErrorKind::Internal,
                 "Failed to write header length `{length}` to packfile.",
@@ -664,32 +745,22 @@ impl<BE: DecryptWriteBackend> RawPacker<BE> {
     ///
     /// * If converting the header length to u32 fails
     /// * If the header could not be written
-    fn save(&mut self) -> RusticResult<()> {
-        if self.size == 0 {
-            return Ok(());
-        }
-
-        self.write_header()?;
-
-        // write file to backend
-        let index = std::mem::take(&mut self.index);
-        let file = std::mem::replace(&mut self.file, BytesMut::new());
-        self.file_writer
-            .as_ref()
-            .unwrap()
-            .send((file.into(), index))
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Internal,
-                    "Failed to send packfile to file writer.",
-                    err,
-                )
-            })?;
-
-        Ok(())
+    pub fn take_data(&mut self) -> (BytesList, IndexPack) {
+        self.size = 0;
+        self.pack_sizer.add_size(self.index.pack_size());
+        self.count = 0;
+        self.created = SystemTime::now();
+        (
+            std::mem::take(&mut self.file),
+            std::mem::take(&mut self.index),
+        )
     }
 
-    fn has(&self, id: &BlobId) -> bool {
+    pub fn take_stats(&mut self) -> PackerStats {
+        std::mem::take(&mut self.stats)
+    }
+
+    pub fn has(&self, id: &BlobId) -> bool {
         self.index.blobs.iter().any(|b| &b.id == id)
     }
 }
@@ -710,7 +781,7 @@ pub(crate) struct FileWriterHandle<BE: DecryptWriteBackend> {
 
 impl<BE: DecryptWriteBackend> FileWriterHandle<BE> {
     // TODO: add documentation
-    fn process(&self, load: (Bytes, PackId, IndexPack)) -> RusticResult<IndexPack> {
+    fn process(&self, load: (BytesList, PackId, IndexPack)) -> RusticResult<IndexPack> {
         let (file, id, mut index) = load;
         index.id = id;
         self.be
@@ -728,7 +799,7 @@ impl<BE: DecryptWriteBackend> FileWriterHandle<BE> {
 // TODO: add documentation
 pub(crate) struct Actor {
     /// The sender to send blobs to the raw packer.
-    sender: Sender<(Bytes, IndexPack)>,
+    sender: Sender<(BytesList, IndexPack)>,
     /// The receiver to receive the status from the raw packer.
     finish: Receiver<RusticResult<()>>,
 }
@@ -758,8 +829,9 @@ impl Actor {
                 let status = rx
                     .into_iter()
                     .readahead_scoped(scope)
-                    .map(|(file, index): (Bytes, IndexPack)| {
-                        let id = hash(&file);
+                    .map(|(file, index): (BytesList, IndexPack)| {
+                        let id = hash_reader(file.clone().reader())
+                            .expect("reading from memory cannot fail");
                         (file, PackId::from(id), index)
                     })
                     .readahead_scoped(scope)
@@ -785,14 +857,10 @@ impl Actor {
     /// # Errors
     ///
     /// If sending the message to the actor fails.
-    fn send(&self, load: (Bytes, IndexPack)) -> PackerResult<()> {
-        self.sender.send(load.clone()).map_err(|err| {
-            PackerErrorKind::SendingCrossbeamDataMessage {
-                data: load.0,
-                index_pack: Box::new(load.1),
-                source: err,
-            }
-        })?;
+    fn send(&self, load: (BytesList, IndexPack)) -> PackerResult<()> {
+        self.sender
+            .send(load)
+            .map_err(|err| PackerErrorKind::SendingCrossbeamDataMessage { source: err })?;
         Ok(())
     }
 
@@ -917,7 +985,7 @@ impl<BE: DecryptFullBackend> BlobCopier<BE> {
                 .expect("convert from u32 to usize should not fail!");
             self.packer
                 .add_raw(
-                    &data[start..end],
+                    Bytes::copy_from_slice(&data[start..end]),
                     &blob_id,
                     u64::from(blob.length),
                     blob.uncompressed_length,

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -586,38 +586,31 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.inner.next() {
-                Some(node) => {
-                    let path = self.path.join(node.name());
-                    if self.recursive
-                        && let Some(id) = node.subtree
-                    {
-                        self.path.push(node.name());
-                        let be = self.be.clone();
-                        let tree = match Tree::from_backend(&be, self.index, id) {
-                            Ok(tree) => tree,
-                            Err(err) => return Some(Err(err)),
-                        };
-                        let old_inner = mem::replace(&mut self.inner, tree.nodes.into_iter());
-                        self.open_iterators.push(old_inner);
-                    }
-
-                    if let Some(overrides) = &self.overrides
-                        && let Match::Ignore(_) = overrides.matched(&path, false)
-                    {
-                        continue;
-                    }
-
-                    return Some(Ok((path, node)));
+            if let Some(node) = self.inner.next() {
+                let path = self.path.join(node.name());
+                if self.recursive
+                    && let Some(id) = node.subtree
+                {
+                    self.path.push(node.name());
+                    let be = self.be.clone();
+                    let tree = match Tree::from_backend(&be, self.index, id) {
+                        Ok(tree) => tree,
+                        Err(err) => return Some(Err(err)),
+                    };
+                    let old_inner = mem::replace(&mut self.inner, tree.nodes.into_iter());
+                    self.open_iterators.push(old_inner);
                 }
-                None => match self.open_iterators.pop() {
-                    Some(it) => {
-                        self.inner = it;
-                        _ = self.path.pop();
-                    }
-                    None => return None,
-                },
+
+                if let Some(overrides) = &self.overrides
+                    && let Match::Ignore(_) = overrides.matched(&path, false)
+                {
+                    continue;
+                }
+                return Some(Ok((path, node)));
             }
+            // if inner was empty, go to parent path
+            self.inner = self.open_iterators.pop()?;
+            _ = self.path.pop();
         }
     }
 }

--- a/crates/core/src/commands/repair/hotcold.rs
+++ b/crates/core/src/commands/repair/hotcold.rs
@@ -99,7 +99,7 @@ fn copy(
     files.into_par_iter().try_for_each(|id| {
         let file = from.read_full(file_type, &id)?;
         let length = u64::try_from(file.len()).expect("file len should fit into u64");
-        to.write_bytes(file_type, &id, false, file)?;
+        to.write_bytes(file_type, &id, false, file.into())?;
         p.inc(length);
         Ok(())
     })

--- a/crates/core/src/crypto/aespoly1305.rs
+++ b/crates/core/src/crypto/aespoly1305.rs
@@ -90,7 +90,7 @@ impl CryptoKey for Key {
             return Err(RusticError::new(
                 ErrorKind::Cryptography,
                 "Data is too short (less than 16 bytes), cannot decrypt.",
-            ))?;
+            ));
         }
 
         let nonce = Nonce::from_slice(&data[0..16]);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -130,8 +130,8 @@ pub use jiff;
 // rustic_core Public API
 pub use crate::{
     backend::{
-        ALL_FILE_TYPES, FileType, ReadBackend, ReadSource, ReadSourceEntry, ReadSourceOpen,
-        RepositoryBackends, WriteBackend,
+        ALL_FILE_TYPES, BytesList, FileType, ReadBackend, ReadSource, ReadSourceEntry,
+        ReadSourceOpen, RepositoryBackends, WriteBackend,
         childstdout::ChildStdoutSource,
         decrypt::{compression_level_range, max_compression_level},
         ignore::{LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions},

--- a/crates/core/src/repofile/packfile.rs
+++ b/crates/core/src/repofile/packfile.rs
@@ -386,7 +386,7 @@ impl<'a> PackHeaderRef<'a> {
     ///
     /// * If writing the binary representation failed
     pub(crate) fn to_binary(&self) -> PackFileResult<Vec<u8>> {
-        let mut writer = Cursor::new(Vec::with_capacity(self.pack_size() as usize));
+        let mut writer = Cursor::new(Vec::with_capacity(self.size() as usize));
         // collect header entries
         for blob in self.0 {
             HeaderEntry::from_blob(blob)

--- a/crates/testing/src/backend.rs
+++ b/crates/testing/src/backend.rs
@@ -5,11 +5,11 @@ pub mod in_memory_backend {
         sync::RwLock,
     };
 
-    use bytes::Bytes;
+    use bytes::{Bytes, BytesMut};
     use enum_map::EnumMap;
 
     use rustic_core::{
-        ErrorKind, FileType, Id, ReadBackend, RusticError, RusticResult, WriteBackend,
+        BytesList, ErrorKind, FileType, Id, ReadBackend, RusticError, RusticResult, WriteBackend,
     };
 
     #[derive(Debug)]
@@ -154,9 +154,14 @@ pub mod in_memory_backend {
             tpe: FileType,
             id: &Id,
             _cacheable: bool,
-            buf: Bytes,
+            content: BytesList,
         ) -> RusticResult<()> {
-            if self.map.write().unwrap()[tpe].insert(*id, buf).is_some() {
+            let mut bytes = BytesMut::new();
+            for input in content.slice() {
+                bytes.extend_from_slice(input);
+            }
+            let bytes = bytes.freeze();
+            if self.map.write().unwrap()[tpe].insert(*id, bytes).is_some() {
                 return Err(
                     RusticError::new(ErrorKind::Backend, "ID `{id}` already exists.")
                         .attach_context("id", id.to_string()),


### PR DESCRIPTION
This PR refactors the packer and the way packfiles are handled in rustic:
- Introduces and uses a `BasicPacker` which only provides the logic without doing any I/O itself
- Packfiles are no longer collected as a single `BytesMut` in memory, but as `BytesList` which equals `Vec<Bytes>`. This reduces allocations and unnecessary memory copies (but is a breaking change w.r.t the backend API).
- fixes the memory allocation used for the pack header. By accident, here again the total pack size was allocated. This fix should reduce the total needed memory especially when using large packfiles
- this PR also fixes some new clippy lints (according to the given suggestions)