### PR TITLE
fix: iOS build

### DIFF
--- a/crates/core/src/backend/local_destination.rs
+++ b/crates/core/src/backend/local_destination.rs
@@ -67,6 +67,7 @@ pub enum LocalDestinationErrorKind {
     FileDoesNotHaveParent(PathBuf),
     #[cfg(any(
         target_os = "macos",
+        target_os = "ios",
         target_os = "openbsd",
         all(target_os = "android", target_pointer_width = "32")
     ))]
@@ -666,11 +667,12 @@ impl LocalDestination {
             NodeType::Dev { device } => {
                 #[cfg(not(any(
                     target_os = "macos",
+                    target_os = "ios",
                     target_os = "openbsd",
                     all(target_os = "android", target_pointer_width = "32")
                 )))]
                 let device = *device;
-                #[cfg(any(target_os = "macos", target_os = "openbsd"))]
+                #[cfg(any(target_os = "macos", target_os = "ios", target_os = "openbsd"))]
                 let device = i32::try_from(*device).map_err(|err| {
                     LocalDestinationErrorKind::DeviceIdConversionFailed {
                         target: "i32".to_string(),
@@ -692,11 +694,12 @@ impl LocalDestination {
             NodeType::Chardev { device } => {
                 #[cfg(not(any(
                     target_os = "macos",
+                    target_os = "ios",
                     target_os = "openbsd",
                     all(target_os = "android", target_pointer_width = "32")
                 )))]
                 let device = *device;
-                #[cfg(any(target_os = "macos", target_os = "openbsd"))]
+                #[cfg(any(target_os = "macos", target_os = "ios", target_os = "openbsd"))]
                 let device = i32::try_from(*device).map_err(|err| {
                     LocalDestinationErrorKind::DeviceIdConversionFailed {
                         target: "i32".to_string(),


### PR DESCRIPTION
`rustic_core` does not compile for `aarch64-apple-ios`. In `crates/core/src/backend/local_destination.rs`, the `NodeType::Dev` and `NodeType::Chardev` branches convert the stored device id to the `dev_t` that `nix::sys::stat::mknod` expects. On Darwin `dev_t` is `i32`, so the code has a gate that does `i32::try_from(*device)` for `macos` and `openbsd`, and passes the `u64` through everywhere else.

iOS is Darwin too — same libc, same `i32` `dev_t` — but the gate only names `macos`. On iOS the crate takes the pass-through path and hands a `u64` to a function wanting `i32`:

```
error[E0308]: mismatched types
  --> crates/core/src/backend/local_destination.rs:715:65
    mknod(&filename, SFlag::S_IFCHR, Mode::empty(), device)
                                                    ^^^^^^ expected `i32`, found `u64`
```

This adds `target_os = "ios"` beside `target_os = "macos"` in the three places that gate appears: the `DeviceIdConversionFailed` error variant's `cfg` (which would otherwise be undefined on iOS), and the two conversion sites. No behaviour changes on any currently compiling target; the `all(target_os = "android", target_pointer_width = "32")` arm is untouched.

The path is not reachable at runtime for a sandboxed iOS app (it restores no block or character devices), but it is compiled regardless, so the crate does not build for the target at all — and a `cargo check` on macOS does not reveal it, because the gate that is wrong is the one macOS does not take.

Verified with a crate depending on `rustic_core` and `rustic_backend` (`rest` only, no `opendal`): `aarch64-apple-ios` and `aarch64-apple-ios-sim` both compile after this, `aarch64-apple-darwin` still compiles, and `zstd-sys` and `ring` cross-compile for iOS without complaint.

If you'd rather cover the whole Apple family at once (tvOS, watchOS and visionOS share the same `dev_t`), `target_vendor = "apple"` in place of the two `target_os` entries would do it — I kept this to the narrowest change, but happy to switch.
