### PR TITLE
fix: verify plaintext blob identities on read

### DIFF
--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -10,7 +10,7 @@ pub use zstd::compression_level_range;
 use crate::{
     BytesList, Progress,
     backend::{FileType, ReadBackend, WriteBackend},
-    blob::BlobLocation,
+    blob::{BlobId, BlobLocation},
     crypto::{CryptoKey, hasher::hash},
     error::{ErrorKind, RusticError, RusticResult},
     id::Id,
@@ -21,6 +21,25 @@ use crate::{
 #[must_use]
 pub fn max_compression_level() -> i32 {
     *compression_level_range().end()
+}
+
+/// Verifies that plaintext content matches its content-addressed blob ID.
+///
+/// # Errors
+///
+/// Returns a verification error when the content hash differs from `expected_id`.
+pub(crate) fn verify_blob_id(data: &[u8], expected_id: &BlobId) -> RusticResult<()> {
+    let actual_id = BlobId::from(hash(data));
+    if actual_id != *expected_id {
+        return Err(RusticError::new(
+            ErrorKind::Verification,
+            "Blob content hash does not match its expected ID.",
+        )
+        .attach_context("expected_id", expected_id.to_string())
+        .attach_context("actual_id", actual_id.to_string()));
+    }
+
+    Ok(())
 }
 
 /// A backend that can decrypt data.
@@ -63,6 +82,7 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     ///
     /// * `data` - The partial data to decrypt.
     /// * `uncompressed_length` - The length of the uncompressed data.
+    /// * `expected_id` - The expected ID of the plaintext blob.
     ///
     /// # Errors
     ///
@@ -72,6 +92,7 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
         &self,
         data: &[u8],
         uncompressed_length: Option<NonZeroU32>,
+        expected_id: &BlobId,
     ) -> RusticResult<Bytes> {
         let mut data = self.decrypt(data)?;
         if let Some(length) = uncompressed_length {
@@ -93,6 +114,9 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
                 .ask_report());
             }
         }
+
+        verify_blob_id(&data, expected_id)?;
+
         Ok(data.into())
     }
 
@@ -106,6 +130,7 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     /// * `offset` - The offset to read from.
     /// * `length` - The length to read.
     /// * `uncompressed_length` - The length of the uncompressed data.
+    /// * `expected_id` - The expected ID of the plaintext blob.
     ///
     /// # Errors
     ///
@@ -116,20 +141,18 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
         id: &Id,
         cacheable: bool,
         location: BlobLocation,
+        expected_id: &BlobId,
     ) -> RusticResult<Bytes> {
         self.read_encrypted_from_partial(
             &self.read_partial(tpe, id, cacheable, location.offset, location.length)?,
             location.uncompressed_length,
+            expected_id,
         )
         .map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::Cryptography,
-                "error processing {tpe}:{id} at {location}",
-                err,
-            )
-            .attach_context("tpe", tpe.to_string())
-            .attach_context("id", id.to_string())
-            .attach_context("location", format!("{location:?}"))
+            err.prepend_guidance_line("error processing {tpe}:{id} at {location}")
+                .attach_context("tpe", tpe.to_string())
+                .attach_context("id", id.to_string())
+                .attach_context("location", format!("{location:?}"))
         })
     }
 
@@ -512,8 +535,12 @@ impl<C: CryptoKey> DecryptBackend<C> {
         data: &[u8],
     ) -> RusticResult<()> {
         if self.extra_verify {
-            let data_check =
-                self.read_encrypted_from_partial(data_encrypted, uncompressed_length)?;
+            let expected_id = BlobId::from(hash(data));
+            let data_check = self.read_encrypted_from_partial(
+                data_encrypted,
+                uncompressed_length,
+                &expected_id,
+            )?;
 
             if data != data_check {
                 return Err(
@@ -766,6 +793,28 @@ mod tests {
         data_encrypted[5] = !data_encrypted[5];
         // will be detected
         assert!(be.very_data(&data_encrypted, ul, data).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_replayed_blob() -> Result<()> {
+        for compression in [None, Some(0)] {
+            let (mut be, expected) = init();
+            be.set_zstd(compression);
+            let replayed = b"{evil}";
+            assert_eq!(expected.len(), replayed.len());
+
+            let (expected_encrypted, _, expected_length) = be.encrypt_data(expected)?;
+            let (replayed_encrypted, _, replayed_length) = be.encrypt_data(replayed)?;
+            assert_eq!(expected_encrypted.len(), replayed_encrypted.len());
+            assert_eq!(expected_length, replayed_length);
+
+            let expected_id = BlobId::from(hash(expected));
+            assert!(
+                be.read_encrypted_from_partial(&replayed_encrypted, replayed_length, &expected_id,)
+                    .is_err()
+            );
+        }
         Ok(())
     }
 }

--- a/crates/core/src/blob/packer.rs
+++ b/crates/core/src/blob/packer.rs
@@ -1030,9 +1030,11 @@ impl<BE: DecryptFullBackend> BlobCopier<BE> {
                 .expect("convert from u32 to usize should not fail!");
             let end = usize::try_from(blob.offset + blob.length - offset)
                 .expect("convert from u32 to usize should not fail!");
-            let data = self
-                .be_src
-                .read_encrypted_from_partial(&read_data[start..end], blob.uncompressed_length)?;
+            let data = self.be_src.read_encrypted_from_partial(
+                &read_data[start..end],
+                blob.uncompressed_length,
+                &blob_id,
+            )?;
 
             self.packer.add(data, blob_id).map_err(|err| {
                 RusticError::with_source(

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -24,7 +24,7 @@ use crate::{
         decrypt::DecryptReadBackend,
         node::{Metadata, Node, NodeType},
     },
-    blob::{BlobType, tree::excludes::Excludes},
+    blob::{BlobId, BlobType, tree::excludes::Excludes},
     crypto::hasher::hash,
     error::{ErrorKind, RusticError, RusticResult},
     impl_blobid,
@@ -148,7 +148,7 @@ impl Tree {
                 )
                 .attach_context("tree_id", id.to_string())
             })?
-            .read_data(be)?;
+            .read_data(be, &BlobId::from(*id))?;
 
         let tree = serde_json::from_slice(&data).map_err(|err| {
             RusticError::with_source(

--- a/crates/core/src/commands/dump.rs
+++ b/crates/core/src/commands/dump.rs
@@ -52,10 +52,13 @@ pub(crate) fn dump<S: IndexedFull>(
     let index_entries: Vec<_> = content
         .iter()
         .map(|id| {
-            repo.index().get_data(id).ok_or_else(|| {
-                RusticError::new(ErrorKind::Internal, "Data Blob `{id}`  not found in index")
-                    .attach_context("id", id.to_string())
-            })
+            repo.index()
+                .get_data(id)
+                .map(|entry| (BlobId::from(**id), entry))
+                .ok_or_else(|| {
+                    RusticError::new(ErrorKind::Internal, "Data Blob `{id}`  not found in index")
+                        .attach_context("id", id.to_string())
+                })
         })
         .collect::<RusticResult<_>>()?;
 
@@ -63,7 +66,7 @@ pub(crate) fn dump<S: IndexedFull>(
     scope(|s| -> RusticResult<()> {
         index_entries
             .iter()
-            .parallel_map_scoped(s, |ie| ie.read_data(be))
+            .parallel_map_scoped(s, |(id, ie)| ie.read_data(be, id))
             .try_for_each(|res| write_blob(w, &res?))
     })
 }

--- a/crates/core/src/commands/restore.rs
+++ b/crates/core/src/commands/restore.rs
@@ -15,11 +15,11 @@ use walkdir::{DirEntry, WalkDir};
 use crate::{
     backend::{
         FileType, ReadBackend,
-        decrypt::DecryptReadBackend,
+        decrypt::{DecryptReadBackend, verify_blob_id},
         local_destination::LocalDestination,
         node::{Node, NodeType},
     },
-    blob::{BlobLocation, BlobLocations},
+    blob::{BlobId, BlobLocation, BlobLocations},
     error::{ErrorKind, RusticError, RusticResult},
     repofile::packfile::PackId,
     repository::{IndexedFull, IndexedTree, Open, Repository},
@@ -31,7 +31,7 @@ pub(crate) mod constants {
 }
 
 type Filenames = Vec<PathBuf>;
-type RestoreInfo = BTreeMap<(PackId, BlobLocation), SmallVec<[FileLocation; 1]>>;
+type RestoreInfo = BTreeMap<(PackId, BlobLocation, BlobId), SmallVec<[FileLocation; 1]>>;
 
 #[allow(clippy::struct_excessive_bools)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
@@ -482,10 +482,12 @@ pub(crate) fn set_metadata(
         .unwrap_or_else(|_| warn!("restore {}: setting file times failed.", path.display()));
 }
 
+type RestoreBlobDestinations = (BlobId, SmallVec<[(usize, u64); 1]>);
+
 struct PackInfo {
     pack_id: PackId,
     from_file: Option<(usize, u64, u32)>,
-    locations: BlobLocations<SmallVec<[(usize, u64); 1]>>,
+    locations: BlobLocations<RestoreBlobDestinations>,
 }
 
 impl PackInfo {
@@ -554,13 +556,14 @@ fn restore_contents<S: Open>(
     }
 
     let sizes = &Mutex::new(file_lengths);
+    let errors = Mutex::new(None);
 
     let p = repo.progress_bytes("restoring file contents...");
     p.set_length(restore_size);
 
     let packs: Vec<_> = restore_info
         .into_iter()
-        .map(|((pack_id, bl), fls)| {
+        .map(|((pack_id, bl, blob_id), fls)| {
             let from_file = fls
                 .iter()
                 .find(|fl| fl.matches)
@@ -575,7 +578,7 @@ fn restore_contents<S: Open>(
             PackInfo {
                 pack_id,
                 from_file,
-                locations: BlobLocations::from_blob_location(bl, name_dests),
+                locations: BlobLocations::from_blob_location(bl, (blob_id, name_dests)),
             }
         })
         // optimize reading from backend by reading many blobs in a row
@@ -609,6 +612,7 @@ fn restore_contents<S: Open>(
         } in packs
         {
             let p = &p;
+            let errors = &errors;
 
             if !blobs.is_empty() {
                 // TODO: error handling!
@@ -627,10 +631,10 @@ fn restore_contents<S: Open>(
                     };
 
                     // save into needed files in parallel
-                    for (bl, name_dests) in blobs {
+                    for (bl, (blob_id, name_dests)) in blobs {
                         let size = bl.data_length().into();
                         let data = if from_file.is_some() {
-                            read_data.clone()
+                            verify_blob_id(&read_data, &blob_id).map(|()| read_data.clone())
                         } else {
                             let start = usize::try_from(bl.offset - offset)
                                 .expect("convert from u32 to usize should not fail!");
@@ -639,8 +643,19 @@ fn restore_contents<S: Open>(
                             be.read_encrypted_from_partial(
                                 &read_data[start..end],
                                 bl.uncompressed_length,
+                                &blob_id,
                             )
-                            .unwrap()
+                        };
+                        let data = match data {
+                            Ok(data) => data,
+                            Err(err) => {
+                                let mut error = errors.lock().unwrap();
+                                if error.is_none() {
+                                    *error = Some(err);
+                                }
+                                drop(error);
+                                return;
+                            }
                         };
                         let is_sparse = match sparse {
                             SparseRestore::ByContent => data.iter().all(|&b| b == 0),
@@ -672,6 +687,13 @@ fn restore_contents<S: Open>(
     });
 
     p.finish();
+
+    let error = errors
+        .into_inner()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(err) = error {
+        return Err(err);
+    }
 
     Ok(())
 }
@@ -810,7 +832,7 @@ impl RestorePlan {
                 .as_mut()
                 .is_some_and(|file| id.blob_matches_reader(length, file));
 
-            let blob_location = self.r.entry((ie.pack, bl)).or_default();
+            let blob_location = self.r.entry((ie.pack, bl, BlobId::from(**id))).or_default();
             blob_location.push(FileLocation {
                 file_idx,
                 file_start: file_pos,
@@ -845,7 +867,7 @@ impl RestorePlan {
             .iter()
             // filter out packs which we need
             .filter(|(_, fls)| fls.iter().all(|fl| !fl.matches))
-            .map(|((pack, _), _)| *pack)
+            .map(|((pack, _, _), _)| *pack)
             .dedup()
             .collect()
     }

--- a/crates/core/src/index.rs
+++ b/crates/core/src/index.rs
@@ -50,16 +50,18 @@ impl IndexEntry {
     /// # Arguments
     ///
     /// * `be` - The backend to read from
+    /// * `id` - The expected ID of the plaintext blob
     ///
     /// # Errors
     ///
     // TODO:  add error! This function will return an error if the blob is not found in the backend.
-    pub fn read_data<B: DecryptReadBackend>(&self, be: &B) -> RusticResult<Bytes> {
+    pub fn read_data<B: DecryptReadBackend>(&self, be: &B, id: &BlobId) -> RusticResult<Bytes> {
         let data = be.read_encrypted_partial(
             FileType::Pack,
             &self.pack,
             self.blob_type.is_cacheable(),
             self.location,
+            id,
         )?;
 
         Ok(data)
@@ -180,7 +182,7 @@ pub trait ReadIndex {
                 .attach_context("id", id.to_string())
                 .attach_context("type", tpe.to_string()))
             },
-            |ie| ie.read_data(be),
+            |ie| ie.read_data(be, id),
         )
     }
 }


### PR DESCRIPTION
## Summary

- verify decrypted and decompressed packed blob bytes against their expected content-addressed ID
- carry expected IDs through tree, dump, restore, and normal copy reads
- reject mismatched locally reused restore content with a verification error
- retain fast-repack's documented unchecked behavior

## Why

AEAD authenticates a ciphertext record, but does not bind that record to its index identity. A valid record stored at the wrong indexed location could therefore be accepted as another blob when its size metadata also matched. Hashing plaintext before consumption prevents silent substitution and cache poisoning.

## Validation

- replay regression: compressed and uncompressed records
- cargo test --locked -p rustic_core --lib: 169 passed
- cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- typos on all changed files

The full workspace integration run reached 52 passing tests; five snapshot comparisons differed only because macOS added com.apple.provenance xattrs to local fixtures.