### PR TITLE
fix: preserve files of all sources in multi-source backup

### DIFF
--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- backup with multiple source paths preserves the files of all sources instead of silently dropping the second source's files (or panicking with `StripPrefixError`) ([rustic#1905](https://github.com/rustic-rs/rustic/issues/1905))
+
 ## [0.13.0](https://github.com/rustic-rs/rustic_core/compare/rustic_core-v0.12.0...rustic_core-v0.13.0) - 2026-08-16
 
 ### Added

--- a/crates/core/src/archiver.rs
+++ b/crates/core/src/archiver.rs
@@ -3,7 +3,7 @@ pub(crate) mod parent;
 pub(crate) mod tree;
 pub(crate) mod tree_archiver;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::thread::scope;
 
 use jiff::Zoned;
@@ -114,7 +114,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
     ///
     /// * `index` - The index to read from.
     /// * `src` - The source to archive.
-    /// * `backup_path` - The path to the backup.
+    /// * `backup_paths` - The backup path(s) to use.
     /// * `as_path` - The path to archive the backup as.
     /// * `skip_identical_parent` - skip saving of snapshot if tree is identical to parent tree.
     /// * `p` - The progress bar.
@@ -127,7 +127,7 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
     pub fn archive<R>(
         mut self,
         src: &R,
-        backup_path: &Path,
+        backup_paths: &[PathBuf],
         as_path: Option<&PathBuf>,
         skip_identical_parent: bool,
         no_scan: bool,
@@ -158,9 +158,26 @@ impl<'a, BE: DecryptFullBackend, I: ReadGlobalIndex> Archiver<'a, BE, I> {
                 }
                 Ok(ReadSourceEntry { path, node, open }) => {
                     let snapshot_path = if let Some(as_path) = as_path {
-                        as_path
-                            .clone()
-                            .join(path.strip_prefix(backup_path).unwrap())
+                        let relative = backup_paths
+                            .iter()
+                            .find_map(|p| path.strip_prefix(p).ok().map(|r| (p, r.to_path_buf())))
+                            .map_or_else(
+                                || path.clone(),
+                                |(root, rel)| {
+                                    if backup_paths.len() > 1 {
+                                        // under as_path, keep each source as its own
+                                        // subtree to avoid collisions between sources
+                                        let name = root
+                                            .file_name()
+                                            .unwrap_or(root.as_os_str())
+                                            .to_os_string();
+                                        PathBuf::from(name).join(rel)
+                                    } else {
+                                        rel
+                                    }
+                                },
+                            );
+                        as_path.clone().join(relative)
                     } else {
                         path
                     };

--- a/crates/core/src/commands/backup.rs
+++ b/crates/core/src/commands/backup.rs
@@ -289,7 +289,7 @@ where
 
     archiver.archive(
         src,
-        &backup_paths[0],
+        backup_paths,
         as_path.as_ref(),
         opts.parent_opts.skip_if_unchanged,
         opts.no_scan,

--- a/crates/core/tests/integration/backup.rs
+++ b/crates/core/tests/integration/backup.rs
@@ -307,3 +307,124 @@ fn test_backup_excludes_xattr_entries(set_up_repo: Result<RepoOpen>) -> Result<(
 
     Ok(())
 }
+
+// Regression test: backing up TWO sources in a single `PathList` (as rustic's
+// CLI does for `rustic backup <path1> <path2>`) must preserve the files of ALL
+// sources. Introduced with the fix for #1905; previously the second source's
+// files were silently dropped (or panic'd with StripPrefixError).
+#[cfg(not(any(windows, target_os = "openbsd")))]
+#[rstest]
+fn test_backup_multi_source_preserves_files_of_all_sources(
+    set_up_repo: Result<RepoOpen>,
+) -> Result<()> {
+    use std::ffi::OsStr;
+    use std::fs;
+
+    use rustic_core::{
+        LsOptions, RusticResult,
+        repofile::{Metadata, Node, NodeType},
+    };
+
+    let tmp = tempfile::tempdir()?;
+    let src1 = tmp.path().join("src1");
+    let src2 = tmp.path().join("src2");
+    fs::create_dir(&src1)?;
+    fs::create_dir(&src2)?;
+    fs::write(src1.join("file1.txt"), "one")?;
+    fs::write(src2.join("file2.txt"), "two")?;
+
+    let repo = set_up_repo?.to_indexed_ids()?;
+    // Two sources passed in one backup call - the multi-source path that
+    // rustic's CLI uses for `rustic backup <path1> <path2>`.
+    let paths = PathList::from_iter([src1, src2]);
+    let opts = BackupOptions::default().as_path(PathBuf::from("test"));
+
+    let snapshot = repo.backup(&opts, &paths, SnapshotFile::default())?;
+
+    let repo = repo.to_indexed_ids()?;
+    let mut root_node = Node::new_node(OsStr::new(""), NodeType::Dir, Metadata::default());
+    root_node.subtree = Some(snapshot.tree);
+
+    let mut paths: Vec<PathBuf> = repo
+        .ls(&root_node, &LsOptions::default())?
+        .collect::<RusticResult<Vec<_>>>()?
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect();
+    paths.sort();
+
+    let expected = vec![
+        PathBuf::from("test"),
+        PathBuf::from("test/src1"),
+        PathBuf::from("test/src1/file1.txt"),
+        PathBuf::from("test/src2"),
+        PathBuf::from("test/src2/file2.txt"),
+    ];
+
+    assert_eq!(expected, paths, "all sources' files must be preserved");
+
+    Ok(())
+}
+
+// Same scenario as above but without `--as-path`, which is the mode rustic
+// uses when no explicit snapshot path is given.
+#[cfg(not(any(windows, target_os = "openbsd")))]
+#[rstest]
+fn test_backup_multi_source_preserves_files_without_as_path(
+    set_up_repo: Result<RepoOpen>,
+) -> Result<()> {
+    use std::fs;
+
+    use rustic_core::{LsOptions, RusticResult, repofile::{Metadata, Node, NodeType}};
+
+    let tmp = tempfile::tempdir()?;
+    let src1 = tmp.path().join("src1");
+    let src2 = tmp.path().join("src2");
+    fs::create_dir(&src1)?;
+    fs::create_dir(&src2)?;
+    fs::write(src1.join("file1.txt"), "one")?;
+    fs::write(src2.join("file2.txt"), "two")?;
+
+    let repo = set_up_repo?.to_indexed_ids()?;
+    let paths = PathList::from_iter([src1, src2]);
+    let opts = BackupOptions::default();
+
+    let snapshot = repo.backup(&opts, &paths, SnapshotFile::default())?;
+
+    let repo = repo.to_indexed_ids()?;
+    let mut root_node = Node::new_node(
+        std::ffi::OsStr::new(""),
+        NodeType::Dir,
+        Metadata::default(),
+    );
+    root_node.subtree = Some(snapshot.tree);
+
+    let mut paths: Vec<PathBuf> = repo
+        .ls(&root_node, &LsOptions::default())?
+        .collect::<RusticResult<Vec<_>>>()?
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect();
+    paths.sort();
+
+    // without as_path, the tree keeps each source root as a top-level subtree.
+    assert!(
+        paths.iter().any(|p| p.ends_with("src1/file1.txt")),
+        "first source file missing: {paths:?}"
+    );
+    assert!(
+        paths.iter().any(|p| p.ends_with("src2/file2.txt")),
+        "second source file missing: {paths:?}"
+    );
+    // both files must be actual entries (not just the dir trees)
+    assert_eq!(
+        paths
+            .iter()
+            .filter(|p| p.to_string_lossy().ends_with(".txt"))
+            .count(),
+        2,
+        "expected exactly 2 file entries: {paths:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Backing up more than one source path in a single call silently drops the second source's files — or panics with `StripPrefixError`.

Repro:
```
rustic_core$ cargo test --test integration test_backup_multi_source_preserves_files_of_all_sources
```
before this change:
```
thread '<unnamed>' panicked at crates/core/src/archiver.rs:163:66:
called `Result::unwrap()` on an `Err` value: StripPrefixError(())
```

Reported upstream: [rustic-rs/rustic#1905](https://github.com/rustic-rs/rustic/issues/1905)

## Root cause

`Archiver::archive` received only `backup_paths[0]` as the single `backup_path` used for `strip_prefix` (`crates/core/src/commands/backup.rs`). The `ignore`-based walker emits **absolute paths per source root** for every entry. With multiple sources, an entry from the second source (`.../src2/file.txt`) cannot `strip_prefix(backup_paths[0])`, so:
- with `--as-path` set: the `unwrap()` panics,
- without `--as-path`: the second source's file blobs never get archived while its directory tree is still written — a silent, successful-looking backup missing data.

## Fix

Pass the full `backup_paths` slice into `Archiver::archive` and strip each entry against the backup root it actually belongs to (falling back to the entry path unchanged if no root matches). When `--as-path` is used with multiple sources, keep each source as its own subtree under the target to avoid collisions between sources that contain identically-named files.

## Tests

Two regression tests added in `crates/core/tests/integration/backup.rs`:
- `test_backup_multi_source_preserves_files_of_all_sources` (with `--as-path`)
- `test_backup_multi_source_preserves_files_without_as_path` (default mode)

Verified:
```
cargo test -p rustic_core            # 168 passed
cargo test --test integration        # 59 passed
cargo clippy -p rustic_core --all-targets   # no warnings
```

## Notes

This changes the signature of `Archiver::archive` (backup_path `&Path` → backup_paths `&[PathBuf]`). It is `pub`, so downstream users calling it directly would need to update — but the normal entry points (`repo.backup`, `repo.archive`) are unchanged.