### PR TITLE
feat!: Add more reqwest options for rest+opendal backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "asyncband"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a214ba60d6231afd0e805e3c27c45a1626d9debaa5a5061c45a1ea1b2f1ed0"
+dependencies = [
+ "hashbrown 0.17.1",
+ "slab",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,9 +2574,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendal"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f20562cc7447fcc915fc5c23df305a412ea80a733c9f2fd9e2d267e2815be6d"
+checksum = "33dbff14cc9bb085224256d6a81289d2f3202e85b06f408d42534b42162a4231"
 dependencies = [
  "ctor",
  "opendal-core",
@@ -2603,11 +2613,12 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec75551ff4cf3e57da98979f6a937aaa9ddb3915bf68cc17d03df733be6646ed"
+checksum = "48dbcef97d3eb7591db2c18d5cae95c836bcce07359b98d98dd6f4e861eb77b7"
 dependencies = [
  "anyhow",
+ "asyncband",
  "base64 0.23.1",
  "bytes",
  "futures",
@@ -2615,7 +2626,6 @@ dependencies = [
  "jiff",
  "log",
  "md-5",
- "mea",
  "percent-encoding",
  "quick-xml",
  "reqsign-core",
@@ -2629,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4d4f19c3ce01126a30611f8e544eaa217104a278c889ac17c9374fe4f9e4ef"
+checksum = "85663452ea32bbc17e8f79ab29788c846d116ec7de31451be9c787e462dcb36c"
 dependencies = [
  "bytes",
  "futures",
@@ -2643,21 +2653,21 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249ac5b0aa5a7a6c3737342d10456067937f9c9a6f3f02544271f7908ab91081"
+checksum = "03f9e144b5228d741c3763ade8711d9b72e5fb6d998e779f2d7a09da0b5a3eba"
 dependencies = [
+ "asyncband",
  "futures",
  "http",
- "mea",
  "opendal-core",
 ]
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c75411ab00f77851ff086b686c1e9ca8175ac18c15afa2cb75b9036436cb06c"
+checksum = "c2de17c61cd32e9d8d7d8efb91795e714dbccbafbc3c4e219e1542f4d6324161"
 dependencies = [
  "log",
  "opendal-core",
@@ -2665,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b7738bd5f233ad8da39af9b9316b9b7a4eaddd91e8e32a1e19b7030688121d"
+checksum = "e94db301964a25366090484d61e6da16d5979cc8faf02c3e12210dc74fafed38"
 dependencies = [
  "backon",
  "log",
@@ -2676,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885cc8f70e3d25945dec6d7fbd60b08d2129cdc04191f32aa176e3cb2274fe2c"
+checksum = "126e7e819f2530a14c3082a0dbe93ea35459532f4c8d46b0c345acd1810d3400"
 dependencies = [
  "governor",
  "opendal-core",
@@ -2686,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a704141924500f3803c05ed871b53305d2a2f11cb5ef20160c3ee688a1857f66"
+checksum = "08956ddda07465449bfd48825f4f0f25e0351278ac974eaa659895d9d74f2c80"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -2696,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3310fbbb48f111c6f590473c2cd15e1b7f8e384444b0d4e328f0464c864d767"
+checksum = "6d278d2fb57661947d1c9fb44047e432b2782c48dc085b7abc99fe6e18c26cf8"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -2717,15 +2727,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3c406729935fe214ce574d68681a1ff7e0b322548f14094912bdbfe50e5c53"
+checksum = "2d564484a8f7d091827e825cfc91ed45bd48e64d262451ee041fe843db81bd8a"
 dependencies = [
+ "asyncband",
  "base64 0.23.1",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "opendal-service-azure-common",
  "quick-xml",
@@ -2738,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd228c87087e4486c5a4d7b978b1db3ebed7f98351e6ed02e9f9bde24f3ce30"
+checksum = "c85f0fbe58e733b6473138aa67cf616127a1ca4f4147567a913e9acb92f2b96a"
 dependencies = [
  "bytes",
  "http",
@@ -2756,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7348c88edf15af435b7be930077746b569fac5e738c1bf6a363b675e7317c9df"
+checksum = "cfcc1bfdac4f54d9018c462dd32ad9e2f68fdf584f825c811550c8ffc87894cd"
 dependencies = [
  "http",
  "opendal-core",
@@ -2766,14 +2776,14 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-b2"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5d1fbf2a0ba77768270ec5bde55a7f5c496655e93a2d2ee85ff56a5325f2ac"
+checksum = "d606353dd192c46db1a146d0085dadd4dba85a97d63a233851de0f5a4697ddb8"
 dependencies = [
+ "asyncband",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "serde",
  "serde_json",
@@ -2781,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d533d4582105d269c8aebeee5f0e8bcf960f41b8aab6197df7012254d9f39bf0"
+checksum = "bb021c128ebde42e6f3e719d4cfed27e994017aa503a7a1e5818bdb61fd67dc9"
 dependencies = [
  "bytes",
  "http",
@@ -2798,13 +2808,13 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dropbox"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668e32a4c68d65dc21b646d96279e1a32d78a295e3ac3fe124b06c7f27fa061f"
+checksum = "09a7f0c1f99885543e2647f5fd148b81fdeb21d2f5fd45e59090fad15fad9105"
 dependencies = [
+ "asyncband",
  "bytes",
  "http",
- "mea",
  "opendal-core",
  "serde",
  "serde_json",
@@ -2812,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826c4e17a30643b888fe983897f9a4b23b07066e1d069727a923cc8fb419a702"
+checksum = "c7ef1e1c45f3f89282a59073897e0d685e51385fed0aea771714789525cff996"
 dependencies = [
  "bytes",
  "log",
@@ -2826,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8226225287abcc9eb620b7924e5852963c51d017b0d56da70b088d68b640e207"
+checksum = "f992e484df00e78880e7d066ecfb06170865e25cc064c5069bf81011c3dd56e3"
 dependencies = [
  "bytes",
  "fastpool",
@@ -2845,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007f3fba63c21e516c956b891e96ff9892d8175662bfb781cdada9d3766a11e6"
+checksum = "da1f2a8c975fd22fea01f0409bcb8774f1ac02ad79863a3490098203121555d3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2866,14 +2876,14 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gdrive"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e856c93abe1eab4a8b119286a8260d468aa9a07f3951c2d5ace16832dfba9b79"
+checksum = "bf817a82a81423bdda3c980e5d5b076f07364a71398dbf038d6220bb4f55b529"
 dependencies = [
+ "asyncband",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "serde",
  "serde_json",
@@ -2881,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dad7db6252879b8f864383027d8b91c57d5cc3c3f6269df5f61cea4a09d1079"
+checksum = "21cbd6ce78d2d3687bc16f353b008bb160a9312d8614015b5646ccd55af19eb7"
 dependencies = [
  "bytes",
  "ghac",
@@ -2901,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fd1f0f28bd052e068d9bb4bc5d30a09de22a4f7cea24558dbeef2b91090cc3"
+checksum = "a2ebcbdfad4b81a1e6dde70e898396e011dfd52b5f8639b2628656f7915d6f4c"
 dependencies = [
  "http",
  "log",
@@ -2913,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3a82f09ace60a740033b112169259d07315ee35caf26c8f82ad3480b5c02b"
+checksum = "f5ad5ec703ad8fee5e81a7a3c207952fcafec9b2c97a3b9a1d655b864f0f9600"
 dependencies = [
  "bytes",
  "http",
@@ -2927,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39f4a4e705d9fb375d53a0dbbdb6fc435a04b94e7697b86a365a6b4ea4b5639"
+checksum = "9e03c635ea35bdb07c1168612d42386635d16a1583c753efaf70bc7c8ac68c83"
 dependencies = [
  "bytes",
  "http",
@@ -2944,14 +2954,14 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-onedrive"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb96d5fb183104a405b010d2131031438cb29227785a2a67187c7d27731a2ea"
+checksum = "d2d251202faa1d3d7e05a02f4fcb7e56a8770dfcd69a5e5fdebc567dabd5133c"
 dependencies = [
+ "asyncband",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "serde",
  "serde_json",
@@ -2960,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd528ec2d49c5ca69e674ffed7b3e0686fb9cfcfea0596870de381467fda4f1b"
+checksum = "8e3ce7a2ceb925e0f28f545b169eb57d04cec6116aae94b8584d2bdbe7d456c6"
 dependencies = [
  "bytes",
  "http",
@@ -2977,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-pcloud"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6dba66e62b66d1ebd1df8cb74505d60d2a9ed06688bdbcd9a814a9c3e81141"
+checksum = "3939c52070fbda08691d25319e4af8965c1c52507a3e868915be5bc4e1303f9e"
 dependencies = [
  "bytes",
  "http",
@@ -2991,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e80cdf192d7eff05feed747894d64f81905ac4eaf132edf7ea270abdd2d663"
+checksum = "c64335f9f24ccb62ac36f1d976342b48611a75ba61979813a4f78a4ebd94de42"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3012,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sftp"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79feb943e8e0f2c8e57c98773e6c9e1006abf486710af78a9929fe22aab1684f"
+checksum = "baf159e1edfbbdab07724396681862c5ecacbe75003495aeb0f3f58910638a50"
 dependencies = [
  "bytes",
  "fastpool",
@@ -3029,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-swift"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44595b08eb013c0003377f501c52823ea206b651e7f2cae0da33c7fcb2fbc928"
+checksum = "63f9552485e97289d44f13577ca15fb62f95965e433a0ce1b5f613f8f52cc52b"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3050,15 +3060,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743e25172ee8de7a4782eabd0d6030095b60558e8354e7422cd960c59adf2131"
+checksum = "1fa9aec39b39efa0367020732991260373492ffb0273259591ec362b664f455f"
 dependencies = [
  "anyhow",
+ "asyncband",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "quick-xml",
  "serde",
@@ -3066,15 +3076,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8703b22fe6e6b8aef40a8fc884aba39c78405c657ec545134552f785c2f193a"
+checksum = "3a0f7466fde4e0574935079401198c59980fe3dceb820c23a239e2fe513b1126"
 dependencies = [
  "anyhow",
+ "asyncband",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "serde",
  "serde_json",
@@ -3083,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-yandex-disk"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34926d9c5014176cee60177382bf99af378fa1084e135556b2bf0612c69ce695"
+checksum = "8aec0fda74736af2b5b967e44b12a4a8a6d34a51ba3043681502424afb59ccf8"
 dependencies = [
  "bytes",
  "http",
@@ -4106,7 +4116,6 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4273,10 +4282,12 @@ dependencies = [
  "conflate",
  "derive_setters",
  "displaydoc",
+ "futures-util",
  "hex",
  "jiff",
  "log",
  "opendal",
+ "opendal-http-transport-reqwest",
  "rand 0.10.2",
  "rayon",
  "reqwest",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -35,13 +35,22 @@ cli = ["merge", "clap"]
 merge = ["dep:conflate"]
 clap = ["dep:clap"]
 opendal = [
+  "reqwest",
   "dep:opendal",
+  "dep:opendal-http-transport-reqwest",
   "dep:rayon",
   "dep:tokio",
-  "tokio/rt-multi-thread",
   "dep:typed-path",
+  "tokio/rt-multi-thread",
 ]
-rest = ["dep:reqwest", "dep:backon"]
+reqwest = ["dep:reqwest"]
+rest = [
+  "reqwest",
+  "dep:backon",
+  "dep:futures-util",
+  "dep:tokio",
+  "tokio/rt-multi-thread",
+]
 rclone = ["rest", "dep:rand", "dep:semver"]
 
 [dependencies]
@@ -63,7 +72,10 @@ strum = { version = "0.28.0", features = ["derive"] }
 
 # general / backend choosing
 hex = { version = "0.4.3", features = ["serde"] }
+rayon = { version = "1.11.0", optional = true }
 serde = { version = "1.0.228" }
+tokio = { version = "1.49.0", optional = true, default-features = false }
+typed-path = { version = "0.12.2", optional = true }
 url = "2.5.8"
 
 # cli support
@@ -74,9 +86,12 @@ conflate = { version = "0.3.3", optional = true }
 aho-corasick = { workspace = true }
 walkdir = "2.5.0"
 
+# reqwest
+reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls", "stream"], optional = true }
+
 # rest backend
 backon = { version = "1.6.0", optional = true }
-reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls", "stream", "blocking"], optional = true }
+futures-util = { version = "0.3.34", default-features = false, optional = true }
 
 # rclone backend
 rand = { version = "0.10.0", optional = true }
@@ -84,18 +99,16 @@ semver = { version = "1.0.27", optional = true }
 
 # opendal backend
 bytesize = "2.3.1"
-rayon = { version = "1.11.0", optional = true }
-tokio = { version = "1.49.0", optional = true, default-features = false }
-typed-path = { version = "0.12.2", optional = true }
+opendal-http-transport-reqwest = { version = "0.58.2", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 # opendal backend
 # - sftp is not supported on windows, see https://github.com/apache/incubator-opendal/issues/2963
-opendal = { version = "0.58.1", features = ["blocking", "services-b2", "services-ftp", "services-sftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-pcloud", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
+opendal = { version = "0.58.2", features = ["blocking", "services-b2", "services-ftp", "services-sftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-pcloud", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # opendal backend
-opendal = { version = "0.58.1", features = ["blocking", "services-b2", "services-ftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-pcloud", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
+opendal = { version = "0.58.2", features = ["blocking", "services-b2", "services-ftp", "services-swift", "services-azblob", "services-azdls", "services-cos", "services-fs", "services-dropbox", "services-gdrive", "services-gcs", "services-ghac", "services-http", "services-ipmfs", "services-memory", "services-obs", "services-onedrive", "services-oss", "services-pcloud", "services-s3", "services-webdav", "services-webhdfs", "services-azfile", "layers-throttle", "services-yandex-disk"], optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -61,6 +61,9 @@ pub mod local;
 /// Utility functions for the backend.
 pub mod util;
 
+#[cfg(feature = "reqwest")]
+pub(crate) mod reqwest;
+
 /// `OpenDAL` backend for Rustic.
 #[cfg(feature = "opendal")]
 pub mod opendal;

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -11,11 +11,12 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use log::{error, trace, warn};
 use opendal::{
-    Entry, Metadata,
+    Entry, HttpTransporter, Metadata, OperationContext,
     blocking::{Operator, StdReader},
     layers::{ConcurrentLimitLayer, LoggingLayer, RetryLayer, ThrottleLayer},
     options::{ListOptions, ReadOptions},
 };
+use opendal_http_transport_reqwest::ReqwestTransport;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use tokio::runtime::Runtime;
 use typed_path::UnixPathBuf;
@@ -25,6 +26,8 @@ use rustic_core::{
     ReadSourceEntry, ReadSourceOpen, RusticError, RusticResult, WriteBackend,
     repofile::{Node, NodeType},
 };
+
+use crate::reqwest::reqwest_client;
 
 mod constants {
     /// Default number of retries
@@ -144,6 +147,10 @@ impl OpenDALBackend {
             .map(|t| Throttle::from_str(t))
             .transpose()?;
 
+        let client = reqwest_client(&options)?;
+        let http_transport = HttpTransporter::new(ReqwestTransport::new(client));
+        let operation_context = OperationContext::new().with_http_transport(http_transport);
+
         let scheme = path
             .as_ref()
             .split(':')
@@ -159,7 +166,7 @@ impl OpenDALBackend {
                 )
                 .attach_context("path", path.as_ref().to_string())
                 .attach_context("schema", scheme.to_string())
-            })?
+            })?.with_context(operation_context)
             .layer(RetryLayer::new().with_max_times(max_retries).with_jitter());
 
         if let Some(Throttle { bandwidth, burst }) = throttle {

--- a/crates/backend/src/reqwest.rs
+++ b/crates/backend/src/reqwest.rs
@@ -1,0 +1,105 @@
+use std::str::FromStr;
+use std::{collections::BTreeMap, io::Read};
+
+use jiff::SignedDuration;
+use log::warn;
+use reqwest::{
+    Client, ClientBuilder,
+    header::{HeaderMap, HeaderValue},
+};
+
+use rustic_core::{ErrorKind, RusticError, RusticResult};
+
+pub(super) mod constants {
+    use std::time::Duration;
+
+    /// Default timeout for the client
+    /// This is set to 10 minutes
+    pub(super) const DEFAULT_TIMEOUT: Duration = Duration::from_mins(10);
+}
+
+fn read_file_contents(log_name: &str, path: &str) -> RusticResult<Vec<u8>> {
+    let mut buf = Vec::new();
+    let _ = std::fs::File::open(path)
+        .map_err(|err| {
+            RusticError::with_source(
+                ErrorKind::InvalidInput,
+                "Cannot open {log_name} `{path}`",
+                err,
+            )
+            .attach_context("path", path)
+            .attach_context("log_name", log_name)
+        })?
+        .read_to_end(&mut buf)
+        .map_err(|err| {
+            RusticError::with_source(
+                ErrorKind::InvalidInput,
+                "Cannot read {log_name} `{path}`",
+                err,
+            )
+            .attach_context("path", path)
+            .attach_context("log_name", log_name)
+        })?;
+    Ok(buf)
+}
+
+fn get_cacert(value: &str) -> RusticResult<reqwest::Certificate> {
+    let buf = read_file_contents("cacert", value)?;
+    reqwest::Certificate::from_pem(&buf).map_err(|err| {
+        RusticError::with_source(
+            ErrorKind::InvalidInput,
+            "Cannot parse cacert `{value}`",
+            err,
+        )
+        .attach_context("value", value)
+    })
+}
+
+fn get_tls_client_cert(value: &str) -> RusticResult<reqwest::Identity> {
+    let buf = read_file_contents("tls-client-cert", value)?;
+    reqwest::Identity::from_pem(&buf).map_err(|err| {
+        RusticError::with_source(
+            ErrorKind::InvalidInput,
+            "Cannot parse tls-client-cert `{value}`",
+            err,
+        )
+        .attach_context("value", value)
+    })
+}
+
+pub fn reqwest_client(options: &BTreeMap<String, String>) -> RusticResult<Client> {
+    let mut headers = HeaderMap::new();
+    _ = headers.insert("User-Agent", HeaderValue::from_static("rustic"));
+
+    // set default timeout to 10 minutes (we can have *large* packfiles)
+    let mut timeout = constants::DEFAULT_TIMEOUT;
+
+    let mut client_builder = ClientBuilder::new().default_headers(headers);
+
+    for (option, value) in options {
+        if option == "timeout" {
+            timeout = SignedDuration::from_str(value).map_err(|err| {
+                    RusticError::with_source(
+                        ErrorKind::InvalidInput,
+                        "Could not parse value `{value}` as duration. Invalid value for option `{option}`.",
+                        err,
+                    )
+                    .attach_context("value", value)
+                    .attach_context("option", "timeout")
+                })?.try_into()
+                // ignore conversation errors, but print out warning
+                .inspect_err(|err| warn!("cannot use timeout: {err}"))
+                .unwrap_or_default();
+        } else if option == "cacert" {
+            client_builder = client_builder.add_root_certificate(get_cacert(value)?);
+        } else if option == "tls-client-cert" {
+            client_builder = client_builder.identity(get_tls_client_cert(value)?);
+        }
+    }
+
+    let client = client_builder.timeout(timeout).build().map_err(|err| {
+        RusticError::with_source(ErrorKind::Backend, "Failed to build HTTP client", err)
+    })?;
+
+    Ok(client)
+}

--- a/crates/backend/src/reqwest.rs
+++ b/crates/backend/src/reqwest.rs
@@ -94,6 +94,20 @@ pub fn reqwest_client(options: &BTreeMap<String, String>) -> RusticResult<Client
             client_builder = client_builder.add_root_certificate(get_cacert(value)?);
         } else if option == "tls-client-cert" {
             client_builder = client_builder.identity(get_tls_client_cert(value)?);
+        } else if option == "http-insecure-tls" {
+            match value.parse() {
+                Err(err) => warn!("cannot use value for `http-insecure-tls`: {err}"),
+                Ok(insecure_tls) => {
+                    client_builder = client_builder.danger_accept_invalid_certs(insecure_tls);
+                }
+            }
+        } else if option == "http-referer" {
+            match value.parse() {
+                Err(err) => warn!("cannot use value for `http-referer`: {err}"),
+                Ok(referer) => {
+                    client_builder = client_builder.referer(referer);
+                }
+            }
         }
     }
 

--- a/crates/backend/src/rest.rs
+++ b/crates/backend/src/rest.rs
@@ -1,35 +1,32 @@
-use std::io::Read;
+use std::collections::BTreeMap;
 use std::str::FromStr;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use backon::{BlockingRetryable, ExponentialBuilder};
 use bytes::Bytes;
-use jiff::SignedDuration;
+use futures_util::stream;
 use log::{trace, warn};
 use reqwest::{
-    Url,
-    blocking::{Body, Client, ClientBuilder},
+    Body, Client, Url,
     header::{HeaderMap, HeaderValue},
 };
 use serde::Deserialize;
+use tokio::runtime::Runtime;
 
 use rustic_core::{
     BytesList, ErrorKind, FileType, Id, ReadBackend, RusticError, RusticResult, WriteBackend,
 };
+
+use crate::reqwest::reqwest_client;
 
 /// joining URL failed on: `{0}`
 #[derive(thiserror::Error, Clone, Copy, Debug, displaydoc::Display)]
 pub struct JoiningUrlFailedError(url::ParseError);
 
 pub(super) mod constants {
-    use std::time::Duration;
-
     /// Default number of retries
     pub(super) const DEFAULT_RETRY: usize = 5;
-
-    /// Default timeout for the client
-    /// This is set to 10 minutes
-    pub(super) const DEFAULT_TIMEOUT: Duration = Duration::from_mins(10);
 }
 
 fn construct_backoff_error(err: reqwest::Error) -> Box<RusticError> {
@@ -38,55 +35,6 @@ fn construct_backoff_error(err: reqwest::Error) -> Box<RusticError> {
         "Backoff failed, please check the logs for more information.",
         err,
     )
-}
-
-fn read_file_contents(log_name: &str, path: &str) -> RusticResult<Vec<u8>> {
-    let mut buf = Vec::new();
-    let _ = std::fs::File::open(path)
-        .map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::InvalidInput,
-                "Cannot open {log_name} `{path}`",
-                err,
-            )
-            .attach_context("path", path)
-            .attach_context("log_name", log_name)
-        })?
-        .read_to_end(&mut buf)
-        .map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::InvalidInput,
-                "Cannot read {log_name} `{path}`",
-                err,
-            )
-            .attach_context("path", path)
-            .attach_context("log_name", log_name)
-        })?;
-    Ok(buf)
-}
-
-fn get_cacert(value: &str) -> RusticResult<reqwest::Certificate> {
-    let buf = read_file_contents("cacert", value)?;
-    reqwest::Certificate::from_pem(&buf).map_err(|err| {
-        RusticError::with_source(
-            ErrorKind::InvalidInput,
-            "Cannot parse cacert `{value}`",
-            err,
-        )
-        .attach_context("value", value)
-    })
-}
-
-fn get_tls_client_cert(value: &str) -> RusticResult<reqwest::Identity> {
-    let buf = read_file_contents("tls-client-cert", value)?;
-    reqwest::Identity::from_pem(&buf).map_err(|err| {
-        RusticError::with_source(
-            ErrorKind::InvalidInput,
-            "Cannot parse tls-client-cert `{value}`",
-            err,
-        )
-        .attach_context("value", value)
-    })
 }
 
 /// A backend implementation that uses REST to access the backend.
@@ -98,6 +46,16 @@ pub struct RestBackend {
     client: Client,
     /// The ``BackoffBuilder`` we use
     backoff: ExponentialBuilder,
+}
+
+fn runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    })
 }
 
 impl RestBackend {
@@ -137,10 +95,7 @@ impl RestBackend {
     ///
     /// * If the url could not be parsed.
     /// * If the client could not be built.
-    pub fn new(
-        url: impl AsRef<str>,
-        options: impl IntoIterator<Item = (String, String)>,
-    ) -> RusticResult<Self> {
+    pub fn new(url: impl AsRef<str>, options: BTreeMap<String, String>) -> RusticResult<Self> {
         let url = url.as_ref().to_string();
 
         let url = if url.ends_with('/') {
@@ -160,10 +115,7 @@ impl RestBackend {
         let mut headers = HeaderMap::new();
         _ = headers.insert("User-Agent", HeaderValue::from_static("rustic"));
 
-        // set default timeout to 10 minutes (we can have *large* packfiles)
-        let mut timeout = constants::DEFAULT_TIMEOUT;
-
-        let mut client_builder = ClientBuilder::new().default_headers(headers);
+        let client = reqwest_client(&options)?;
 
         // backon doesn't allow us to specify `None` for `max_delay`
         // see <https://github.com/Xuanwo/backon/pull/160>
@@ -171,7 +123,6 @@ impl RestBackend {
             .with_max_delay(Duration::MAX) // no maximum elapsed time; we count number of retries
             .with_max_times(constants::DEFAULT_RETRY);
 
-        // FIXME: If we have multiple times the same option, this could lead to unexpected behavior
         for (option, value) in options {
             if option == "retry" {
                 let max_retries = match value.as_str() {
@@ -188,29 +139,8 @@ impl RestBackend {
                     })?,
                 };
                 backoff = backoff.with_max_times(max_retries);
-            } else if option == "timeout" {
-                timeout = SignedDuration::from_str(&value).map_err(|err| {
-                    RusticError::with_source(
-                        ErrorKind::InvalidInput,
-                        "Could not parse value `{value}` as duration. Invalid value for option `{option}`.",
-                        err,
-                    )
-                    .attach_context("value", value)
-                    .attach_context("option", "timeout")
-                })?.try_into()
-                // ignore conversation errors, but print out warning
-                .inspect_err(|err| warn!("cannot use timeout: {err}"))
-                .unwrap_or_default();
-            } else if option == "cacert" {
-                client_builder = client_builder.add_root_certificate(get_cacert(&value)?);
-            } else if option == "tls-client-cert" {
-                client_builder = client_builder.identity(get_tls_client_cert(&value)?);
             }
         }
-
-        let client = client_builder.timeout(timeout).build().map_err(|err| {
-            RusticError::with_source(ErrorKind::Backend, "Failed to build HTTP client", err)
-        })?;
 
         Ok(Self {
             url,
@@ -300,32 +230,43 @@ impl ReadBackend for RestBackend {
         })?;
 
         self.retry_notify(|| {
-            if tpe == FileType::Config {
-                return Ok(
-                    if self.client.head(url.clone()).send()?.status().is_success() {
-                        vec![(Id::default(), 0)]
-                    } else {
-                        Vec::new()
-                    },
-                );
-            }
+            runtime().block_on(async {
+                if tpe == FileType::Config {
+                    return Ok(
+                        if self
+                            .client
+                            .head(url.clone())
+                            .send()
+                            .await?
+                            .status()
+                            .is_success()
+                        {
+                            vec![(Id::default(), 0)]
+                        } else {
+                            Vec::new()
+                        },
+                    );
+                }
 
-            let list = self
-                .client
-                .get(url.clone())
-                .header("Accept", "application/vnd.x.restic.rest.v2")
-                .send()?
-                .error_for_status()?
-                .json::<Option<Vec<ListEntry>>>()? // use Option to be handle null json value
-                .unwrap_or_default();
+                let list = self
+                    .client
+                    .get(url.clone())
+                    .header("Accept", "application/vnd.x.restic.rest.v2")
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json::<Option<Vec<ListEntry>>>() // use Option to  handle null json value
+                    .await?
+                    .unwrap_or_default();
 
-            Ok(list
-                .into_iter()
-                .filter_map(|entry| {
-                    let id = Id::parse_some(&entry.name, tpe)?;
-                    Some((id, entry.size))
-                })
-                .collect())
+                Ok(list
+                    .into_iter()
+                    .filter_map(|entry| {
+                        let id = Id::parse_some(&entry.name, tpe)?;
+                        Some((id, entry.size))
+                    })
+                    .collect())
+            })
         })
         .map_err(construct_backoff_error)
     }
@@ -349,11 +290,15 @@ impl ReadBackend for RestBackend {
             .map_err(|err| construct_join_url_error(err, tpe, id, &self.url))?;
 
         self.retry_notify(|| {
-            self.client
-                .get(url.clone())
-                .send()?
-                .error_for_status()?
-                .bytes()
+            runtime().block_on(async {
+                self.client
+                    .get(url.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .bytes()
+                    .await
+            })
         })
         .map_err(construct_backoff_error)
     }
@@ -391,12 +336,16 @@ impl ReadBackend for RestBackend {
         })?;
 
         self.retry_notify(|| {
-            self.client
-                .get(url.clone())
-                .header("Range", header_value.clone())
-                .send()?
-                .error_for_status()?
-                .bytes()
+            runtime().block_on(async {
+                self.client
+                    .get(url.clone())
+                    .header("Range", header_value.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .bytes()
+                    .await
+            })
         })
         .map_err(construct_backoff_error)
     }
@@ -442,8 +391,15 @@ impl WriteBackend for RestBackend {
         })?;
 
         self.retry_notify(|| {
-            _ = self.client.post(url.clone()).send()?.error_for_status()?;
-            Ok(())
+            runtime().block_on(async {
+                _ = self
+                    .client
+                    .post(url.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                Ok(())
+            })
         })
         .map_err(construct_backoff_error)
     }
@@ -473,14 +429,24 @@ impl WriteBackend for RestBackend {
             .map_err(|err| construct_join_url_error(err, tpe, id, &self.url))?;
 
         self.retry_notify(|| {
-            let body = Body::new(content.clone().reader());
-            _ = self
-                .client
-                .post(url.clone())
-                .body(body)
-                .send()?
-                .error_for_status()?;
-            Ok(())
+            let stream = stream::iter(
+                content
+                    .clone()
+                    .into_vec()
+                    .into_iter()
+                    .map(|b| -> RusticResult<_> { Ok(b) }),
+            );
+            let body = Body::wrap_stream(stream);
+            runtime().block_on(async {
+                _ = self
+                    .client
+                    .post(url.clone())
+                    .body(body)
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                Ok(())
+            })
         })
         .map_err(construct_backoff_error)
     }
@@ -503,8 +469,15 @@ impl WriteBackend for RestBackend {
             .map_err(|err| construct_join_url_error(err, tpe, id, &self.url))?;
 
         self.retry_notify(|| {
-            _ = self.client.delete(url.clone()).send()?.error_for_status()?;
-            Ok(())
+            runtime().block_on(async {
+                _ = self
+                    .client
+                    .delete(url.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                Ok(())
+            })
         })
         .map_err(construct_backoff_error)
     }


### PR DESCRIPTION
This PR introduces a reqwest client which is used by both the rest and the opendal backend (for http-based backend access).

Furthermore it adds some options to fine-tune this client:
- `http-insecure-tls` -> allows to use self-signed certificates
- `http-referer` -> allows to configure whether a Referer header is used
- `timeout` (new for opendal) -> allow to configure the timeout for a single http request
- `cacert` (new for opendal)  -> allows to read and use a root certificate from a local file
- `tls-client-cert` (new for opendal) -> allows to read and use a client certificate from a local file.

closes #555
closes https://github.com/rustic-rs/rustic/issues/1895

This is a breaking change as `RestBackend::new` now takes the options as `BTreeMap<String,String>` instead as accepting any iterator.