### PR TITLE
docs: update core README credential API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This crate exposes a few features for controlling dependency usage:
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{ConfigOptions, KeyOptions, Repository, RepositoryOptions};
+use rustic_core::{Credentials, ConfigOptions, KeyOptions, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -78,10 +78,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Init repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
     let key_opts = KeyOptions::default();
     let config_opts = ConfigOptions::default();
-    let _repo = Repository::new(&repo_opts, &backends)?.init(&key_opts, &config_opts)?;
+    let _repo = Repository::new(&repo_opts, &backends)?.init(&creds, &key_opts, &config_opts)?;
 
     // -> use _repo for any operation on an open repository
     Ok(())
@@ -92,7 +93,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{BackupOptions, PathList, Repository, RepositoryOptions, SnapshotOptions};
+use rustic_core::{BackupOptions, Credentials, PathList, Repository, RepositoryOptions, SnapshotOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -107,10 +108,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
 
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&creds)?
         .to_indexed_ids()?;
 
     let backup_opts = BackupOptions::default();
@@ -131,7 +133,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{LocalDestination, LsOptions, Repository, RepositoryOptions, RestoreOptions};
+use rustic_core::{Credentials, LocalDestination, LsOptions, Repository, RepositoryOptions, RestoreOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -145,9 +147,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
     let repo = Repository::new(&repo_opts, &backends)?
-        .open()?
+        .open(&creds)?
         .to_indexed()?;
 
     // use latest snapshot without filtering snapshots
@@ -175,7 +178,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{CheckOptions, Repository, RepositoryOptions};
+use rustic_core::{CheckOptions, Credentials, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -189,8 +192,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-    let repo = Repository::new(&repo_opts, &backends)?.open()?;
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
+    let repo = Repository::new(&repo_opts, &backends)?.open(&creds)?;
 
     // Check repository with standard options but omitting cache checks
     let opts = CheckOptions::default().trust_cache(true);

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -67,7 +67,7 @@ This crate exposes a few features for controlling dependency usage:
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{ConfigOptions, KeyOptions, Repository, RepositoryOptions};
+use rustic_core::{Credentials, ConfigOptions, KeyOptions, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -81,10 +81,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Init repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
     let key_opts = KeyOptions::default();
     let config_opts = ConfigOptions::default();
-    let _repo = Repository::new(&repo_opts, backends)?.init(&key_opts, &config_opts)?;
+    let _repo = Repository::new(&repo_opts, &backends)?.init(&creds, &key_opts, &config_opts)?;
 
     // -> use _repo for any operation on an open repository
     Ok(())
@@ -95,7 +96,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{BackupOptions, PathList, Repository, RepositoryOptions, SnapshotOptions};
+use rustic_core::{BackupOptions, Credentials, PathList, Repository, RepositoryOptions, SnapshotOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -110,10 +111,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
 
-    let repo = Repository::new(&repo_opts, backends)?
-        .open()?
+    let repo = Repository::new(&repo_opts, &backends)?
+        .open(&creds)?
         .to_indexed_ids()?;
 
     let backup_opts = BackupOptions::default();
@@ -127,13 +129,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("successfully created snapshot:\n{snap:#?}");
     Ok(())
+}
 ```
 
 ### Example: Restoring a snapshot
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{LocalDestination, LsOptions, Repository, RepositoryOptions, RestoreOptions};
+use rustic_core::{Credentials, LocalDestination, LsOptions, Repository, RepositoryOptions, RestoreOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -147,9 +150,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-    let repo = Repository::new(&repo_opts, backends)?
-        .open()?
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
+    let repo = Repository::new(&repo_opts, &backends)?
+        .open(&creds)?
         .to_indexed()?;
 
     // use latest snapshot without filtering snapshots
@@ -177,7 +181,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ```rust
 use rustic_backend::BackendOptions;
-use rustic_core::{CheckOptions, Repository, RepositoryOptions};
+use rustic_core::{CheckOptions, Credentials, Repository, RepositoryOptions};
 use simplelog::{Config, LevelFilter, SimpleLogger};
 use std::error::Error;
 
@@ -191,8 +195,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .to_backends()?;
 
     // Open repository
-    let repo_opts = RepositoryOptions::default().password("test");
-    let repo = Repository::new(&repo_opts, backends)?.open()?;
+    let creds = Credentials::Password("test".into());
+    let repo_opts = RepositoryOptions::default();
+    let repo = Repository::new(&repo_opts, &backends)?.open(&creds)?;
 
     // Check repository with standard options but omitting cache checks
     let opts = CheckOptions::default().trust_cache(true);


### PR DESCRIPTION
## Summary

- update root and published core README examples to use Credentials
- use the current init and open signatures in all four examples
- repair the snapshot example code fence

Fixes #502

## Validation

- cargo test -p rustic_core --doc --locked
- cargo fmt --check
- git diff --check