### PR TITLE
feat: implement some exclude options for opendal source

### DIFF
--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -21,7 +21,7 @@ use tokio::runtime::Runtime;
 use typed_path::UnixPathBuf;
 
 use rustic_core::{
-    ALL_FILE_TYPES, BytesList, ErrorKind, FileType, Id, ReadBackend, ReadSource, ReadSourceEntry,
+    ALL_FILE_TYPES, BytesList, ErrorKind, Excludes, FileType, Id, ReadBackend, ReadSource, ReadSourceEntry,
     ReadSourceOpen, RusticError, RusticResult, WriteBackend,
     repofile::{Node, NodeType},
 };
@@ -209,9 +209,12 @@ impl OpenDALBackend {
 
     /// Turn this `OpenDALBackend into a ReadSource`
     ///
+    /// # Arguments
+    /// * `excludes` - The exclude patterns to apply
+    ///
     /// # Errors
-    /// If listing fails
-    pub fn as_source(self) -> RusticResult<OpenDALReadSource> {
+    /// If listing fails or exclude patterns cannot be compiled
+    pub fn as_source(self, excludes: &Excludes) -> RusticResult<OpenDALReadSource> {
         let list_options = ListOptions {
             recursive: true,
             ..Default::default()
@@ -237,6 +240,32 @@ impl OpenDALBackend {
             })
             .collect();
         entries.sort_unstable_by(|e1, e2| e1.path().cmp(e2.path()));
+
+        if !excludes.is_empty() {
+            let matcher = excludes.as_override()?;
+            let mut ignoring: Option<String> = None;
+
+            entries.retain(|e| {
+                let path = e.path();
+                let path = path.strip_suffix('/').unwrap_or(path);
+                let is_dir = e.metadata().is_dir();
+
+                if let Some(ref prefix) = ignoring {
+                    if !path.starts_with(prefix) {
+                        ignoring = None;
+                    } else {
+                        return false;
+                    }
+                }
+
+                matcher.matched(path, is_dir).is_ignore().then(|| {
+                    if is_dir {
+                        ignoring = Some(path.to_string() + "/")
+                    }
+                    false
+                }).unwrap_or(true)
+            });
+        }
 
         Ok(OpenDALReadSource {
             entries,

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -21,8 +21,8 @@ use tokio::runtime::Runtime;
 use typed_path::UnixPathBuf;
 
 use rustic_core::{
-    ALL_FILE_TYPES, BytesList, ErrorKind, Excludes, FileType, Id, ReadBackend, ReadSource, ReadSourceEntry,
-    ReadSourceOpen, RusticError, RusticResult, WriteBackend,
+    ALL_FILE_TYPES, BytesList, ErrorKind, Excludes, FileType, Id, ReadBackend, ReadSource,
+    ReadSourceEntry, ReadSourceOpen, RusticError, RusticResult, WriteBackend,
     repofile::{Node, NodeType},
 };
 
@@ -249,20 +249,23 @@ impl OpenDALBackend {
                 let path = "/".to_string() + e.path().trim_matches('/');
                 let is_dir = e.metadata().is_dir();
 
-                if let Some(ref prefix) = ignoring {
-                    if !path.starts_with(prefix) {
-                        ignoring = None;
-                    } else {
+                if let Some(prefix) = &ignoring {
+                    if path.starts_with(prefix) {
                         return false;
                     }
+                    ignoring = None;
                 }
 
-                matcher.matched(&path, is_dir).is_ignore().then(|| {
-                    if is_dir {
-                        ignoring = Some(path.to_string() + "/")
+                if matcher.matched(&path, is_dir).is_ignore() {
+                    {
+                        if is_dir {
+                            ignoring = Some(path + "/");
+                        }
+                        false
                     }
-                    false
-                }).unwrap_or(true)
+                } else {
+                    true
+                }
             });
         }
 

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -246,8 +246,7 @@ impl OpenDALBackend {
             let mut ignoring: Option<String> = None;
 
             entries.retain(|e| {
-                let path = e.path();
-                let path = path.strip_suffix('/').unwrap_or(path);
+                let path = "/".to_string() + e.path().trim_matches('/');
                 let is_dir = e.metadata().is_dir();
 
                 if let Some(ref prefix) = ignoring {
@@ -258,7 +257,7 @@ impl OpenDALBackend {
                     }
                 }
 
-                matcher.matched(path, is_dir).is_ignore().then(|| {
+                matcher.matched(&path, is_dir).is_ignore().then(|| {
                     if is_dir {
                         ignoring = Some(path.to_string() + "/")
                     }

--- a/crates/core/src/blob/tree/excludes.rs
+++ b/crates/core/src/blob/tree/excludes.rs
@@ -40,7 +40,12 @@ impl Excludes {
         self == &Self::default()
     }
 
-    pub(crate) fn as_override(&self) -> RusticResult<Override> {
+    /// Convert excludes to an Override for glob pattern matching
+    ///
+    /// # Errors
+    ///
+    /// * If glob patterns cannot be compiled into an override
+    pub fn as_override(&self) -> RusticResult<Override> {
         let mut override_builder = OverrideBuilder::new("");
         for g in &self.globs {
             _ = override_builder.add(g).map_err(|err| {


### PR DESCRIPTION
the new opendal as source backend supports no exclusion whatsoever, which is quite a shortcoming (and should probably be documented). This commit partially fixes that, it does not implement all exclusions, but at least it implements glob exclusions, which is better than nothing.

I do not consider this commit a final resolution, especially given the general intention to get rid of dependency on `ignore`, but I'd say it's definitely an improvement.