### PR TITLE
feat: log OpenDAL retries as a single line

### DIFF
--- a/crates/backend/CHANGELOG.md
+++ b/crates/backend/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- log OpenDAL retries as a single line instead of dumping the error `Debug` tree
+
 ## [0.7.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.6.2...rustic_backend-v0.7.0) - 2026-08-16
 
 ### Added

--- a/crates/backend/CHANGELOG.md
+++ b/crates/backend/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
-
-### Fixed
-
-- log OpenDAL retries as a single line instead of dumping the error `Debug` tree
-
 ## [0.7.0](https://github.com/rustic-rs/rustic_core/compare/rustic_backend-v0.6.2...rustic_backend-v0.7.0) - 2026-08-16
 
 ### Added

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -13,7 +13,9 @@ use log::{error, trace, warn};
 use opendal::{
     Entry, HttpTransporter, Metadata, OperationContext,
     blocking::{Operator, StdReader},
-    layers::{ConcurrentLimitLayer, LoggingLayer, RetryLayer, ThrottleLayer},
+    layers::{
+        ConcurrentLimitLayer, LoggingLayer, RetryEvent, RetryInterceptor, RetryLayer, ThrottleLayer,
+    },
     options::{ListOptions, ReadOptions},
 };
 use opendal_http_transport_reqwest::ReqwestTransport;
@@ -48,6 +50,26 @@ fn runtime() -> &'static Runtime {
             .build()
             .unwrap()
     })
+}
+
+/// Log `OpenDAL` retries as a single line using `Display`, not `Debug`.
+///
+/// `OpenDAL`'s default interceptor formats the error with `{:?}`, which dumps
+/// the full context/source tree across many lines and fights progress/TUI
+/// output.
+#[derive(Clone, Copy, Debug)]
+struct CompactRetryInterceptor;
+
+impl RetryInterceptor for CompactRetryInterceptor {
+    fn intercept(&self, event: RetryEvent<'_>) {
+        warn!(
+            "Error {err} at {duration:?}, retrying {op:?} (attempt {attempt})",
+            err = event.err,
+            duration = event.retry_after,
+            op = event.op,
+            attempt = event.attempt,
+        );
+    }
 }
 
 /// Throttling parameters
@@ -167,7 +189,12 @@ impl OpenDALBackend {
                 .attach_context("path", path.as_ref().to_string())
                 .attach_context("schema", scheme.to_string())
             })?.with_context(operation_context)
-            .layer(RetryLayer::new().with_max_times(max_retries).with_jitter());
+            .layer(
+                RetryLayer::new()
+                    .with_max_times(max_retries)
+                    .with_jitter()
+                    .with_notify(CompactRetryInterceptor),
+            );
 
         if let Some(Throttle { bandwidth, burst }) = throttle {
             operator = operator.layer(ThrottleLayer::new(bandwidth, burst));
@@ -653,6 +680,27 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn opendal_error_display_is_single_line() {
+        let err = opendal::Error::new(opendal::ErrorKind::Unexpected, "send http request")
+            .with_operation("read")
+            .with_context("url", "https://example.com/index/abc")
+            .set_source(std::io::Error::other(
+                "connection closed before message completed",
+            ));
+
+        let display = err.to_string();
+        let debug = format!("{err:?}");
+        assert!(
+            !display.contains('\n'),
+            "Display should be one line, got: {display:?}"
+        );
+        assert!(
+            debug.contains("Context:"),
+            "Debug should dump context, got: {debug}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- replace OpenDAL's default retry interceptor with a compact one-line warning
- keep the same information (error, delay, operation, attempt) without dumping the `Debug` context tree
- match the REST backend style: `Error {err} at {duration:?}, retrying ...`

## Why

Temporary backend errors such as B2 `connection closed before message completed` are already retried. The default interceptor formats the error with `{:?}`, which prints a multi-line Context/Source dump and overwrites progress output. OpenDAL's `Display` form is already a single line.

## Validation

- `cargo test -p rustic_backend --lib opendal`
- `cargo clippy -p rustic_backend --lib -- -D warnings`

A companion rustic CLI PR captures console logs while the TUI owns the terminal so remaining log output cannot overwrite the progress popup.