### PR TITLE
perf: reuse per-thread zstd output buffer for prune trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4349,6 +4349,7 @@ dependencies = [
  "jiff",
  "lockable",
  "log",
+ "memchr",
  "mockall",
  "nix",
  "pariter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,6 +4360,7 @@ dependencies = [
  "rayon",
  "rstest",
  "runtime-format",
+ "rustc-hash",
  "rustic_backend",
  "rustic_cdc",
  "rustic_testing",

--- a/crates/backend/src/opendal.rs
+++ b/crates/backend/src/opendal.rs
@@ -34,6 +34,14 @@ use crate::reqwest::reqwest_client;
 mod constants {
     /// Default number of retries
     pub(super) const DEFAULT_RETRY: usize = 5;
+
+    /// B2 `b2_list_file_names` page size to request.
+    ///
+    /// `OpenDAL` only sends `maxFileCount` when `ListOptions.limit` is set. If we
+    /// omit it, B2 defaults to 100 names per page (max 10000). Prune (and
+    /// check) list every pack under `data/`, so the default turns a few dozen
+    /// round-trips into thousands and dominates runtime against B2.
+    pub(super) const B2_LIST_PAGE_SIZE: usize = 10_000;
 }
 
 /// `OpenDALBackend` contains a wrapper around an blocking operator of the `OpenDAL` library.
@@ -217,6 +225,30 @@ impl OpenDALBackend {
         Ok(Self { operator })
     }
 
+    /// Listing options used for repository (and source) listings.
+    ///
+    /// For B2 this raises the per-request page size from the API default of 100
+    /// to the documented maximum of 10000.
+    fn list_options(&self, recursive: bool) -> ListOptions {
+        ListOptions {
+            recursive,
+            limit: self.list_page_size(),
+            ..Default::default()
+        }
+    }
+
+    /// Backend-specific list page size, if we should override the service default.
+    fn list_page_size(&self) -> Option<usize> {
+        let info = self.operator.info();
+        if !info.capability().list_with_limit {
+            return None;
+        }
+        match info.scheme() {
+            "b2" => Some(constants::B2_LIST_PAGE_SIZE),
+            _ => None,
+        }
+    }
+
     /// Return a path for the given file type and id.
     ///
     /// # Arguments
@@ -249,10 +281,7 @@ impl OpenDALBackend {
     /// # Errors
     /// If listing fails or exclude patterns cannot be compiled
     pub fn as_source(self, excludes: &Excludes) -> RusticResult<OpenDALReadSource> {
-        let list_options = ListOptions {
-            recursive: true,
-            ..Default::default()
-        };
+        let list_options = self.list_options(true);
         // openDAL lister may entries in random order; hence we collect and sort them here.
         // This also allows to handle listing errors directly
         let mut entries: Vec<_> = self
@@ -348,14 +377,9 @@ impl ReadBackend for OpenDALBackend {
         }
 
         let path = tpe.dirname().to_string() + "/";
-        let list_options = ListOptions {
-            recursive: true,
-            ..Default::default()
-        };
-
         let lister = self
             .operator
-            .lister_options(&path, list_options)
+            .lister_options(&path, self.list_options(true))
             .map_err(|err| {
                 RusticError::with_source(ErrorKind::Backend, "Listing failed for `{type}`", err)
                     .attach_context("type", tpe.to_string())
@@ -405,13 +429,9 @@ impl ReadBackend for OpenDALBackend {
         }
 
         let path = tpe.dirname().to_string() + "/";
-        let list_options = ListOptions {
-            recursive: true,
-            ..Default::default()
-        };
         let lister = self
             .operator
-            .lister_options(&path, list_options)
+            .lister_options(&path, self.list_options(true))
             .map_err(|err| {
                 RusticError::with_source(ErrorKind::Backend, "Listing failed for `{type}`", err)
                     .attach_context("type", tpe.to_string())
@@ -630,6 +650,28 @@ mod tests {
     #[case("10kB;10MB")]
     fn invalid_throttle(#[case] input: &str) {
         assert!(Throttle::from_str(input).is_err());
+    }
+
+    #[rstest]
+    #[case("b2", Some(constants::B2_LIST_PAGE_SIZE))]
+    #[case("s3_aws", None)]
+    fn list_page_size_matches_scheme(
+        #[case] fixture: &str,
+        #[case] expected: Option<usize>,
+    ) -> Result<()> {
+        #[derive(Deserialize)]
+        struct TestCase {
+            path: String,
+            options: BTreeMap<String, String>,
+        }
+
+        let fixture_path = PathBuf::from(format!("tests/fixtures/opendal/{fixture}.toml"));
+        let test: TestCase = toml::from_str(&fs::read_to_string(fixture_path)?)?;
+        let backend = OpenDALBackend::new(test.path, test.options)?;
+
+        assert_eq!(backend.list_page_size(), expected);
+        assert_eq!(backend.list_options(true).limit, expected);
+        Ok(())
     }
 
     #[rstest]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,6 +54,7 @@ crossbeam-channel = "0.5.15"
 pariter = "0.6.0"
 rayon = "1.11.0"
 rustc-hash = "2.1.1"
+memchr = "2.8"
 
 # crypto
 aes256ctr_poly1305aes = { version = "0.2.1", features = ["std"] } # we need std here for error impls

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -53,6 +53,7 @@ log = { workspace = true }
 crossbeam-channel = "0.5.15"
 pariter = "0.6.0"
 rayon = "1.11.0"
+rustc-hash = "2.1.1"
 
 # crypto
 aes256ctr_poly1305aes = { version = "0.2.1", features = ["std"] } # we need std here for error impls

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -75,7 +75,7 @@ cached = { version = "2.0.2", default-features = false, features = ["proc_macro"
 dunce = "1.0.5"
 filetime = "0.2.27"
 ignore = "0.4.25"
-nix = { version = "0.31.1", default-features = false, features = ["user", "fs"] }
+nix = { version = "0.31.1", default-features = false, features = ["user", "fs", "resource"] }
 path-dedot = "4.0.1"
 walkdir = "2.5.0"
 

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -114,6 +114,14 @@ pub trait ReadBackend: Send + Sync + 'static {
         (current_num_threads() + 16).clamp(16, 32)
     }
 
+    /// How many threads to spawn to load trees (`TreeStreamer`).
+    ///
+    /// Remote backends use `2 × CPUs` (8–32) so prune is not RTT-bound on B2.
+    /// Cached backends use fewer when pack files are already on disk.
+    fn tree_loader_count(&self) -> usize {
+        current_num_threads().saturating_mul(2).clamp(8, 32)
+    }
+
     /// Lists all files of the given type.
     ///
     /// # Arguments
@@ -459,6 +467,9 @@ impl ReadBackend for Arc<dyn WriteBackend> {
     }
     fn prefetch_workers(&self, tpe: FileType, ids: &[Id]) -> usize {
         self.deref().prefetch_workers(tpe, ids)
+    }
+    fn tree_loader_count(&self) -> usize {
+        self.deref().tree_loader_count()
     }
     fn list(&self, tpe: FileType) -> RusticResult<Vec<Id>> {
         self.deref().list(tpe)

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -15,6 +15,7 @@ use std::{io::Read, ops::Deref, path::PathBuf, sync::Arc};
 use bytes::{Buf, Bytes, buf::Reader};
 use enum_map::Enum;
 use log::trace;
+use rayon::current_num_threads;
 
 #[cfg(test)]
 use mockall::mock;
@@ -104,6 +105,14 @@ pub trait ReadBackend: Send + Sync + 'static {
     ///
     /// * If the files could not be listed.
     fn list_with_size(&self, tpe: FileType) -> RusticResult<Vec<(Id, u32)>>;
+
+    /// How many parallel readers to use for `stream_list` of these files.
+    ///
+    /// Remote backends keep extra workers for B2 RTTs. Cached backends use a
+    /// few workers when the files are already on disk so we do not thrash HDD.
+    fn prefetch_workers(&self, _tpe: FileType, _ids: &[Id]) -> usize {
+        (current_num_threads() + 16).clamp(16, 32)
+    }
 
     /// Lists all files of the given type.
     ///
@@ -447,6 +456,9 @@ impl ReadBackend for Arc<dyn WriteBackend> {
     }
     fn list_with_size(&self, tpe: FileType) -> RusticResult<Vec<(Id, u32)>> {
         self.deref().list_with_size(tpe)
+    }
+    fn prefetch_workers(&self, tpe: FileType, ids: &[Id]) -> usize {
+        self.deref().prefetch_workers(tpe, ids)
     }
     fn list(&self, tpe: FileType) -> RusticResult<Vec<Id>> {
         self.deref().list(tpe)

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -106,6 +106,17 @@ impl ReadBackend for CachedBackend {
         }
     }
 
+    fn tree_loader_count(&self) -> usize {
+        // Warm pack cache: local preads. 2×CPUs loaders oversubscribe QEMU
+        // vCPUs (KVM PV spinlocks + musl malloc). Cold cache: keep extra
+        // loaders for B2 RTTs.
+        if self.cache.has_cached_packs() {
+            rayon::current_num_threads().clamp(4, 8)
+        } else {
+            self.be.tree_loader_count()
+        }
+    }
+
     /// Lists all files with their size of the given type.
     ///
     /// # Arguments
@@ -396,6 +407,15 @@ impl Cache {
             path,
             open_files: Arc::new(OpenFileCache::new(constants::OPEN_FILE_CAPACITY)),
         })
+    }
+
+    /// True if at least one pack file is already in this cache.
+    #[must_use]
+    pub fn has_cached_packs(&self) -> bool {
+        WalkDir::new(self.path.join(FileType::Pack.dirname()))
+            .into_iter()
+            .filter_map(Result::ok)
+            .any(|e| e.file_type().is_file())
     }
 
     /// Returns the path to the location of this [`Cache`].

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -802,7 +802,7 @@ mod tests {
     fn read_partial_reuses_open_file() {
         let (_dir, cache) = new_cache();
         let id = Id::random();
-        let payload: Vec<u8> = (0..4096).map(|i| i as u8).collect();
+        let payload: Vec<u8> = (0..=u8::MAX).cycle().take(4096).collect();
         cache
             .write_bytes(FileType::Pack, &id, &payload.clone().into())
             .unwrap();
@@ -868,7 +868,7 @@ mod tests {
     fn concurrent_partial_reads() {
         let (_dir, cache) = new_cache();
         let id = Id::random();
-        let payload: Vec<u8> = (0..8192).map(|i| (i % 251) as u8).collect();
+        let payload: Vec<u8> = (0..=250_u8).cycle().take(8192).collect();
         cache
             .write_bytes(FileType::Pack, &id, &payload.clone().into())
             .unwrap();

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -46,8 +46,8 @@ fn open_file_capacity() -> usize {
     32
 }
 
-fn open_file_capacity_from_soft_limit(soft: u64) -> usize {
-    usize::try_from(soft.saturating_sub(constants::OPEN_FILE_RESERVE))
+fn open_file_capacity_from_soft_limit(soft: impl Into<u64>) -> usize {
+    usize::try_from(soft.into().saturating_sub(constants::OPEN_FILE_RESERVE))
         .unwrap_or(usize::MAX)
         .min(constants::OPEN_FILE_CAPACITY)
         .max(1)

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::HashMap,
+    fmt,
     fs::{self, File},
-    io::{self, Read, Seek, SeekFrom},
+    io::{self, Read},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -18,6 +19,34 @@ use crate::{
     id::Id,
     repofile::configfile::RepositoryId,
 };
+
+mod constants {
+    /// Pack files kept open for cache `read_partial`.
+    ///
+    /// Tree walking reads many blobs from the same packs. Opening the cache
+    /// file per blob was ~65% of prune CPU in a Time Profiler trace.
+    pub(super) const OPEN_FILE_CAPACITY: usize = 2048;
+}
+
+type OpenFileCache = quick_cache::sync::Cache<Id, Arc<File>>;
+
+fn is_too_many_open_files(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        // POSIX EMFILE / ENFILE. Do not treat 4 as a match: that is EINTR.
+        matches!(err.raw_os_error(), Some(24 | 23))
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_TOO_MANY_OPEN_FILES
+        err.raw_os_error() == Some(4)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = err;
+        false
+    }
+}
 
 /// Backend that caches data.
 ///
@@ -159,12 +188,18 @@ impl ReadBackend for CachedBackend {
         length: u32,
     ) -> RusticResult<Bytes> {
         if cacheable || tpe.is_cacheable() {
-            let guard = self.lock_pool.blocking_lock(*id);
-            if self.cache.path(tpe, id).exists() {
-                // early drop the lock guard, so we can read the cache in parallel.
-                drop(guard);
+            match self.cache.read_partial(tpe, id, offset, length) {
+                Ok(Some(data)) => return Ok(data),
+                Ok(None) => {}
+                Err(err) => warn!(
+                    "Error in cache backend reading {tpe:?},{id}: {}",
+                    err.display_log()
+                ),
             }
 
+            // Miss: serialize fills of the same pack so two threads don't both
+            // download it. Hits above skip this lock and the exists()+open storm.
+            let _guard = self.lock_pool.blocking_lock(*id);
             match self.cache.read_partial(tpe, id, offset, length) {
                 Ok(Some(data)) => return Ok(data),
                 Ok(None) => {}
@@ -263,10 +298,21 @@ impl WriteBackend for CachedBackend {
 }
 
 /// Backend that caches data in a directory.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Cache {
     /// The path to the cache.
     path: PathBuf,
+    /// Recently used cache files kept open for `read_partial`.
+    open_files: Arc<OpenFileCache>,
+}
+
+impl fmt::Debug for Cache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cache")
+            .field("path", &self.path)
+            .field("open_files", &self.open_files.len())
+            .finish()
+    }
 }
 
 impl Cache {
@@ -329,7 +375,10 @@ impl Cache {
             .attach_context("id", id.to_string())
         })?;
 
-        Ok(Self { path })
+        Ok(Self {
+            path,
+            open_files: Arc::new(OpenFileCache::new(constants::OPEN_FILE_CAPACITY)),
+        })
     }
 
     /// Returns the path to the location of this [`Cache`].
@@ -501,11 +550,23 @@ impl Cache {
     ) -> RusticResult<Option<Bytes>> {
         trace!("cache reading tpe: {tpe:?}, id: {id}, offset: {offset}");
 
-        let path = self.path(tpe, id);
+        if let Some(file) = self.open_files.get(id) {
+            match Self::read_range(&file, offset, length) {
+                Ok(data) => {
+                    trace!("cache hit!");
+                    return Ok(Some(data));
+                }
+                Err(_) => {
+                    // Stale or truncated FD; reopen from disk.
+                    _ = self.open_files.remove(id);
+                }
+            }
+        }
 
-        let mut file = match File::open(&path) {
-            Ok(file) => file,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        let path = self.path(tpe, id);
+        let file = match self.open_cached(id, &path) {
+            Ok(Some(file)) => file,
+            Ok(None) => return Ok(None),
             Err(err) => {
                 return Err(RusticError::with_source(
                     ErrorKind::InputOutput,
@@ -518,23 +579,7 @@ impl Cache {
             }
         };
 
-        _ = file
-            .seek(SeekFrom::Start(u64::from(offset)))
-            .map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::InputOutput,
-                    "Failed to seek to `{offset}` in file `{path}`",
-                    err,
-                )
-                .attach_context("path", path.display().to_string())
-                .attach_context("tpe", tpe.to_string())
-                .attach_context("id", id.to_string())
-                .attach_context("offset", offset.to_string())
-            })?;
-
-        let mut vec = vec![0; length as usize];
-
-        file.read_exact(&mut vec).map_err(|err| {
+        let data = Self::read_range(&file, offset, length).map_err(|err| {
             RusticError::with_source(
                 ErrorKind::InputOutput,
                 "Failed to read at offset `{offset}` from file at `{path}`",
@@ -549,7 +594,50 @@ impl Cache {
 
         trace!("cache hit!");
 
-        Ok(Some(vec.into()))
+        Ok(Some(data))
+    }
+
+    fn open_cached(&self, id: &Id, path: &Path) -> io::Result<Option<Arc<File>>> {
+        if let Some(file) = self.open_files.get(id) {
+            return Ok(Some(file));
+        }
+
+        match File::open(path) {
+            Ok(file) => Ok(Some(self.remember_open(id, file))),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) if is_too_many_open_files(&err) => {
+                self.open_files.clear();
+                match File::open(path) {
+                    Ok(file) => Ok(Some(self.remember_open(id, file))),
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+                    Err(err) => Err(err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn remember_open(&self, id: &Id, file: File) -> Arc<File> {
+        let file = Arc::new(file);
+        self.open_files.insert(*id, file.clone());
+        file
+    }
+
+    fn read_range(file: &File, offset: u32, length: u32) -> io::Result<Bytes> {
+        let mut vec = vec![0; length as usize];
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileExt;
+            file.read_exact_at(&mut vec, u64::from(offset))?;
+        }
+        #[cfg(not(unix))]
+        {
+            use std::io::{Seek, SeekFrom};
+            let mut file = file.try_clone()?;
+            file.seek(SeekFrom::Start(u64::from(offset)))?;
+            file.read_exact(&mut vec)?;
+        }
+        Ok(vec.into())
     }
 
     /// Writes the given data to the given file.
@@ -627,6 +715,8 @@ impl Cache {
             .attach_context("path", filename.display().to_string())
             .ask_report()
         })?;
+        // Drop any FD pointing at the previous inode.
+        _ = self.open_files.remove(id);
 
         Ok(())
     }
@@ -643,6 +733,7 @@ impl Cache {
     /// * If the file could not be removed.
     pub fn remove(&self, tpe: FileType, id: &Id) -> RusticResult<()> {
         trace!("cache writing tpe: {tpe:?}, id: {id}");
+        _ = self.open_files.remove(id);
         let filename = self.path(tpe, id);
         fs::remove_file(&filename).map_err(|err| {
             RusticError::with_source(
@@ -656,5 +747,111 @@ impl Cache {
         })?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn new_cache() -> (tempfile::TempDir, Cache) {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = Cache::new(RepositoryId::default(), Some(dir.path().to_path_buf())).unwrap();
+        (dir, cache)
+    }
+
+    #[test]
+    fn read_partial_reuses_open_file() {
+        let (_dir, cache) = new_cache();
+        let id = Id::random();
+        let payload: Vec<u8> = (0..4096).map(|i| i as u8).collect();
+        cache
+            .write_bytes(FileType::Pack, &id, &payload.clone().into())
+            .unwrap();
+
+        for _ in 0..64 {
+            let got = cache
+                .read_partial(FileType::Pack, &id, 100, 50)
+                .unwrap()
+                .unwrap();
+            assert_eq!(got.as_ref(), &payload[100..150]);
+        }
+        assert_eq!(cache.open_files.len(), 1);
+    }
+
+    #[test]
+    fn write_bytes_invalidates_open_file() {
+        let (_dir, cache) = new_cache();
+        let id = Id::random();
+        cache
+            .write_bytes(FileType::Pack, &id, &vec![0_u8; 128].into())
+            .unwrap();
+        assert_eq!(
+            cache
+                .read_partial(FileType::Pack, &id, 0, 4)
+                .unwrap()
+                .unwrap()
+                .as_ref(),
+            &[0, 0, 0, 0]
+        );
+
+        cache
+            .write_bytes(FileType::Pack, &id, &vec![0xff_u8; 128].into())
+            .unwrap();
+        assert_eq!(
+            cache
+                .read_partial(FileType::Pack, &id, 0, 4)
+                .unwrap()
+                .unwrap()
+                .as_ref(),
+            &[0xff, 0xff, 0xff, 0xff]
+        );
+    }
+
+    #[test]
+    fn remove_closes_and_hides_file() {
+        let (_dir, cache) = new_cache();
+        let id = Id::random();
+        cache
+            .write_bytes(FileType::Pack, &id, &vec![1_u8; 16].into())
+            .unwrap();
+        _ = cache.read_partial(FileType::Pack, &id, 0, 4).unwrap();
+        cache.remove(FileType::Pack, &id).unwrap();
+        assert!(
+            cache
+                .read_partial(FileType::Pack, &id, 0, 4)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(cache.open_files.len(), 0);
+    }
+
+    #[test]
+    fn concurrent_partial_reads() {
+        let (_dir, cache) = new_cache();
+        let id = Id::random();
+        let payload: Vec<u8> = (0..8192).map(|i| (i % 251) as u8).collect();
+        cache
+            .write_bytes(FileType::Pack, &id, &payload.clone().into())
+            .unwrap();
+        thread::scope(|s| {
+            for t in 0..16 {
+                let cache = &cache;
+                let payload = &payload;
+                _ = s.spawn(move || {
+                    let offset = u32::try_from(t * 16).unwrap();
+                    for _ in 0..100 {
+                        let got = cache
+                            .read_partial(FileType::Pack, &id, offset, 16)
+                            .unwrap()
+                            .unwrap();
+                        let start = usize::try_from(offset).unwrap();
+                        assert_eq!(got.as_ref(), &payload[start..start + 16]);
+                    }
+                });
+            }
+        });
+        assert_eq!(cache.open_files.len(), 1);
     }
 }

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -26,22 +26,31 @@ mod constants {
     /// Tree walking reads many blobs from the same packs. Opening the cache
     /// file per blob was ~65% of prune CPU in a Time Profiler trace.
     pub(super) const OPEN_FILE_CAPACITY: usize = 2048;
+    /// Descriptors left for sockets, index files, and other I/O.
+    pub(super) const OPEN_FILE_RESERVE: u64 = 64;
 }
 
 type OpenFileCache = quick_cache::sync::Cache<Id, Arc<CachedFile>>;
 
-/// Keep most descriptors available for backend connections and other I/O.
+/// Use up to [`constants::OPEN_FILE_CAPACITY`] cached pack FDs, leaving
+/// [`constants::OPEN_FILE_RESERVE`] for other I/O. `rlimit/8` mapped a Darwin
+/// 8192 soft limit to 1024 handles.
 fn open_file_capacity() -> usize {
     #[cfg(unix)]
     if let Ok((soft, _)) =
         nix::sys::resource::getrlimit(nix::sys::resource::Resource::RLIMIT_NOFILE)
     {
-        return usize::try_from(soft / 8)
-            .unwrap_or(usize::MAX)
-            .min(constants::OPEN_FILE_CAPACITY);
+        return open_file_capacity_from_soft_limit(soft);
     }
     // Conservative fallback on platforms without a queryable descriptor limit.
     32
+}
+
+fn open_file_capacity_from_soft_limit(soft: u64) -> usize {
+    usize::try_from(soft.saturating_sub(constants::OPEN_FILE_RESERVE))
+        .unwrap_or(usize::MAX)
+        .min(constants::OPEN_FILE_CAPACITY)
+        .max(1)
 }
 
 struct CachedFile {
@@ -935,6 +944,14 @@ mod tests {
             }
         });
         assert_eq!(cache.open_files.len(), 1);
+    }
+
+    #[test]
+    fn open_file_capacity_uses_reserve_not_an_eighth() {
+        assert_eq!(open_file_capacity_from_soft_limit(8192), 2048);
+        assert_eq!(open_file_capacity_from_soft_limit(1024), 960);
+        assert_eq!(open_file_capacity_from_soft_limit(64), 1);
+        assert_eq!(open_file_capacity_from_soft_limit(0), 1);
     }
 
     #[cfg(unix)]

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -89,6 +89,23 @@ impl ReadBackend for CachedBackend {
         self.be.location()
     }
 
+    fn prefetch_workers(&self, tpe: FileType, ids: &[Id]) -> usize {
+        if ids.is_empty() {
+            return 1;
+        }
+        let hits = ids
+            .iter()
+            .filter(|id| self.cache.path(tpe, id).is_file())
+            .count();
+        // Warm cache: few readers so we do not thrash local disk. Cold cache:
+        // extra workers for high-latency GETs.
+        if hits.saturating_mul(4) >= ids.len().saturating_mul(3) {
+            rayon::current_num_threads().clamp(2, 4)
+        } else {
+            (rayon::current_num_threads() + 16).clamp(16, 32)
+        }
+    }
+
     /// Lists all files with their size of the given type.
     ///
     /// # Arguments

--- a/crates/core/src/backend/cache.rs
+++ b/crates/core/src/backend/cache.rs
@@ -28,7 +28,65 @@ mod constants {
     pub(super) const OPEN_FILE_CAPACITY: usize = 2048;
 }
 
-type OpenFileCache = quick_cache::sync::Cache<Id, Arc<File>>;
+type OpenFileCache = quick_cache::sync::Cache<Id, Arc<CachedFile>>;
+
+/// Keep most descriptors available for backend connections and other I/O.
+fn open_file_capacity() -> usize {
+    #[cfg(unix)]
+    if let Ok((soft, _)) =
+        nix::sys::resource::getrlimit(nix::sys::resource::Resource::RLIMIT_NOFILE)
+    {
+        return usize::try_from(soft / 8)
+            .unwrap_or(usize::MAX)
+            .min(constants::OPEN_FILE_CAPACITY);
+    }
+    // Conservative fallback on platforms without a queryable descriptor limit.
+    32
+}
+
+struct CachedFile {
+    file: File,
+    #[cfg(any(test, not(unix)))]
+    seek_lock: std::sync::Mutex<()>,
+}
+
+impl CachedFile {
+    fn new(file: File) -> Self {
+        Self {
+            file,
+            #[cfg(any(test, not(unix)))]
+            seek_lock: std::sync::Mutex::new(()),
+        }
+    }
+
+    fn read_range(&self, offset: u32, length: u32) -> io::Result<Bytes> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileExt;
+            let mut vec = vec![0; length as usize];
+            self.file.read_exact_at(&mut vec, u64::from(offset))?;
+            Ok(vec.into())
+        }
+        #[cfg(not(unix))]
+        self.read_range_seeking(offset, length)
+    }
+
+    /// Cloned file handles share a cursor. Serialize the entire seek/read pair
+    /// on platforms without positional reads; never clone the cached handle.
+    #[cfg(any(test, not(unix)))]
+    fn read_range_seeking(&self, offset: u32, length: u32) -> io::Result<Bytes> {
+        use std::io::{Seek, SeekFrom};
+        let _guard = self
+            .seek_lock
+            .lock()
+            .map_err(|_| io::Error::other("cache seek lock poisoned"))?;
+        let mut file = &self.file;
+        let mut vec = vec![0; length as usize];
+        _ = file.seek(SeekFrom::Start(u64::from(offset)))?;
+        file.read_exact(&mut vec)?;
+        Ok(vec.into())
+    }
+}
 
 fn is_too_many_open_files(err: &io::Error) -> bool {
     #[cfg(unix)]
@@ -405,7 +463,7 @@ impl Cache {
 
         Ok(Self {
             path,
-            open_files: Arc::new(OpenFileCache::new(constants::OPEN_FILE_CAPACITY)),
+            open_files: Arc::new(OpenFileCache::new(open_file_capacity())),
         })
     }
 
@@ -588,7 +646,7 @@ impl Cache {
         trace!("cache reading tpe: {tpe:?}, id: {id}, offset: {offset}");
 
         if let Some(file) = self.open_files.get(id) {
-            match Self::read_range(&file, offset, length) {
+            match file.read_range(offset, length) {
                 Ok(data) => {
                     trace!("cache hit!");
                     return Ok(Some(data));
@@ -616,7 +674,7 @@ impl Cache {
             }
         };
 
-        let data = Self::read_range(&file, offset, length).map_err(|err| {
+        let data = file.read_range(offset, length).map_err(|err| {
             RusticError::with_source(
                 ErrorKind::InputOutput,
                 "Failed to read at offset `{offset}` from file at `{path}`",
@@ -634,7 +692,7 @@ impl Cache {
         Ok(Some(data))
     }
 
-    fn open_cached(&self, id: &Id, path: &Path) -> io::Result<Option<Arc<File>>> {
+    fn open_cached(&self, id: &Id, path: &Path) -> io::Result<Option<Arc<CachedFile>>> {
         if let Some(file) = self.open_files.get(id) {
             return Ok(Some(file));
         }
@@ -654,27 +712,10 @@ impl Cache {
         }
     }
 
-    fn remember_open(&self, id: &Id, file: File) -> Arc<File> {
-        let file = Arc::new(file);
+    fn remember_open(&self, id: &Id, file: File) -> Arc<CachedFile> {
+        let file = Arc::new(CachedFile::new(file));
         self.open_files.insert(*id, file.clone());
         file
-    }
-
-    fn read_range(file: &File, offset: u32, length: u32) -> io::Result<Bytes> {
-        let mut vec = vec![0; length as usize];
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::FileExt;
-            file.read_exact_at(&mut vec, u64::from(offset))?;
-        }
-        #[cfg(not(unix))]
-        {
-            use std::io::{Seek, SeekFrom};
-            let mut file = file.try_clone()?;
-            file.seek(SeekFrom::Start(u64::from(offset)))?;
-            file.read_exact(&mut vec)?;
-        }
-        Ok(vec.into())
     }
 
     /// Writes the given data to the given file.
@@ -885,10 +926,59 @@ mod tests {
                             .unwrap();
                         let start = usize::try_from(offset).unwrap();
                         assert_eq!(got.as_ref(), &payload[start..start + 16]);
+                        // Exercise the non-Unix implementation on every test platform.
+                        let file = cache.open_files.get(&id).unwrap();
+                        let got = file.read_range_seeking(offset, 16).unwrap();
+                        assert_eq!(got.as_ref(), &payload[start..start + 16]);
                     }
                 });
             }
         });
         assert_eq!(cache.open_files.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_respects_file_descriptor_limit() {
+        use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+        const CHILD: &str = "RUSTIC_CACHE_FD_LIMIT_TEST";
+        if std::env::var_os(CHILD).is_none() {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "backend::cache::tests::cache_respects_file_descriptor_limit",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env(CHILD, "1")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let (_, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+        setrlimit(Resource::RLIMIT_NOFILE, 64.min(hard), hard).unwrap();
+        let (_dir, cache) = new_cache();
+        let ids: Vec<_> = (0..100).map(|_| Id::random()).collect();
+        for id in &ids {
+            cache
+                .write_bytes(FileType::Pack, id, &vec![0_u8; 16].into())
+                .unwrap();
+        }
+        for id in &ids {
+            _ = cache
+                .read_partial(FileType::Pack, id, 0, 4)
+                .unwrap()
+                .unwrap();
+            // Other backend/file operations must still have descriptor headroom.
+            let _other_files: Vec<_> = (0..16).map(|_| File::open("/dev/null").unwrap()).collect();
+        }
     }
 }

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -656,6 +656,10 @@ impl<C: CryptoKey> ReadBackend for DecryptBackend<C> {
         self.be.prefetch_workers(tpe, ids)
     }
 
+    fn tree_loader_count(&self) -> usize {
+        self.be.tree_loader_count()
+    }
+
     fn read_full(&self, tpe: FileType, id: &Id) -> RusticResult<Bytes> {
         self.be.read_full(tpe, id)
     }

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -191,9 +191,9 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     fn stream_list<F: RepoFile>(&self, list: Vec<F::Id>, p: &Progress) -> StreamResult<F::Id, F> {
         p.set_length(list.len() as u64);
         // Index/snapshot files are small; on B2 this is RTT-bound (one GET each).
-        // Restic uses `connections + GOMAXPROCS`. Keep extra workers so some can
-        // GET while others decrypt/parse, and buffer so send does not stall IO.
-        let workers = (rayon::current_num_threads() + 16).clamp(16, 32);
+        // Cached backends report fewer workers when the files are already local.
+        let ids: Vec<_> = list.iter().map(|id| **id).collect();
+        let workers = self.prefetch_workers(F::TYPE, &ids);
         let (tx, rx) = bounded(workers.saturating_mul(2));
         let be = self.clone();
         let p = p.clone();
@@ -650,6 +650,10 @@ impl<C: CryptoKey> ReadBackend for DecryptBackend<C> {
 
     fn list_with_size(&self, tpe: FileType) -> RusticResult<Vec<(Id, u32)>> {
         self.be.list_with_size(tpe)
+    }
+
+    fn prefetch_workers(&self, tpe: FileType, ids: &[Id]) -> usize {
+        self.be.prefetch_workers(tpe, ids)
     }
 
     fn read_full(&self, tpe: FileType, id: &Id) -> RusticResult<Bytes> {

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -5,29 +5,46 @@ use crossbeam_channel::{Receiver, bounded};
 use rayon::{prelude::*, spawn};
 use zstd::stream::{copy_encode, decode_all, encode_all};
 
+thread_local! {
+    static ZSTD: RefCell<ZstdTls> = const {
+        RefCell::new(ZstdTls {
+            decompressor: None,
+            buf: Vec::new(),
+        })
+    };
+}
+
+struct ZstdTls {
+    decompressor: Option<zstd::bulk::Decompressor<'static>>,
+    buf: Vec<u8>,
+}
+
+fn zstd_tls_decompressor(
+    slot: &mut ZstdTls,
+) -> RusticResult<&mut zstd::bulk::Decompressor<'static>> {
+    if slot.decompressor.is_none() {
+        slot.decompressor = Some(zstd::bulk::Decompressor::new().map_err(|err| {
+            RusticError::with_source(
+                ErrorKind::Internal,
+                "Failed to create zstd decompressor.",
+                err,
+            )
+        })?);
+    }
+    Ok(slot
+        .decompressor
+        .as_mut()
+        .expect("zstd decompressor is initialized"))
+}
+
 /// Decode zstd with a decompressor kept on this thread.
 ///
 /// `zstd::decode_all` builds a new `DCtx` per call. Tree walking does that for
 /// every blob and showed up as `ZSTD_createDCtx` / `munmap` / page faults.
 fn zstd_decompress(data: &[u8], uncompressed_len: usize) -> RusticResult<Vec<u8>> {
-    thread_local! {
-        static DECOMPRESSOR: RefCell<Option<zstd::bulk::Decompressor<'static>>> =
-            const { RefCell::new(None) };
-    }
-
-    DECOMPRESSOR.with(|slot| {
+    ZSTD.with(|slot| {
         let mut slot = slot.borrow_mut();
-        if slot.is_none() {
-            *slot = Some(zstd::bulk::Decompressor::new().map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Internal,
-                    "Failed to create zstd decompressor.",
-                    err,
-                )
-            })?);
-        }
-        slot.as_mut()
-            .expect("zstd decompressor is initialized")
+        zstd_tls_decompressor(&mut slot)?
             .decompress(data, uncompressed_len)
             .map_err(|err| {
                 RusticError::with_source(
@@ -36,6 +53,48 @@ fn zstd_decompress(data: &[u8], uncompressed_len: usize) -> RusticResult<Vec<u8>
                     err,
                 )
             })
+    })
+}
+
+/// Decompress into a thread-local buffer and run `f` on the plaintext.
+///
+/// Prune tree walking used to allocate a new uncompressed `Vec` per blob,
+/// which showed up as `kernel_init_pages`. The buffer keeps capacity on this
+/// thread so later trees reuse the same pages.
+fn zstd_decompress_with<R>(
+    data: &[u8],
+    uncompressed_len: usize,
+    f: impl FnOnce(&[u8]) -> RusticResult<R>,
+) -> RusticResult<R> {
+    ZSTD.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let ZstdTls { decompressor, buf } = &mut *slot;
+        if decompressor.is_none() {
+            *decompressor = Some(zstd::bulk::Decompressor::new().map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "Failed to create zstd decompressor.",
+                    err,
+                )
+            })?);
+        }
+        buf.clear();
+        if buf.capacity() < uncompressed_len {
+            buf.reserve(uncompressed_len);
+        }
+        let written = decompressor
+            .as_mut()
+            .expect("zstd decompressor is initialized")
+            .decompress_to_buffer(data, buf)
+            .map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "Failed to decode zstd compressed data. The data may be corrupted.",
+                    err,
+                )
+            })?;
+        buf.truncate(written);
+        f(buf)
     })
 }
 
@@ -122,6 +181,34 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
             }
         }
         Ok(data.into())
+    }
+
+    /// Decrypt and decompress `data`, then run `f` on the plaintext without
+    /// allocating a new uncompressed `Vec` on every call.
+    fn with_decoded_from_partial<R>(
+        &self,
+        data: &[u8],
+        uncompressed_length: Option<NonZeroU32>,
+        f: impl FnOnce(&[u8]) -> RusticResult<R>,
+    ) -> RusticResult<R> {
+        let decrypted = self.decrypt(data)?;
+        if let Some(length) = uncompressed_length {
+            let expected = length.get() as usize;
+            zstd_decompress_with(&decrypted, expected, |plain| {
+                if plain.len() != expected {
+                    return Err(RusticError::new(
+                        ErrorKind::Internal,
+                        "Length of uncompressed data `{actual_length}` does not match the given length `{expected_length}`.",
+                    )
+                    .attach_context("expected_length", length.get().to_string())
+                    .attach_context("actual_length", plain.len().to_string())
+                    .ask_report());
+                }
+                f(plain)
+            })
+        } else {
+            f(&decrypted)
+        }
     }
 
     /// Reads the given file with the given offset and length.

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -1,9 +1,43 @@
-use std::{num::NonZeroU32, sync::Arc};
+use std::{cell::RefCell, num::NonZeroU32, sync::Arc};
 
 use bytes::Bytes;
 use crossbeam_channel::{Receiver, bounded};
 use rayon::{prelude::*, spawn};
 use zstd::stream::{copy_encode, decode_all, encode_all};
+
+/// Decode zstd with a decompressor kept on this thread.
+///
+/// `zstd::decode_all` builds a new `DCtx` per call. Tree walking does that for
+/// every blob and showed up as `ZSTD_createDCtx` / `munmap` / page faults.
+fn zstd_decompress(data: &[u8], uncompressed_len: usize) -> RusticResult<Vec<u8>> {
+    thread_local! {
+        static DECOMPRESSOR: RefCell<Option<zstd::bulk::Decompressor<'static>>> =
+            const { RefCell::new(None) };
+    }
+
+    DECOMPRESSOR.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(zstd::bulk::Decompressor::new().map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "Failed to create zstd decompressor.",
+                    err,
+                )
+            })?);
+        }
+        slot.as_mut()
+            .expect("zstd decompressor is initialized")
+            .decompress(data, uncompressed_len)
+            .map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "Failed to decode zstd compressed data. The data may be corrupted.",
+                    err,
+                )
+            })
+    })
+}
 
 pub use zstd::compression_level_range;
 
@@ -75,13 +109,7 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     ) -> RusticResult<Bytes> {
         let mut data = self.decrypt(data)?;
         if let Some(length) = uncompressed_length {
-            data = decode_all(&*data).map_err(|err| {
-                RusticError::with_source(
-                    ErrorKind::Internal,
-                    "Failed to decode zstd compressed data. The data may be corrupted.",
-                    err,
-                )
-            })?;
+            data = zstd_decompress(&data, length.get() as usize)?;
 
             if data.len() != length.get() as usize {
                 return Err(RusticError::new(

--- a/crates/core/src/backend/decrypt.rs
+++ b/crates/core/src/backend/decrypt.rs
@@ -190,17 +190,26 @@ pub trait DecryptReadBackend: ReadBackend + Clone + 'static {
     /// If the files could not be read.
     fn stream_list<F: RepoFile>(&self, list: Vec<F::Id>, p: &Progress) -> StreamResult<F::Id, F> {
         p.set_length(list.len() as u64);
-        // we use a zero-capacity channel; the loading is typically the bottleneck, not the processing.
-        let (tx, rx) = bounded(0);
+        // Index/snapshot files are small; on B2 this is RTT-bound (one GET each).
+        // Restic uses `connections + GOMAXPROCS`. Keep extra workers so some can
+        // GET while others decrypt/parse, and buffer so send does not stall IO.
+        let workers = (rayon::current_num_threads() + 16).clamp(16, 32);
+        let (tx, rx) = bounded(workers.saturating_mul(2));
         let be = self.clone();
         let p = p.clone();
 
         spawn(move || {
-            _ = list.into_par_iter().try_for_each(|id| {
-                let file = be.get_file::<F>(&id).map(|file| (id, file));
-                p.inc(1);
-                tx.send(file).ok() // abort as soon as possible if sending fails, i.e. if the receiver is dropped
-            });
+            let work = || {
+                _ = list.into_par_iter().try_for_each(|id| {
+                    let file = be.get_file::<F>(&id).map(|file| (id, file));
+                    p.inc(1);
+                    tx.send(file).ok()
+                });
+            };
+            match rayon::ThreadPoolBuilder::new().num_threads(workers).build() {
+                Ok(pool) => pool.install(work),
+                Err(_) => work(),
+            }
         });
         Ok(rx)
     }

--- a/crates/core/src/blob.rs
+++ b/crates/core/src/blob.rs
@@ -13,8 +13,13 @@ pub(super) mod constants {
     /// The maximum size of pack-part which is read at once from the backend.
     /// (needed to limit the memory size used for large backends)
     pub(crate) const LIMIT_PACK_READ: u32 = 40 * 1024 * 1024; // 40 MiB
-    /// The maximum size of holes which are still read when repacking
-    pub(crate) const MAX_HOLESIZE: u32 = 256 * 1024; // 256 kiB
+    /// Maximum unused gap that is still fetched with the surrounding blobs.
+    ///
+    /// 256 KiB was too small for high-latency object stores (B2): every larger
+    /// hole became another HTTP range GET, and prune/restore issued those
+    /// sequentially. 4 MiB is about one RTT of extra download on a ~100 Mbps
+    /// link, which is cheaper than an extra request.
+    pub(crate) const MAX_HOLESIZE: u32 = 4 * 1024 * 1024; // 4 MiB
 }
 
 /// All [`BlobType`]s which are supported by the repository

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -702,6 +702,24 @@ pub struct TreeStreamer<T> {
 /// Recursively visits all trees and subtrees, but each tree ID only once.
 pub type TreeStreamerOnce = TreeStreamer<Tree>;
 
+fn ignore_loaded_tree<T>(_: &T) {}
+
+/// Called from each tree-loader thread after a tree is decoded.
+pub(crate) trait OnTreeLoad<T>: Send + 'static {
+    fn on_load(&mut self, tree: &T);
+    fn finish(self)
+    where
+        Self: Sized,
+    {
+    }
+}
+
+impl<T, F: FnMut(&T) + Send + 'static> OnTreeLoad<T> for F {
+    fn on_load(&mut self, tree: &T) {
+        self(tree);
+    }
+}
+
 impl<T: LoadedTree> TreeStreamer<T> {
     /// Creates a new `TreeStreamerOnce`.
     ///
@@ -725,20 +743,23 @@ impl<T: LoadedTree> TreeStreamer<T> {
         ids: Vec<TreeId>,
         p: Progress,
     ) -> RusticResult<Self> {
-        Self::new_with_on_load(be, index, ids, p, |_| {})
+        Self::new_with_on_load(be, index, ids, p, || ignore_loaded_tree)
     }
 
-    /// Like [`Self::new`], and runs `on_load` in each loader thread after a tree
-    /// is decoded so prune can record used blob ids without a single consumer.
-    pub fn new_with_on_load<BE: DecryptReadBackend, I: ReadGlobalIndex, F>(
+    /// Like [`Self::new`], but each loader thread gets its own `on_load` from
+    /// `factory` so prune can fill a thread-local used-id map with no locks.
+    pub fn new_with_on_load<BE, I, F, H>(
         be: &BE,
         index: &I,
         ids: Vec<TreeId>,
         p: Progress,
-        on_load: F,
+        mut factory: F,
     ) -> RusticResult<Self>
     where
-        F: Fn(&T) + Send + Sync + Clone + 'static,
+        BE: DecryptReadBackend,
+        I: ReadGlobalIndex,
+        F: FnMut() -> H,
+        H: OnTreeLoad<T>,
     {
         p.set_length(ids.len() as u64);
 
@@ -754,14 +775,15 @@ impl<T: LoadedTree> TreeStreamer<T> {
             let index = index.clone();
             let in_rx = in_rx.clone();
             let out_tx = out_tx.clone();
-            let on_load = on_load.clone();
+            let mut on_load = factory();
             let _join_handle = std::thread::spawn(move || {
                 for (path, id, count) in in_rx {
-                    let loaded = T::load(&be, &index, id).inspect(|tree| on_load(tree));
+                    let loaded = T::load(&be, &index, id).inspect(|tree| on_load.on_load(tree));
                     if out_tx.send(loaded.map(|tree| (path, tree, count))).is_err() {
                         break;
                     }
                 }
+                on_load.finish();
             });
         }
 

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -725,6 +725,21 @@ impl<T: LoadedTree> TreeStreamer<T> {
         ids: Vec<TreeId>,
         p: Progress,
     ) -> RusticResult<Self> {
+        Self::new_with_on_load(be, index, ids, p, |_| {})
+    }
+
+    /// Like [`Self::new`], and runs `on_load` in each loader thread after a tree
+    /// is decoded so prune can record used blob ids without a single consumer.
+    pub fn new_with_on_load<BE: DecryptReadBackend, I: ReadGlobalIndex, F>(
+        be: &BE,
+        index: &I,
+        ids: Vec<TreeId>,
+        p: Progress,
+        on_load: F,
+    ) -> RusticResult<Self>
+    where
+        F: Fn(&T) + Send + Sync + Clone + 'static,
+    {
         p.set_length(ids.len() as u64);
 
         let loaders = be.tree_loader_count();
@@ -739,12 +754,11 @@ impl<T: LoadedTree> TreeStreamer<T> {
             let index = index.clone();
             let in_rx = in_rx.clone();
             let out_tx = out_tx.clone();
+            let on_load = on_load.clone();
             let _join_handle = std::thread::spawn(move || {
                 for (path, id, count) in in_rx {
-                    if out_tx
-                        .send(T::load(&be, &index, id).map(|tree| (path, tree, count)))
-                        .is_err()
-                    {
+                    let loaded = T::load(&be, &index, id).inspect(|tree| on_load(tree));
+                    if out_tx.send(loaded.map(|tree| (path, tree, count))).is_err() {
                         break;
                     }
                 }

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -6,7 +6,7 @@ mod used_blobs;
 use std::{
     borrow::Cow,
     cmp::Ordering,
-    collections::{BTreeMap, BinaryHeap, HashSet},
+    collections::{BTreeMap, BinaryHeap},
     ffi::OsStr,
     mem,
     path::{Component, Path, PathBuf, Prefix},
@@ -17,6 +17,7 @@ use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use derive_setters::Setters;
 use ignore::Match;
 use ignore::overrides::Override;
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Serialize;
 
@@ -684,7 +685,7 @@ impl LoadedTree for UsedBlobsTree {
 #[derive(Debug)]
 pub struct TreeStreamer<T> {
     /// The visited tree IDs
-    visited: HashSet<TreeId>,
+    visited: FxHashSet<TreeId>,
     /// Depth-first backlog of tree IDs not yet sent to a loader.
     backlog: Vec<(PathBuf, TreeId, usize)>,
     /// The queue to send tree IDs to
@@ -789,7 +790,7 @@ impl<T: LoadedTree> TreeStreamer<T> {
 
         let counter = vec![0; ids.len()];
         let mut streamer = Self {
-            visited: HashSet::new(),
+            visited: FxHashSet::default(),
             backlog: Vec::new(),
             queue_in: Some(in_tx),
             queue_out: out_rx,

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -17,7 +17,6 @@ use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use derive_setters::Setters;
 use ignore::Match;
 use ignore::overrides::Override;
-use rayon::current_num_threads;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Serialize;
 
@@ -53,23 +52,6 @@ pub enum TreeErrorKind {
 }
 
 pub(crate) type TreeResult<T> = Result<T, TreeErrorKind>;
-
-pub(super) mod constants {
-    /// Minimum / maximum tree-loader threads for `TreeStreamerOnce`.
-    ///
-    /// Four was too few on high-latency backends (B2): prune's "finding used
-    /// blobs..." walks every unique tree with a pack range GET. Restic uses
-    /// `connections + GOMAXPROCS` workers. We scale with Rayon (2× CPUs,
-    /// clamped) so a 4-core box gets 8 loaders, not 4.
-    pub(super) const MIN_TREE_LOADER: usize = 8;
-    pub(super) const MAX_TREE_LOADER: usize = 32;
-}
-
-fn tree_loader_count() -> usize {
-    current_num_threads()
-        .saturating_mul(2)
-        .clamp(constants::MIN_TREE_LOADER, constants::MAX_TREE_LOADER)
-}
 
 type NodeStreamItem = RusticResult<(PathBuf, Node)>;
 impl_blobid!(TreeId, BlobType::Tree);
@@ -745,7 +727,7 @@ impl<T: LoadedTree> TreeStreamer<T> {
     ) -> RusticResult<Self> {
         p.set_length(ids.len() as u64);
 
-        let loaders = tree_loader_count();
+        let loaders = be.tree_loader_count();
         let (out_tx, out_rx) = bounded(loaders.saturating_mul(4).max(32));
         // Bound the loader input so we do not dump every snapshot root at once.
         // Combined with a LIFO backlog this keeps workers on recently discovered

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -663,8 +663,18 @@ impl LoadedTree for UsedBlobsTree {
         index: &I,
         id: TreeId,
     ) -> RusticResult<Self> {
-        let data = read_tree_bytes(be, index, id)?;
-        used_blobs::parse_used_blobs_tree(&data).map_err(tree_json_error)
+        index
+            .get_tree(&id)
+            .ok_or_else(|| {
+                RusticError::new(
+                    ErrorKind::Internal,
+                    "Tree ID `{tree_id}` not found in index",
+                )
+                .attach_context("tree_id", id.to_string())
+            })?
+            .with_decoded(be, |data| {
+                used_blobs::parse_used_blobs_tree(data).map_err(tree_json_error)
+            })
     }
 
     fn child_trees(&self, _parent: &Path) -> Vec<(PathBuf, TreeId)> {

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -1,6 +1,7 @@
 pub mod excludes;
 pub mod modify;
 pub mod rewrite;
+mod used_blobs;
 
 use std::{
     borrow::Cow,
@@ -70,9 +71,51 @@ fn tree_loader_count() -> usize {
         .clamp(constants::MIN_TREE_LOADER, constants::MAX_TREE_LOADER)
 }
 
-pub(crate) type TreeStreamItem = RusticResult<(PathBuf, Tree)>;
 type NodeStreamItem = RusticResult<(PathBuf, Node)>;
 impl_blobid!(TreeId, BlobType::Tree);
+
+pub(crate) use used_blobs::UsedBlobsTree;
+
+/// A tree loaded by [`TreeStreamerOnce`].
+///
+/// Prune uses [`UsedBlobsTree`] so it does not allocate full [`Node`]s.
+pub(crate) trait LoadedTree: Send + 'static {
+    fn load<BE: DecryptReadBackend, I: ReadGlobalIndex>(
+        be: &BE,
+        index: &I,
+        id: TreeId,
+    ) -> RusticResult<Self>
+    where
+        Self: Sized;
+
+    fn child_trees(&self, parent: &Path) -> Vec<(PathBuf, TreeId)>;
+}
+
+fn read_tree_bytes<BE: DecryptReadBackend, I: ReadGlobalIndex>(
+    be: &BE,
+    index: &I,
+    id: TreeId,
+) -> RusticResult<bytes::Bytes> {
+    index
+        .get_tree(&id)
+        .ok_or_else(|| {
+            RusticError::new(
+                ErrorKind::Internal,
+                "Tree ID `{tree_id}` not found in index",
+            )
+            .attach_context("tree_id", id.to_string())
+        })?
+        .read_data(be)
+}
+
+fn tree_json_error(err: serde_json::Error) -> Box<RusticError> {
+    RusticError::with_source(
+        ErrorKind::Internal,
+        "Failed to deserialize tree from JSON.",
+        err,
+    )
+    .ask_report()
+}
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
 /// A [`Tree`] is a list of [`Node`]s
@@ -152,27 +195,8 @@ impl Tree {
         index: &impl ReadGlobalIndex,
         id: TreeId,
     ) -> RusticResult<Self> {
-        let data = index
-            .get_tree(&id)
-            .ok_or_else(|| {
-                RusticError::new(
-                    ErrorKind::Internal,
-                    "Tree ID `{tree_id}` not found in index",
-                )
-                .attach_context("tree_id", id.to_string())
-            })?
-            .read_data(be)?;
-
-        let tree = serde_json::from_slice(&data).map_err(|err| {
-            RusticError::with_source(
-                ErrorKind::Internal,
-                "Failed to deserialize tree from JSON.",
-                err,
-            )
-            .ask_report()
-        })?;
-
-        Ok(tree)
+        let data = read_tree_bytes(be, index, id)?;
+        serde_json::from_slice(&data).map_err(tree_json_error)
     }
 
     /// Creates a new node from a path.
@@ -628,19 +652,61 @@ where
     }
 }
 
+impl LoadedTree for Tree {
+    fn load<BE: DecryptReadBackend, I: ReadGlobalIndex>(
+        be: &BE,
+        index: &I,
+        id: TreeId,
+    ) -> RusticResult<Self> {
+        Self::from_backend(be, index, id)
+    }
+
+    fn child_trees(&self, parent: &Path) -> Vec<(PathBuf, TreeId)> {
+        self.nodes
+            .iter()
+            .filter_map(|node| {
+                let id = node.subtree?;
+                let mut path = parent.to_path_buf();
+                path.push(node.name());
+                Some((path, id))
+            })
+            .collect()
+    }
+}
+
+impl LoadedTree for UsedBlobsTree {
+    fn load<BE: DecryptReadBackend, I: ReadGlobalIndex>(
+        be: &BE,
+        index: &I,
+        id: TreeId,
+    ) -> RusticResult<Self> {
+        let data = read_tree_bytes(be, index, id)?;
+        used_blobs::parse_used_blobs_tree(&data).map_err(tree_json_error)
+    }
+
+    fn child_trees(&self, _parent: &Path) -> Vec<(PathBuf, TreeId)> {
+        self.dir_trees
+            .iter()
+            .copied()
+            .map(|id| (PathBuf::new(), id))
+            .collect()
+    }
+}
+
 /// [`TreeStreamerOnce`] recursively visits all trees and subtrees, but each tree ID only once
 ///
 /// # Type Parameters
 ///
+/// * `T` - The loaded tree type. Defaults to a full [`Tree`].
 /// * `P` - The progress indicator
 #[derive(Debug)]
-pub struct TreeStreamerOnce {
+pub struct TreeStreamer<T> {
     /// The visited tree IDs
     visited: HashSet<TreeId>,
     /// The queue to send tree IDs to
     queue_in: Option<Sender<(PathBuf, TreeId, usize)>>,
     /// The queue to receive trees from
-    queue_out: Receiver<RusticResult<(PathBuf, Tree, usize)>>,
+    queue_out: Receiver<RusticResult<(PathBuf, T, usize)>>,
     /// The progress indicator
     p: Progress,
     /// The number of trees that are not yet finished
@@ -649,7 +715,10 @@ pub struct TreeStreamerOnce {
     finished_ids: usize,
 }
 
-impl TreeStreamerOnce {
+/// Recursively visits all trees and subtrees, but each tree ID only once.
+pub type TreeStreamerOnce = TreeStreamer<Tree>;
+
+impl<T: LoadedTree> TreeStreamer<T> {
     /// Creates a new `TreeStreamerOnce`.
     ///
     /// # Type Parameters
@@ -686,7 +755,7 @@ impl TreeStreamerOnce {
             let _join_handle = std::thread::spawn(move || {
                 for (path, id, count) in in_rx {
                     if out_tx
-                        .send(Tree::from_backend(&be, &index, id).map(|tree| (path, tree, count)))
+                        .send(T::load(&be, &index, id).map(|tree| (path, tree, count)))
                         .is_err()
                     {
                         break;
@@ -761,8 +830,8 @@ impl TreeStreamerOnce {
     }
 }
 
-impl Iterator for TreeStreamerOnce {
-    type Item = TreeStreamItem;
+impl<T: LoadedTree> Iterator for TreeStreamer<T> {
+    type Item = RusticResult<(PathBuf, T)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.counter.len() == self.finished_ids {
@@ -785,25 +854,21 @@ impl Iterator for TreeStreamerOnce {
             Ok(Err(err)) => return Some(Err(err)),
         };
 
-        for node in &tree.nodes {
-            if let Some(id) = node.subtree {
-                let mut path = path.clone();
-                path.push(node.name());
-                match self.add_pending(path.clone(), id, count) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        return Some(Err(err).map_err(|err| {
-                            RusticError::with_source(
-                                ErrorKind::Internal,
-                                "Failed to add tree ID `{tree_id}` to pending queue (`{count}`).",
-                                err,
-                            )
-                            .attach_context("path", path.display().to_string())
-                            .attach_context("tree_id", id.to_string())
-                            .attach_context("count", count.to_string())
-                            .ask_report()
-                        }));
-                    }
+        for (child_path, id) in tree.child_trees(&path) {
+            match self.add_pending(child_path.clone(), id, count) {
+                Ok(_) => {}
+                Err(err) => {
+                    return Some(Err(err).map_err(|err| {
+                        RusticError::with_source(
+                            ErrorKind::Internal,
+                            "Failed to add tree ID `{tree_id}` to pending queue (`{count}`).",
+                            err,
+                        )
+                        .attach_context("path", child_path.display().to_string())
+                        .attach_context("tree_id", id.to_string())
+                        .attach_context("count", count.to_string())
+                        .ask_report()
+                    }));
                 }
             }
         }

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -13,7 +13,7 @@ use std::{
     str::{self, Utf8Error},
 };
 
-use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
+use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use derive_setters::Setters;
 use ignore::Match;
 use ignore::overrides::Override;
@@ -703,6 +703,8 @@ impl LoadedTree for UsedBlobsTree {
 pub struct TreeStreamer<T> {
     /// The visited tree IDs
     visited: HashSet<TreeId>,
+    /// Depth-first backlog of tree IDs not yet sent to a loader.
+    backlog: Vec<(PathBuf, TreeId, usize)>,
     /// The queue to send tree IDs to
     queue_in: Option<Sender<(PathBuf, TreeId, usize)>>,
     /// The queue to receive trees from
@@ -745,7 +747,10 @@ impl<T: LoadedTree> TreeStreamer<T> {
 
         let loaders = tree_loader_count();
         let (out_tx, out_rx) = bounded(loaders.saturating_mul(4).max(32));
-        let (in_tx, in_rx) = unbounded();
+        // Bound the loader input so we do not dump every snapshot root at once.
+        // Combined with a LIFO backlog this keeps workers on recently discovered
+        // children (depth-first), which hits the same cached packs.
+        let (in_tx, in_rx) = bounded(loaders);
 
         for _ in 0..loaders {
             let be = be.clone();
@@ -767,6 +772,7 @@ impl<T: LoadedTree> TreeStreamer<T> {
         let counter = vec![0; ids.len()];
         let mut streamer = Self {
             visited: HashSet::new(),
+            backlog: Vec::new(),
             queue_in: Some(in_tx),
             queue_out: out_rx,
             p,
@@ -775,58 +781,59 @@ impl<T: LoadedTree> TreeStreamer<T> {
         };
 
         for (count, id) in ids.into_iter().enumerate() {
-            if !streamer
-                .add_pending(PathBuf::new(), id, count)
-                .map_err(|err| {
-                    RusticError::with_source(
-                        ErrorKind::Internal,
-                        "Failed to add tree ID `{tree_id}` to unbounded pending queue (`{count}`).",
-                        err,
-                    )
-                    .attach_context("tree_id", id.to_string())
-                    .attach_context("count", count.to_string())
-                    .ask_report()
-                })?
-            {
+            if !streamer.add_pending(PathBuf::new(), id, count) {
                 streamer.p.inc(1);
                 streamer.finished_ids += 1;
             }
         }
+        streamer.fill_queue().map_err(|err| {
+            RusticError::with_source(
+                ErrorKind::Internal,
+                "Failed to send tree IDs to loader queue.",
+                err,
+            )
+            .ask_report()
+        })?;
 
         Ok(streamer)
     }
 
-    /// Adds a tree ID to the queue.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path of the tree.
-    /// * `id` - The ID of the tree.
-    /// * `count` - The index of the tree.
+    /// Pushes a tree ID onto the depth-first backlog if it has not been seen.
     ///
     /// # Returns
     ///
-    /// Whether the tree ID was added to the queue.
-    ///
-    /// # Errors
-    ///
-    /// * If sending the message fails.
-    fn add_pending(&mut self, path: PathBuf, id: TreeId, count: usize) -> TreeResult<bool> {
+    /// Whether the tree ID was added.
+    fn add_pending(&mut self, path: PathBuf, id: TreeId, count: usize) -> bool {
         if self.visited.insert(id) {
-            self.queue_in
-                .as_ref()
-                .unwrap()
-                .send((path, id, count))
-                .map_err(|err| TreeErrorKind::Channel {
-                    kind: "sending crossbeam message",
-                    source: err.into(),
-                })?;
-
             self.counter[count] += 1;
-            Ok(true)
+            self.backlog.push((path, id, count));
+            true
         } else {
-            Ok(false)
+            false
         }
+    }
+
+    /// Sends backlog items to loaders, last-in first, until the input channel is full.
+    fn fill_queue(&mut self) -> TreeResult<()> {
+        let Some(tx) = self.queue_in.as_ref() else {
+            return Ok(());
+        };
+        while let Some(job) = self.backlog.pop() {
+            match tx.try_send(job) {
+                Ok(()) => {}
+                Err(TrySendError::Full(job)) => {
+                    self.backlog.push(job);
+                    break;
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(TreeErrorKind::Channel {
+                        kind: "sending crossbeam message",
+                        source: "loader queue disconnected".into(),
+                    });
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -854,23 +861,19 @@ impl<T: LoadedTree> Iterator for TreeStreamer<T> {
             Ok(Err(err)) => return Some(Err(err)),
         };
 
-        for (child_path, id) in tree.child_trees(&path) {
-            match self.add_pending(child_path.clone(), id, count) {
-                Ok(_) => {}
-                Err(err) => {
-                    return Some(Err(err).map_err(|err| {
-                        RusticError::with_source(
-                            ErrorKind::Internal,
-                            "Failed to add tree ID `{tree_id}` to pending queue (`{count}`).",
-                            err,
-                        )
-                        .attach_context("path", child_path.display().to_string())
-                        .attach_context("tree_id", id.to_string())
-                        .attach_context("count", count.to_string())
-                        .ask_report()
-                    }));
-                }
-            }
+        // Push children last-to-first so the next pop is the first child (DFS).
+        for (child_path, id) in tree.child_trees(&path).into_iter().rev() {
+            _ = self.add_pending(child_path, id, count);
+        }
+        if let Err(err) = self.fill_queue() {
+            return Some(Err(err).map_err(|err| {
+                RusticError::with_source(
+                    ErrorKind::Internal,
+                    "Failed to send tree IDs to loader queue.",
+                    err,
+                )
+                .ask_report()
+            }));
         }
 
         self.counter[count] -= 1;

--- a/crates/core/src/blob/tree.rs
+++ b/crates/core/src/blob/tree.rs
@@ -5,7 +5,7 @@ pub mod rewrite;
 use std::{
     borrow::Cow,
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    collections::{BTreeMap, BinaryHeap, HashSet},
     ffi::OsStr,
     mem,
     path::{Component, Path, PathBuf, Prefix},
@@ -16,6 +16,7 @@ use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
 use derive_setters::Setters;
 use ignore::Match;
 use ignore::overrides::Override;
+use rayon::current_num_threads;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Serialize;
 
@@ -53,8 +54,20 @@ pub enum TreeErrorKind {
 pub(crate) type TreeResult<T> = Result<T, TreeErrorKind>;
 
 pub(super) mod constants {
-    /// The maximum number of trees that are loaded in parallel
-    pub(super) const MAX_TREE_LOADER: usize = 4;
+    /// Minimum / maximum tree-loader threads for `TreeStreamerOnce`.
+    ///
+    /// Four was too few on high-latency backends (B2): prune's "finding used
+    /// blobs..." walks every unique tree with a pack range GET. Restic uses
+    /// `connections + GOMAXPROCS` workers. We scale with Rayon (2× CPUs,
+    /// clamped) so a 4-core box gets 8 loaders, not 4.
+    pub(super) const MIN_TREE_LOADER: usize = 8;
+    pub(super) const MAX_TREE_LOADER: usize = 32;
+}
+
+fn tree_loader_count() -> usize {
+    current_num_threads()
+        .saturating_mul(2)
+        .clamp(constants::MIN_TREE_LOADER, constants::MAX_TREE_LOADER)
 }
 
 pub(crate) type TreeStreamItem = RusticResult<(PathBuf, Tree)>;
@@ -623,7 +636,7 @@ where
 #[derive(Debug)]
 pub struct TreeStreamerOnce {
     /// The visited tree IDs
-    visited: BTreeSet<TreeId>,
+    visited: HashSet<TreeId>,
     /// The queue to send tree IDs to
     queue_in: Option<Sender<(PathBuf, TreeId, usize)>>,
     /// The queue to receive trees from
@@ -661,10 +674,11 @@ impl TreeStreamerOnce {
     ) -> RusticResult<Self> {
         p.set_length(ids.len() as u64);
 
-        let (out_tx, out_rx) = bounded(constants::MAX_TREE_LOADER);
+        let loaders = tree_loader_count();
+        let (out_tx, out_rx) = bounded(loaders.saturating_mul(4).max(32));
         let (in_tx, in_rx) = unbounded();
 
-        for _ in 0..constants::MAX_TREE_LOADER {
+        for _ in 0..loaders {
             let be = be.clone();
             let index = index.clone();
             let in_rx = in_rx.clone();
@@ -683,7 +697,7 @@ impl TreeStreamerOnce {
 
         let counter = vec![0; ids.len()];
         let mut streamer = Self {
-            visited: BTreeSet::new(),
+            visited: HashSet::new(),
             queue_in: Some(in_tx),
             queue_out: out_rx,
             p,

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -59,7 +59,7 @@ fn parse_hex_id(s: &str) -> Option<Id> {
 
 struct HexDataIdVisitor;
 
-impl Visitor<'_> for HexDataIdVisitor {
+impl<'de> Visitor<'de> for HexDataIdVisitor {
     type Value = DataId;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -71,11 +71,15 @@ impl Visitor<'_> for HexDataIdVisitor {
             .map(DataId::from)
             .ok_or_else(|| E::invalid_value(de::Unexpected::Str(v), &self))
     }
+
+    fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
+        self.visit_str(v)
+    }
 }
 
 struct HexTreeIdVisitor;
 
-impl Visitor<'_> for HexTreeIdVisitor {
+impl<'de> Visitor<'de> for HexTreeIdVisitor {
     type Value = TreeId;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -86,6 +90,10 @@ impl Visitor<'_> for HexTreeIdVisitor {
         parse_hex_id(v)
             .map(TreeId::from)
             .ok_or_else(|| E::invalid_value(de::Unexpected::Str(v), &self))
+    }
+
+    fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
+        self.visit_str(v)
     }
 }
 

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -6,6 +6,7 @@
 
 use std::borrow::Cow;
 
+use memchr::memchr2;
 use serde::de::Error as DeError;
 
 use crate::{
@@ -36,53 +37,22 @@ const HEX_NIBBLE: [u8; 256] = hex_nibble_table();
 fn find_unescaped_quote(bytes: &[u8]) -> Result<usize, ScanError> {
     let n = bytes.len();
     let mut i = 0;
-    while i + 16 <= n {
-        if let Some(off) = first_quote_or_slash(load_u64_ne(bytes, i)) {
-            i += off;
-        } else if let Some(off) = first_quote_or_slash(load_u64_ne(bytes, i + 8)) {
-            i += 8 + off;
-        } else {
-            i += 16;
-            continue;
-        }
-        match bytes[i] {
-            b'"' => return Ok(i),
-            b'\\' => {
-                if i + 1 >= n {
-                    return Scan::err("unterminated string escape");
-                }
-                i += 2;
-            }
-            _ => i += 1,
-        }
-    }
-    while i + 8 <= n {
-        if let Some(off) = first_quote_or_slash(load_u64_ne(bytes, i)) {
-            i += off;
-            match bytes[i] {
-                b'"' => return Ok(i),
-                b'\\' => {
-                    if i + 1 >= n {
-                        return Scan::err("unterminated string escape");
-                    }
-                    i += 2;
-                }
-                _ => i += 1,
-            }
-        } else {
-            i += 8;
-        }
-    }
     while i < n {
-        match bytes[i] {
-            b'"' => return Ok(i),
-            b'\\' => {
-                if i + 1 >= n {
-                    return Scan::err("unterminated string escape");
+        match memchr2(b'"', b'\\', &bytes[i..]) {
+            None => break,
+            Some(rel) => {
+                i += rel;
+                match bytes[i] {
+                    b'"' => return Ok(i),
+                    b'\\' => {
+                        if i + 1 >= n {
+                            return Scan::err("unterminated string escape");
+                        }
+                        i += 2;
+                    }
+                    _ => i += 1,
                 }
-                i += 2;
             }
-            _ => i += 1,
         }
     }
     Scan::err("unterminated string")

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -32,6 +32,62 @@ const fn hex_nibble_table() -> [u8; 256] {
 
 const HEX_NIBBLE: [u8; 256] = hex_nibble_table();
 
+/// Index of the closing `"` in a JSON string body (after the opening quote).
+fn find_unescaped_quote(bytes: &[u8]) -> Result<usize, ScanError> {
+    let n = bytes.len();
+    let mut i = 0;
+    while i + 16 <= n {
+        if let Some(off) = first_quote_or_slash(load_u64_ne(bytes, i)) {
+            i += off;
+        } else if let Some(off) = first_quote_or_slash(load_u64_ne(bytes, i + 8)) {
+            i += 8 + off;
+        } else {
+            i += 16;
+            continue;
+        }
+        match bytes[i] {
+            b'"' => return Ok(i),
+            b'\\' => {
+                if i + 1 >= n {
+                    return Scan::err("unterminated string escape");
+                }
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    while i + 8 <= n {
+        if let Some(off) = first_quote_or_slash(load_u64_ne(bytes, i)) {
+            i += off;
+            match bytes[i] {
+                b'"' => return Ok(i),
+                b'\\' => {
+                    if i + 1 >= n {
+                        return Scan::err("unterminated string escape");
+                    }
+                    i += 2;
+                }
+                _ => i += 1,
+            }
+        } else {
+            i += 8;
+        }
+    }
+    while i < n {
+        match bytes[i] {
+            b'"' => return Ok(i),
+            b'\\' => {
+                if i + 1 >= n {
+                    return Scan::err("unterminated string escape");
+                }
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    Scan::err("unterminated string")
+}
+
 #[inline]
 fn decode_hex32(src: &[u8]) -> Option<[u8; 32]> {
     if src.len() != 64 {
@@ -134,24 +190,9 @@ impl<'a> Scan<'a> {
     /// Skip the rest of a JSON string. `pos` is already past the opening quote.
     fn skip_string_body(&mut self) -> Result<(), ScanError> {
         let bytes = self.buf.get(self.pos..).unwrap_or(&[]);
-        let mut i = 0;
-        while i < bytes.len() {
-            match bytes[i..].iter().position(|&b| b == b'"' || b == b'\\') {
-                None => break,
-                Some(rel) => {
-                    i += rel;
-                    if bytes[i] == b'"' {
-                        self.pos += i + 1;
-                        return Ok(());
-                    }
-                    if i + 1 >= bytes.len() {
-                        return Self::err("unterminated string escape");
-                    }
-                    i += 2;
-                }
-            }
-        }
-        Self::err("unterminated string")
+        let i = find_unescaped_quote(bytes)?;
+        self.pos += i + 1;
+        Ok(())
     }
 
     fn skip_string(&mut self) -> Result<(), ScanError> {
@@ -591,5 +632,28 @@ mod tests {
         ] {
             assert!(parse_used_blobs_tree(json.as_bytes()).is_err(), "{json}");
         }
+    }
+    #[test]
+    fn find_unescaped_quote_handles_escapes_and_long_bodies() {
+        assert_eq!(find_unescaped_quote(b"\"").unwrap(), 0);
+        assert_eq!(find_unescaped_quote(b"hello\"").unwrap(), 5);
+        assert_eq!(find_unescaped_quote(br#"quo\"te""#).unwrap(), 7);
+        assert_eq!(find_unescaped_quote(br#"foo\\""#).unwrap(), 5);
+        let long = [b'a'; 80];
+        let mut body = long.to_vec();
+        body.push(b'"');
+        assert_eq!(find_unescaped_quote(&body).unwrap(), 80);
+        assert!(find_unescaped_quote(b"noend").is_err());
+        assert!(find_unescaped_quote(b"abc\\").is_err());
+    }
+
+    #[test]
+    fn skips_long_unescaped_names() {
+        let name = "n".repeat(80);
+        let json = format!(
+            r#"{{"nodes":[{{"name":"{name}","mtime":"2020-01-01T00:00:00+00:00","type":"file","content":["{FILE_ID}"]}}]}}"#
+        );
+        let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
+        assert_eq!(used.file_blobs, vec![FILE_ID.parse::<DataId>().unwrap()]);
     }
 }

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -4,6 +4,8 @@
 //! dedicated JSON scanner skips names, metadata, and xattrs without UTF-8
 //! validation or serde parse of unused fields.
 
+use std::borrow::Cow;
+
 use serde::de::Error as DeError;
 
 use crate::{
@@ -226,38 +228,42 @@ impl<'a> Scan<'a> {
         }
     }
 
-    /// Object key as raw bytes. Escaped keys are skipped and returned empty.
-    fn parse_key(&mut self) -> Result<&'a [u8], ScanError> {
-        if !self.eat(b'"') {
-            return Self::err("expected object key");
-        }
+    /// Borrow ordinary ASCII keys and type names; decode JSON escapes only
+    /// on the slow path so escaped live references keep their meaning.
+    fn parse_short_string(&mut self) -> Result<Cow<'a, [u8]>, ScanError> {
+        self.expect(b'"')?;
         let start = self.pos;
-        while let Some(b) = self.peek() {
-            if b == b'\\' {
-                self.skip_string_body()?;
-                return Ok(b"");
+        let bytes = &self.buf[start..];
+        for (i, byte) in bytes.iter().copied().enumerate() {
+            match byte {
+                b'"' => {
+                    self.pos = start + i + 1;
+                    return Ok(Cow::Borrowed(&self.buf[start..start + i]));
+                }
+                b'\\' | 0x80..=0xff => {
+                    self.pos = start + i;
+                    self.skip_string_body()?;
+                    let decoded: String = serde_json::from_slice(&self.buf[start - 1..self.pos])?;
+                    return Ok(Cow::Owned(decoded.into_bytes()));
+                }
+                0..=0x1f => return Self::err("control character in JSON string"),
+                _ => {}
             }
-            if b == b'"' {
-                let key = &self.buf[start..self.pos];
-                self.bump();
-                return Ok(key);
-            }
-            self.bump();
         }
         Self::err("unterminated string")
     }
 
+    fn parse_key(&mut self) -> Result<Cow<'a, [u8]>, ScanError> {
+        self.parse_short_string()
+    }
+
     fn parse_kind(&mut self) -> Result<UsedBlobKind, ScanError> {
         self.skip_ws();
-        if !self.eat(b'"') {
-            return Self::err("expected type string");
-        }
-        let start = self.pos;
-        self.skip_string_body()?;
-        Ok(match &self.buf[start..self.pos - 1] {
+        Ok(match self.parse_short_string()?.as_ref() {
             b"file" => UsedBlobKind::File,
             b"dir" => UsedBlobKind::Dir,
-            _ => UsedBlobKind::Other,
+            b"symlink" | b"dev" | b"chardev" | b"fifo" | b"socket" => UsedBlobKind::Other,
+            _ => return Self::err("unknown node type"),
         })
     }
 
@@ -266,6 +272,7 @@ impl<'a> Scan<'a> {
         if !self.eat(b'"') {
             return Self::err("expected hex id string");
         }
+        let start = self.pos - 1;
         let rest = self.buf.get(self.pos..).unwrap_or(&[]);
         if rest.len() >= 65
             && rest[64] == b'"'
@@ -275,7 +282,10 @@ impl<'a> Scan<'a> {
             return Ok(Id::new(bytes));
         }
         self.skip_string_body()?;
-        Self::err("invalid hex blob id")
+        let decoded: String = serde_json::from_slice(&self.buf[start..self.pos])?;
+        decode_hex32(decoded.as_bytes())
+            .map(Id::new)
+            .ok_or_else(|| DeError::custom("invalid hex blob id"))
     }
 
     fn parse_content(&mut self, tree: &mut UsedBlobsTree) -> Result<(), ScanError> {
@@ -316,7 +326,7 @@ impl<'a> Scan<'a> {
         self.expect(b'{')?;
         let files_at = tree.file_blobs.len();
         let dirs_at = tree.dir_trees.len();
-        let mut kind = UsedBlobKind::Other;
+        let mut kind = None;
         let mut first = true;
         loop {
             self.skip_ws();
@@ -334,14 +344,19 @@ impl<'a> Scan<'a> {
             let key = self.parse_key()?;
             self.skip_ws();
             self.expect(b':')?;
-            match key {
-                b"type" => kind = self.parse_kind()?,
+            match key.as_ref() {
+                b"type" => {
+                    if kind.is_some() {
+                        return Self::err("duplicate node type");
+                    }
+                    kind = Some(self.parse_kind()?);
+                }
                 b"content" => self.parse_content(tree)?,
                 b"subtree" => self.parse_subtree(tree)?,
                 _ => self.skip_value()?,
             }
         }
-        match kind {
+        match kind.ok_or_else(|| <ScanError as DeError>::custom("missing node type"))? {
             UsedBlobKind::File => tree.dir_trees.truncate(dirs_at),
             UsedBlobKind::Dir => tree.file_blobs.truncate(files_at),
             UsedBlobKind::Other => {
@@ -397,7 +412,7 @@ impl<'a> Scan<'a> {
             let key = self.parse_key()?;
             self.skip_ws();
             self.expect(b':')?;
-            if key == b"nodes" {
+            if key.as_ref() == b"nodes" {
                 self.parse_nodes(&mut tree)?;
             } else {
                 self.skip_value()?;
@@ -533,5 +548,48 @@ mod tests {
         let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
         assert!(used.file_blobs.is_empty());
         assert_eq!(used.dir_trees, vec![TREE_ID.parse::<TreeId>().unwrap()]);
+    }
+
+    #[test]
+    fn escaped_live_references_match_full_tree() {
+        let json = format!(
+            r#"{{"nodes":[{{"name":"file","type":"file","content":["{FILE_ID}"]}},{{"name":"dir","type":"dir","subtree":"{TREE_ID}"}}]}}"#
+        );
+        for (plain, escaped) in [
+            (r#""nodes""#, r#""n\u006fdes""#),
+            (r#""type""#, r#""t\u0079pe""#),
+            (r#""content""#, r#""cont\u0065nt""#),
+            (r#""subtree""#, r#""subtr\u0065e""#),
+            (r#""file""#, r#""f\u0069le""#),
+            (r#""dir""#, r#""d\u0069r""#),
+            ("012345", r"\u003012345"),
+            ("fedcba", r"\u0066edcba"),
+        ] {
+            let escaped_json = json.replace(plain, escaped);
+            let full: Tree = serde_json::from_str(&escaped_json).unwrap();
+            let used = parse_used_blobs_tree(escaped_json.as_bytes()).unwrap();
+            let files: Vec<_> = full
+                .nodes
+                .iter()
+                .flat_map(|n| n.content.iter().flatten().copied())
+                .collect();
+            let dirs: Vec<_> = full.nodes.iter().filter_map(|n| n.subtree).collect();
+            assert_eq!(used.file_blobs, files, "{escaped_json}");
+            assert_eq!(used.dir_trees, dirs, "{escaped_json}");
+        }
+    }
+
+    #[test]
+    fn rejects_ambiguous_node_types_and_invalid_escapes() {
+        for json in [
+            r#"{"nodes":[{"type":"future_file"}]}"#,
+            r#"{"nodes":[{"name":"missing type"}]}"#,
+            r#"{"nodes":[{"type":"file","type":"symlink"}]}"#,
+            r#"{"n\qodes":[]}"#,
+            r#"{"nodes":[{"type":"f\qile"}]}"#,
+            r#"{"nodes":[{"type":"file","content":["\q"]}]}"#,
+        ] {
+            assert!(parse_used_blobs_tree(json.as_bytes()).is_err(), "{json}");
+        }
     }
 }

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -1,14 +1,10 @@
 //! Stream-decode restic trees for prune without materializing `Node`s.
 //!
-//! Prune only needs file content blob ids and directory subtree ids. Full
-//! `Tree` deserialize also allocates names, metadata, and xattrs.
+//! Prune only needs file content blob ids and directory subtree ids. A
+//! dedicated JSON scanner skips names, metadata, and xattrs without UTF-8
+//! validation or serde parse of unused fields.
 
-use std::{borrow::Cow, fmt};
-
-use serde::{
-    Deserialize, Deserializer,
-    de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor},
-};
+use serde::de::Error as DeError;
 
 use crate::{
     Id,
@@ -53,133 +49,7 @@ fn decode_hex32(src: &[u8]) -> Option<[u8; 32]> {
     Some(out)
 }
 
-fn parse_hex_id(s: &str) -> Option<Id> {
-    decode_hex32(s.as_bytes()).map(Id::new)
-}
-
-struct HexDataIdVisitor;
-
-impl<'de> Visitor<'de> for HexDataIdVisitor {
-    type Value = DataId;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a 64-character hex blob id")
-    }
-
-    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-        parse_hex_id(v)
-            .map(DataId::from)
-            .ok_or_else(|| E::invalid_value(de::Unexpected::Str(v), &self))
-    }
-
-    fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
-        self.visit_str(v)
-    }
-}
-
-struct HexTreeIdVisitor;
-
-impl<'de> Visitor<'de> for HexTreeIdVisitor {
-    type Value = TreeId;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a 64-character hex tree id")
-    }
-
-    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-        parse_hex_id(v)
-            .map(TreeId::from)
-            .ok_or_else(|| E::invalid_value(de::Unexpected::Str(v), &self))
-    }
-
-    fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
-        self.visit_str(v)
-    }
-}
-
-fn deserialize_data_ids<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<Vec<DataId>, D::Error> {
-    struct SeqVisitor;
-
-    impl<'de> Visitor<'de> for SeqVisitor {
-        type Value = Vec<DataId>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("an array of hex blob ids")
-        }
-
-        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-            Ok(Vec::new())
-        }
-
-        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
-            Ok(Vec::new())
-        }
-
-        fn visit_some<D: Deserializer<'de>>(
-            self,
-            deserializer: D,
-        ) -> Result<Self::Value, D::Error> {
-            deserializer.deserialize_seq(self)
-        }
-
-        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-            let mut out = Vec::new();
-            while let Some(id) = seq.next_element_seed(HexDataIdSeed)? {
-                out.push(id);
-            }
-            Ok(out)
-        }
-    }
-
-    deserializer.deserialize_any(SeqVisitor)
-}
-
-struct HexDataIdSeed;
-
-impl<'de> DeserializeSeed<'de> for HexDataIdSeed {
-    type Value = DataId;
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_str(HexDataIdVisitor)
-    }
-}
-
-fn deserialize_opt_tree_id<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<Option<TreeId>, D::Error> {
-    struct OptVisitor;
-
-    impl<'de> Visitor<'de> for OptVisitor {
-        type Value = Option<TreeId>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a hex tree id or null")
-        }
-
-        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-            Ok(None)
-        }
-
-        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
-            Ok(None)
-        }
-
-        fn visit_some<D: Deserializer<'de>>(
-            self,
-            deserializer: D,
-        ) -> Result<Self::Value, D::Error> {
-            deserializer.deserialize_str(HexTreeIdVisitor).map(Some)
-        }
-
-        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            HexTreeIdVisitor.visit_str(v).map(Some)
-        }
-    }
-
-    deserializer.deserialize_any(OptVisitor)
-}
+type ScanError = serde_json::Error;
 
 /// Compact tree contents used by prune's used-blob walk.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -188,145 +58,361 @@ pub(crate) struct UsedBlobsTree {
     pub dir_trees: Vec<TreeId>,
 }
 
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Default, Clone, Copy)]
 enum UsedBlobKind {
     File,
     Dir,
     #[default]
-    #[serde(other)]
     Other,
 }
 
-impl<'de> Deserialize<'de> for UsedBlobsTree {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_map(UsedBlobsTreeVisitor)
-    }
+struct Scan<'a> {
+    buf: &'a [u8],
+    pos: usize,
 }
 
-struct UsedBlobsTreeVisitor;
-
-impl<'de> Visitor<'de> for UsedBlobsTreeVisitor {
-    type Value = UsedBlobsTree;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a restic tree object")
+impl<'a> Scan<'a> {
+    fn err<T>(msg: &'static str) -> Result<T, ScanError> {
+        Err(DeError::custom(msg))
     }
 
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        let mut tree = UsedBlobsTree::default();
-        while let Some(key) = map.next_key::<Cow<'_, str>>()? {
-            if key == "nodes" {
-                map.next_value_seed(NodesSeed(&mut tree))?;
-            } else {
-                let _: IgnoredAny = map.next_value()?;
+    #[inline]
+    fn peek(&self) -> Option<u8> {
+        self.buf.get(self.pos).copied()
+    }
+
+    #[inline]
+    fn bump(&mut self) {
+        self.pos += 1;
+    }
+
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            self.bump();
+        }
+    }
+
+    #[inline]
+    fn eat(&mut self, c: u8) -> bool {
+        if self.peek() == Some(c) {
+            self.bump();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, c: u8) -> Result<(), ScanError> {
+        if self.eat(c) {
+            Ok(())
+        } else {
+            Self::err("unexpected JSON token")
+        }
+    }
+
+    fn skip_lit(&mut self, lit: &[u8]) -> Result<(), ScanError> {
+        let rest = self.buf.get(self.pos..).unwrap_or(&[]);
+        if rest.starts_with(lit) {
+            self.pos += lit.len();
+            Ok(())
+        } else {
+            Self::err("invalid JSON literal")
+        }
+    }
+
+    fn try_null(&mut self) -> Result<bool, ScanError> {
+        if self.peek() == Some(b'n') {
+            self.skip_lit(b"null")?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Skip the rest of a JSON string. `pos` is already past the opening quote.
+    fn skip_string_body(&mut self) -> Result<(), ScanError> {
+        let bytes = self.buf.get(self.pos..).unwrap_or(&[]);
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i..].iter().position(|&b| b == b'"' || b == b'\\') {
+                None => break,
+                Some(rel) => {
+                    i += rel;
+                    if bytes[i] == b'"' {
+                        self.pos += i + 1;
+                        return Ok(());
+                    }
+                    if i + 1 >= bytes.len() {
+                        return Self::err("unterminated string escape");
+                    }
+                    i += 2;
+                }
             }
+        }
+        Self::err("unterminated string")
+    }
+
+    fn skip_string(&mut self) -> Result<(), ScanError> {
+        if !self.eat(b'"') {
+            return Self::err("expected string");
+        }
+        self.skip_string_body()
+    }
+
+    fn skip_digits(&mut self) -> bool {
+        let start = self.pos;
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.bump();
+        }
+        self.pos > start
+    }
+
+    fn skip_number(&mut self) -> Result<(), ScanError> {
+        let _ = self.eat(b'-');
+        if !self.skip_digits() {
+            return Self::err("invalid number");
+        }
+        if self.eat(b'.') && !self.skip_digits() {
+            return Self::err("invalid number");
+        }
+        if matches!(self.peek(), Some(b'e' | b'E')) {
+            self.bump();
+            if matches!(self.peek(), Some(b'+' | b'-')) {
+                self.bump();
+            }
+            if !self.skip_digits() {
+                return Self::err("invalid number");
+            }
+        }
+        Ok(())
+    }
+
+    fn skip_value(&mut self) -> Result<(), ScanError> {
+        self.skip_ws();
+        match self.peek() {
+            Some(b'"') => self.skip_string(),
+            Some(b'{') => self.skip_comma_list(b'{', b'}', true),
+            Some(b'[') => self.skip_comma_list(b'[', b']', false),
+            Some(b't') => self.skip_lit(b"true"),
+            Some(b'f') => self.skip_lit(b"false"),
+            Some(b'n') => self.skip_lit(b"null"),
+            Some(b'-' | b'0'..=b'9') => self.skip_number(),
+            _ => Self::err("expected JSON value"),
+        }
+    }
+
+    fn skip_comma_list(&mut self, open: u8, close: u8, object: bool) -> Result<(), ScanError> {
+        self.expect(open)?;
+        let mut first = true;
+        loop {
+            self.skip_ws();
+            if self.eat(close) {
+                return Ok(());
+            }
+            if !first {
+                self.expect(b',')?;
+                self.skip_ws();
+                if self.eat(close) {
+                    return Self::err("trailing comma");
+                }
+            }
+            first = false;
+            if object {
+                self.skip_string()?;
+                self.skip_ws();
+                self.expect(b':')?;
+            }
+            self.skip_value()?;
+        }
+    }
+
+    /// Object key as raw bytes. Escaped keys are skipped and returned empty.
+    fn parse_key(&mut self) -> Result<&'a [u8], ScanError> {
+        if !self.eat(b'"') {
+            return Self::err("expected object key");
+        }
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b == b'\\' {
+                self.skip_string_body()?;
+                return Ok(b"");
+            }
+            if b == b'"' {
+                let key = &self.buf[start..self.pos];
+                self.bump();
+                return Ok(key);
+            }
+            self.bump();
+        }
+        Self::err("unterminated string")
+    }
+
+    fn parse_kind(&mut self) -> Result<UsedBlobKind, ScanError> {
+        self.skip_ws();
+        if !self.eat(b'"') {
+            return Self::err("expected type string");
+        }
+        let start = self.pos;
+        self.skip_string_body()?;
+        Ok(match &self.buf[start..self.pos - 1] {
+            b"file" => UsedBlobKind::File,
+            b"dir" => UsedBlobKind::Dir,
+            _ => UsedBlobKind::Other,
+        })
+    }
+
+    fn parse_hex_id(&mut self) -> Result<Id, ScanError> {
+        self.skip_ws();
+        if !self.eat(b'"') {
+            return Self::err("expected hex id string");
+        }
+        let rest = self.buf.get(self.pos..).unwrap_or(&[]);
+        if rest.len() >= 65
+            && rest[64] == b'"'
+            && let Some(bytes) = decode_hex32(&rest[..64])
+        {
+            self.pos += 65;
+            return Ok(Id::new(bytes));
+        }
+        self.skip_string_body()?;
+        Self::err("invalid hex blob id")
+    }
+
+    fn parse_content(&mut self, tree: &mut UsedBlobsTree) -> Result<(), ScanError> {
+        self.skip_ws();
+        if self.try_null()? {
+            return Ok(());
+        }
+        self.expect(b'[')?;
+        let mut first = true;
+        loop {
+            self.skip_ws();
+            if self.eat(b']') {
+                return Ok(());
+            }
+            if !first {
+                self.expect(b',')?;
+                self.skip_ws();
+                if self.eat(b']') {
+                    return Self::err("trailing comma");
+                }
+            }
+            first = false;
+            tree.file_blobs.push(DataId::from(self.parse_hex_id()?));
+        }
+    }
+
+    fn parse_subtree(&mut self, tree: &mut UsedBlobsTree) -> Result<(), ScanError> {
+        self.skip_ws();
+        if self.try_null()? {
+            return Ok(());
+        }
+        tree.dir_trees.push(TreeId::from(self.parse_hex_id()?));
+        Ok(())
+    }
+
+    fn parse_node(&mut self, tree: &mut UsedBlobsTree) -> Result<(), ScanError> {
+        self.skip_ws();
+        self.expect(b'{')?;
+        let files_at = tree.file_blobs.len();
+        let dirs_at = tree.dir_trees.len();
+        let mut kind = UsedBlobKind::Other;
+        let mut first = true;
+        loop {
+            self.skip_ws();
+            if self.eat(b'}') {
+                break;
+            }
+            if !first {
+                self.expect(b',')?;
+                self.skip_ws();
+                if self.eat(b'}') {
+                    return Self::err("trailing comma");
+                }
+            }
+            first = false;
+            let key = self.parse_key()?;
+            self.skip_ws();
+            self.expect(b':')?;
+            match key {
+                b"type" => kind = self.parse_kind()?,
+                b"content" => self.parse_content(tree)?,
+                b"subtree" => self.parse_subtree(tree)?,
+                _ => self.skip_value()?,
+            }
+        }
+        match kind {
+            UsedBlobKind::File => tree.dir_trees.truncate(dirs_at),
+            UsedBlobKind::Dir => tree.file_blobs.truncate(files_at),
+            UsedBlobKind::Other => {
+                tree.file_blobs.truncate(files_at);
+                tree.dir_trees.truncate(dirs_at);
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_nodes(&mut self, tree: &mut UsedBlobsTree) -> Result<(), ScanError> {
+        self.skip_ws();
+        if self.try_null()? {
+            return Ok(());
+        }
+        self.expect(b'[')?;
+        let mut first = true;
+        loop {
+            self.skip_ws();
+            if self.eat(b']') {
+                return Ok(());
+            }
+            if !first {
+                self.expect(b',')?;
+                self.skip_ws();
+                if self.eat(b']') {
+                    return Self::err("trailing comma");
+                }
+            }
+            first = false;
+            self.parse_node(tree)?;
+        }
+    }
+
+    fn parse_tree(&mut self) -> Result<UsedBlobsTree, ScanError> {
+        self.skip_ws();
+        self.expect(b'{')?;
+        let mut tree = UsedBlobsTree::default();
+        let mut first = true;
+        loop {
+            self.skip_ws();
+            if self.eat(b'}') {
+                break;
+            }
+            if !first {
+                self.expect(b',')?;
+                self.skip_ws();
+                if self.eat(b'}') {
+                    return Self::err("trailing comma");
+                }
+            }
+            first = false;
+            let key = self.parse_key()?;
+            self.skip_ws();
+            self.expect(b':')?;
+            if key == b"nodes" {
+                self.parse_nodes(&mut tree)?;
+            } else {
+                self.skip_value()?;
+            }
+        }
+        self.skip_ws();
+        if self.pos != self.buf.len() {
+            return Self::err("trailing JSON");
         }
         Ok(tree)
     }
 }
 
-struct NodesSeed<'a>(&'a mut UsedBlobsTree);
-
-impl<'de> DeserializeSeed<'de> for NodesSeed<'_> {
-    type Value = ();
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_any(self)
-    }
-}
-
-impl<'de> Visitor<'de> for NodesSeed<'_> {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a nodes array or null")
-    }
-
-    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-        Ok(())
-    }
-
-    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
-        Ok(())
-    }
-
-    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_seq(self)
-    }
-
-    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        while seq.next_element_seed(NodeSeed(self.0))?.is_some() {}
-        Ok(())
-    }
-}
-
-struct NodeSeed<'a>(&'a mut UsedBlobsTree);
-
-impl<'de> DeserializeSeed<'de> for NodeSeed<'_> {
-    type Value = ();
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_map(self)
-    }
-}
-
-impl<'de> Visitor<'de> for NodeSeed<'_> {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a restic tree node object")
-    }
-
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        let mut kind = UsedBlobKind::Other;
-        let mut content = Vec::new();
-        let mut subtree = None;
-        while let Some(key) = map.next_key::<Cow<'_, str>>()? {
-            match key.as_ref() {
-                "type" => kind = map.next_value()?,
-                "content" => content = map.next_value_seed(DataIdsSeed)?,
-                "subtree" => subtree = map.next_value_seed(OptTreeIdSeed)?,
-                _ => {
-                    let _: IgnoredAny = map.next_value()?;
-                }
-            }
-        }
-        match kind {
-            UsedBlobKind::File => self.0.file_blobs.append(&mut content),
-            UsedBlobKind::Dir => {
-                if let Some(id) = subtree {
-                    self.0.dir_trees.push(id);
-                }
-            }
-            UsedBlobKind::Other => {}
-        }
-        Ok(())
-    }
-}
-
-struct DataIdsSeed;
-
-impl<'de> DeserializeSeed<'de> for DataIdsSeed {
-    type Value = Vec<DataId>;
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserialize_data_ids(deserializer)
-    }
-}
-
-struct OptTreeIdSeed;
-
-impl<'de> DeserializeSeed<'de> for OptTreeIdSeed {
-    type Value = Option<TreeId>;
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserialize_opt_tree_id(deserializer)
-    }
-}
-
 pub(crate) fn parse_used_blobs_tree(data: &[u8]) -> Result<UsedBlobsTree, serde_json::Error> {
-    serde_json::from_slice(data)
+    Scan { buf: data, pos: 0 }.parse_tree()
 }
 
 #[cfg(test)]
@@ -428,5 +514,24 @@ mod tests {
         assert!(
             parse_used_blobs_tree(br#"{"nodes":[{"type":"file","content":["zzzz"]}]}"#).is_err()
         );
+    }
+
+    #[test]
+    fn skips_escaped_names_and_accepts_content_before_type() {
+        let json =
+            format!(r#"{{"nodes":[{{"name":"quo\"te","content":["{FILE_ID}"],"type":"file"}}]}}"#);
+        let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
+        assert_eq!(used.file_blobs, vec![FILE_ID.parse::<DataId>().unwrap()]);
+        assert!(used.dir_trees.is_empty());
+    }
+
+    #[test]
+    fn file_content_is_ignored_on_dirs_and_other_types() {
+        let json = format!(
+            r#"{{"nodes":[{{"type":"dir","content":["{FILE_ID}"],"subtree":"{TREE_ID}"}},{{"type":"symlink","content":["{FILE_ID}"]}}]}}"#
+        );
+        let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
+        assert!(used.file_blobs.is_empty());
+        assert_eq!(used.dir_trees, vec![TREE_ID.parse::<TreeId>().unwrap()]);
     }
 }

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -169,11 +169,7 @@ mod tests {
             .filter(|n| matches!(n.node_type, crate::backend::node::NodeType::File))
             .flat_map(|n| n.content.iter().flatten().copied())
             .collect();
-        let full_dirs: Vec<_> = full
-            .nodes
-            .iter()
-            .filter_map(|n| n.subtree)
-            .collect();
+        let full_dirs: Vec<_> = full.nodes.iter().filter_map(|n| n.subtree).collect();
 
         assert_eq!(used.file_blobs, full_files);
         assert_eq!(used.dir_trees, full_dirs);
@@ -203,9 +199,7 @@ mod tests {
 
     #[test]
     fn ignores_unknown_tree_keys() {
-        let json = format!(
-            r#"{{"extra":1,"nodes":[{{"type":"file","content":["{FILE_ID}"]}}]}}"#
-        );
+        let json = format!(r#"{{"extra":1,"nodes":[{{"type":"file","content":["{FILE_ID}"]}}]}}"#);
         let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
         assert_eq!(used.file_blobs.len(), 1);
         assert!(used.dir_trees.is_empty());

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -231,7 +231,7 @@ impl<'a> Scan<'a> {
             }
             first = false;
             if object {
-                self.skip_string()?;
+                _ = self.parse_short_string()?;
                 self.skip_ws();
                 self.expect(b':')?;
             }

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -180,23 +180,14 @@ pub(crate) struct UsedBlobsTree {
     pub dir_trees: Vec<TreeId>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum UsedBlobKind {
     File,
     Dir,
+    #[default]
     #[serde(other)]
     Other,
-}
-
-#[derive(Debug, Deserialize)]
-struct UsedBlobNode {
-    #[serde(rename = "type")]
-    kind: UsedBlobKind,
-    #[serde(default, deserialize_with = "deserialize_data_ids")]
-    content: Vec<DataId>,
-    #[serde(default, deserialize_with = "deserialize_opt_tree_id")]
-    subtree: Option<TreeId>,
 }
 
 impl<'de> Deserialize<'de> for UsedBlobsTree {
@@ -257,20 +248,72 @@ impl<'de> Visitor<'de> for NodesSeed<'_> {
     }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        while let Some(node) = seq.next_element::<UsedBlobNode>()? {
-            match node.kind {
-                UsedBlobKind::File => {
-                    self.0.file_blobs.extend(node.content);
+        while seq.next_element_seed(NodeSeed(self.0))?.is_some() {}
+        Ok(())
+    }
+}
+
+struct NodeSeed<'a>(&'a mut UsedBlobsTree);
+
+impl<'de> DeserializeSeed<'de> for NodeSeed<'_> {
+    type Value = ();
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_map(self)
+    }
+}
+
+impl<'de> Visitor<'de> for NodeSeed<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a restic tree node object")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut kind = UsedBlobKind::Other;
+        let mut content = Vec::new();
+        let mut subtree = None;
+        while let Some(key) = map.next_key::<Cow<'_, str>>()? {
+            match key.as_ref() {
+                "type" => kind = map.next_value()?,
+                "content" => content = map.next_value_seed(DataIdsSeed)?,
+                "subtree" => subtree = map.next_value_seed(OptTreeIdSeed)?,
+                _ => {
+                    let _: IgnoredAny = map.next_value()?;
                 }
-                UsedBlobKind::Dir => {
-                    if let Some(subtree) = node.subtree {
-                        self.0.dir_trees.push(subtree);
-                    }
-                }
-                UsedBlobKind::Other => {}
             }
         }
+        match kind {
+            UsedBlobKind::File => self.0.file_blobs.append(&mut content),
+            UsedBlobKind::Dir => {
+                if let Some(id) = subtree {
+                    self.0.dir_trees.push(id);
+                }
+            }
+            UsedBlobKind::Other => {}
+        }
         Ok(())
+    }
+}
+
+struct DataIdsSeed;
+
+impl<'de> DeserializeSeed<'de> for DataIdsSeed {
+    type Value = Vec<DataId>;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserialize_data_ids(deserializer)
+    }
+}
+
+struct OptTreeIdSeed;
+
+impl<'de> DeserializeSeed<'de> for OptTreeIdSeed {
+    type Value = Option<TreeId>;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserialize_opt_tree_id(deserializer)
     }
 }
 

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -1,0 +1,213 @@
+//! Stream-decode restic trees for prune without materializing `Node`s.
+//!
+//! Prune only needs file content blob ids and directory subtree ids. Full
+//! `Tree` deserialize also allocates names, metadata, and xattrs.
+
+use std::{borrow::Cow, fmt};
+
+use serde::{
+    Deserialize, Deserializer,
+    de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor},
+};
+
+use crate::blob::{DataId, tree::TreeId};
+
+/// Compact tree contents used by prune's used-blob walk.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct UsedBlobsTree {
+    pub file_blobs: Vec<DataId>,
+    pub dir_trees: Vec<TreeId>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum UsedBlobKind {
+    File,
+    Dir,
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsedBlobNode {
+    #[serde(rename = "type")]
+    kind: UsedBlobKind,
+    #[serde(default)]
+    content: Option<Vec<DataId>>,
+    #[serde(default)]
+    subtree: Option<TreeId>,
+}
+
+impl<'de> Deserialize<'de> for UsedBlobsTree {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(UsedBlobsTreeVisitor)
+    }
+}
+
+struct UsedBlobsTreeVisitor;
+
+impl<'de> Visitor<'de> for UsedBlobsTreeVisitor {
+    type Value = UsedBlobsTree;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a restic tree object")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut tree = UsedBlobsTree::default();
+        while let Some(key) = map.next_key::<Cow<'_, str>>()? {
+            if key == "nodes" {
+                map.next_value_seed(NodesSeed(&mut tree))?;
+            } else {
+                let _: IgnoredAny = map.next_value()?;
+            }
+        }
+        Ok(tree)
+    }
+}
+
+struct NodesSeed<'a>(&'a mut UsedBlobsTree);
+
+impl<'de> DeserializeSeed<'de> for NodesSeed<'_> {
+    type Value = ();
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for NodesSeed<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a nodes array or null")
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_seq(self)
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        while let Some(node) = seq.next_element::<UsedBlobNode>()? {
+            match node.kind {
+                UsedBlobKind::File => {
+                    if let Some(content) = node.content {
+                        self.0.file_blobs.extend(content);
+                    }
+                }
+                UsedBlobKind::Dir => {
+                    if let Some(subtree) = node.subtree {
+                        self.0.dir_trees.push(subtree);
+                    }
+                }
+                UsedBlobKind::Other => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn parse_used_blobs_tree(data: &[u8]) -> Result<UsedBlobsTree, serde_json::Error> {
+    serde_json::from_slice(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::node::Node;
+    use crate::blob::tree::Tree;
+
+    const FILE_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const TREE_ID: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    #[test]
+    fn extracts_file_and_dir_ids_and_skips_the_rest() {
+        let json = format!(
+            r#"{{
+                "nodes": [
+                    {{
+                        "name": "foo",
+                        "type": "file",
+                        "mtime": "2020-01-01T00:00:00+00:00",
+                        "mode": 420,
+                        "uid": 1000,
+                        "user": "brad",
+                        "inode": 1,
+                        "size": 3,
+                        "links": 1,
+                        "extended_attributes": [{{"name": "user.foo", "value": "YQ=="}}],
+                        "content": ["{FILE_ID}"]
+                    }},
+                    {{
+                        "name": "bar",
+                        "type": "dir",
+                        "subtree": "{TREE_ID}"
+                    }},
+                    {{
+                        "name": "link",
+                        "type": "symlink",
+                        "linktarget": "/tmp/x"
+                    }}
+                ]
+            }}"#
+        );
+
+        let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
+        let full: Tree = serde_json::from_slice(json.as_bytes()).unwrap();
+
+        let full_files: Vec<_> = full
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.node_type, crate::backend::node::NodeType::File))
+            .flat_map(|n| n.content.iter().flatten().copied())
+            .collect();
+        let full_dirs: Vec<_> = full
+            .nodes
+            .iter()
+            .filter_map(|n| n.subtree)
+            .collect();
+
+        assert_eq!(used.file_blobs, full_files);
+        assert_eq!(used.dir_trees, full_dirs);
+        assert_eq!(used.file_blobs, vec![FILE_ID.parse::<DataId>().unwrap()]);
+        assert_eq!(used.dir_trees, vec![TREE_ID.parse::<TreeId>().unwrap()]);
+        // Full deserialize kept metadata we did not allocate in the prune path.
+        let foo: &Node = &full.nodes[0];
+        assert_eq!(foo.name, "foo");
+        assert_eq!(foo.meta.extended_attributes.len(), 1);
+    }
+
+    #[test]
+    fn null_or_missing_nodes_is_empty() {
+        assert_eq!(
+            parse_used_blobs_tree(br#"{"nodes":null}"#).unwrap(),
+            UsedBlobsTree::default()
+        );
+        assert_eq!(
+            parse_used_blobs_tree(br#"{}"#).unwrap(),
+            UsedBlobsTree::default()
+        );
+        assert_eq!(
+            parse_used_blobs_tree(br#"{"nodes":[]}"#).unwrap(),
+            UsedBlobsTree::default()
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_tree_keys() {
+        let json = format!(
+            r#"{{"extra":1,"nodes":[{{"type":"file","content":["{FILE_ID}"]}}]}}"#
+        );
+        let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
+        assert_eq!(used.file_blobs.len(), 1);
+        assert!(used.dir_trees.is_empty());
+    }
+}

--- a/crates/core/src/blob/tree/used_blobs.rs
+++ b/crates/core/src/blob/tree/used_blobs.rs
@@ -10,7 +10,168 @@ use serde::{
     de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor},
 };
 
-use crate::blob::{DataId, tree::TreeId};
+use crate::{
+    Id,
+    blob::{DataId, tree::TreeId},
+};
+
+/// Nibble lookup: 0–15 for hex digits, `0xFF` otherwise.
+const fn hex_nibble_table() -> [u8; 256] {
+    let mut t = [0xff_u8; 256];
+    let mut i: u8 = 0;
+    while i < 10 {
+        t[b'0' as usize + i as usize] = i;
+        i += 1;
+    }
+    i = 0;
+    while i < 6 {
+        t[b'a' as usize + i as usize] = 10 + i;
+        t[b'A' as usize + i as usize] = 10 + i;
+        i += 1;
+    }
+    t
+}
+
+const HEX_NIBBLE: [u8; 256] = hex_nibble_table();
+
+#[inline]
+fn decode_hex32(src: &[u8]) -> Option<[u8; 32]> {
+    if src.len() != 64 {
+        return None;
+    }
+    let mut out = [0_u8; 32];
+    let mut i = 0;
+    while i < 32 {
+        let hi = HEX_NIBBLE[src[i * 2] as usize];
+        let lo = HEX_NIBBLE[src[i * 2 + 1] as usize];
+        if (hi | lo) == 0xff {
+            return None;
+        }
+        out[i] = (hi << 4) | lo;
+        i += 1;
+    }
+    Some(out)
+}
+
+fn parse_hex_id(s: &str) -> Option<Id> {
+    decode_hex32(s.as_bytes()).map(Id::new)
+}
+
+struct HexDataIdVisitor;
+
+impl Visitor<'_> for HexDataIdVisitor {
+    type Value = DataId;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a 64-character hex blob id")
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        parse_hex_id(v)
+            .map(DataId::from)
+            .ok_or_else(|| E::invalid_value(de::Unexpected::Str(v), &self))
+    }
+}
+
+struct HexTreeIdVisitor;
+
+impl Visitor<'_> for HexTreeIdVisitor {
+    type Value = TreeId;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a 64-character hex tree id")
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        parse_hex_id(v)
+            .map(TreeId::from)
+            .ok_or_else(|| E::invalid_value(de::Unexpected::Str(v), &self))
+    }
+}
+
+fn deserialize_data_ids<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<DataId>, D::Error> {
+    struct SeqVisitor;
+
+    impl<'de> Visitor<'de> for SeqVisitor {
+        type Value = Vec<DataId>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("an array of hex blob ids")
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(Vec::new())
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(Vec::new())
+        }
+
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            deserializer.deserialize_seq(self)
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut out = Vec::new();
+            while let Some(id) = seq.next_element_seed(HexDataIdSeed)? {
+                out.push(id);
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_any(SeqVisitor)
+}
+
+struct HexDataIdSeed;
+
+impl<'de> DeserializeSeed<'de> for HexDataIdSeed {
+    type Value = DataId;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_str(HexDataIdVisitor)
+    }
+}
+
+fn deserialize_opt_tree_id<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<TreeId>, D::Error> {
+    struct OptVisitor;
+
+    impl<'de> Visitor<'de> for OptVisitor {
+        type Value = Option<TreeId>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a hex tree id or null")
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            deserializer.deserialize_str(HexTreeIdVisitor).map(Some)
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            HexTreeIdVisitor.visit_str(v).map(Some)
+        }
+    }
+
+    deserializer.deserialize_any(OptVisitor)
+}
 
 /// Compact tree contents used by prune's used-blob walk.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -32,9 +193,9 @@ enum UsedBlobKind {
 struct UsedBlobNode {
     #[serde(rename = "type")]
     kind: UsedBlobKind,
-    #[serde(default)]
-    content: Option<Vec<DataId>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_data_ids")]
+    content: Vec<DataId>,
+    #[serde(default, deserialize_with = "deserialize_opt_tree_id")]
     subtree: Option<TreeId>,
 }
 
@@ -99,9 +260,7 @@ impl<'de> Visitor<'de> for NodesSeed<'_> {
         while let Some(node) = seq.next_element::<UsedBlobNode>()? {
             match node.kind {
                 UsedBlobKind::File => {
-                    if let Some(content) = node.content {
-                        self.0.file_blobs.extend(content);
-                    }
+                    self.0.file_blobs.extend(node.content);
                 }
                 UsedBlobKind::Dir => {
                     if let Some(subtree) = node.subtree {
@@ -203,5 +362,20 @@ mod tests {
         let used = parse_used_blobs_tree(json.as_bytes()).unwrap();
         assert_eq!(used.file_blobs.len(), 1);
         assert!(used.dir_trees.is_empty());
+    }
+
+    #[test]
+    fn hex_ids_accept_uppercase_and_reject_garbage() {
+        let upper = format!(
+            r#"{{"nodes":[{{"type":"file","content":["{}"]}}]}}"#,
+            FILE_ID.to_uppercase()
+        );
+        assert_eq!(
+            parse_used_blobs_tree(upper.as_bytes()).unwrap().file_blobs,
+            vec![FILE_ID.parse::<DataId>().unwrap()]
+        );
+        assert!(
+            parse_used_blobs_tree(br#"{"nodes":[{"type":"file","content":["zzzz"]}]}"#).is_err()
+        );
     }
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -152,7 +152,8 @@ pub(super) mod constants {
     /// Minimum size of an index file to be considered for pruning
     pub(super) const MIN_INDEX_LEN: usize = 10_000;
     /// Per-loader used-id vec start size. Avoids grow during the walk.
-    pub(super) const USED_ID_VEC_CAP: usize = 1 << 21;
+    /// ~22M unique blobs / 8 loaders plus dups; 4M slots is 128 MiB/loader.
+    pub(super) const USED_ID_VEC_CAP: usize = 1 << 22;
     /// Parallel `HashMap` shards for the used-id merge. Power of two.
     pub(super) const USED_ID_SHARDS: usize = 16;
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -72,13 +72,89 @@ impl Hash for UsedId {
     }
 }
 
-type UsedIdMap = HashMap<UsedId, u8, BuildHasherDefault<UsedIdHasher>>;
+type UsedIdShard = HashMap<UsedId, u8, BuildHasherDefault<UsedIdHasher>>;
+
+/// Used blob ids, sharded so the post-walk `HashMap` fill can run in parallel.
+#[derive(Debug)]
+struct UsedIdMap {
+    shards: Vec<UsedIdShard>,
+}
+
+impl Default for UsedIdMap {
+    fn default() -> Self {
+        Self {
+            shards: (0..constants::USED_ID_SHARDS)
+                .map(|_| UsedIdShard::default())
+                .collect(),
+        }
+    }
+}
+
+impl UsedIdMap {
+    #[inline]
+    fn shard(id: &UsedId) -> usize {
+        usize::try_from(id.0.as_u64() & (constants::USED_ID_SHARDS as u64 - 1)).unwrap_or(0)
+    }
+
+    fn from_lists(lists: Vec<Vec<UsedId>>) -> Self {
+        let total: usize = lists.iter().map(Vec::len).sum();
+        let cap = (total / constants::USED_ID_SHARDS).saturating_add(64);
+        let mut buckets: Vec<Vec<UsedId>> = (0..constants::USED_ID_SHARDS)
+            .map(|_| Vec::with_capacity(cap))
+            .collect();
+        for list in lists {
+            for id in list {
+                buckets[Self::shard(&id)].push(id);
+            }
+        }
+        let shards = buckets
+            .into_par_iter()
+            .map(|mut v| {
+                v.sort_unstable();
+                v.dedup();
+                let mut map =
+                    UsedIdShard::with_capacity_and_hasher(v.len(), BuildHasherDefault::default());
+                map.extend(v.into_iter().map(|id| (id, 0)));
+                map
+            })
+            .collect();
+        Self { shards }
+    }
+
+    #[cfg(test)]
+    fn get(&self, id: &UsedId) -> Option<&u8> {
+        self.shards[Self::shard(id)].get(id)
+    }
+
+    #[inline]
+    fn get_mut(&mut self, id: &UsedId) -> Option<&mut u8> {
+        let i = Self::shard(id);
+        self.shards[i].get_mut(id)
+    }
+
+    #[cfg(test)]
+    fn insert(&mut self, id: UsedId, v: u8) -> Option<u8> {
+        let i = Self::shard(&id);
+        self.shards[i].insert(id, v)
+    }
+
+    fn remove(&mut self, id: &UsedId) -> Option<u8> {
+        let i = Self::shard(id);
+        self.shards[i].remove(id)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&UsedId, &u8)> + '_ {
+        self.shards.iter().flat_map(HashMap::iter)
+    }
+}
 
 pub(super) mod constants {
     /// Minimum size of an index file to be considered for pruning
     pub(super) const MIN_INDEX_LEN: usize = 10_000;
     /// Per-loader used-id vec start size. Avoids grow during the walk.
     pub(super) const USED_ID_VEC_CAP: usize = 1 << 21;
+    /// Parallel `HashMap` shards for the used-id merge. Power of two.
+    pub(super) const USED_ID_SHARDS: usize = 16;
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -837,7 +913,7 @@ impl PrunePlan {
     ///
     /// * If a blob is missing
     fn check(&self) -> RusticResult<()> {
-        for (id, count) in &self.used_ids {
+        for (id, count) in self.used_ids.iter() {
             if *count == 0 {
                 return Err(RusticError::new(
                     ErrorKind::Internal,
@@ -1682,9 +1758,9 @@ fn find_used_blobs<S>(
         .try_collect()?;
     p.finish();
 
-    let mut ids: UsedIdMap = snap_trees
+    let snap_ids: Vec<UsedId> = snap_trees
         .iter()
-        .map(|id| (UsedId(BlobId::from(**id)), 0))
+        .map(|id| UsedId(BlobId::from(**id)))
         .collect();
     let p = repo.progress_counter("finding used blobs...");
     let (ids_tx, ids_rx) = mpsc::channel();
@@ -1701,13 +1777,9 @@ fn find_used_blobs<S>(
         let _ = item;
     }
     drop(tree_streamer);
-    let lists: Vec<_> = ids_rx.iter().collect();
-    ids.reserve(lists.iter().map(Vec::len).sum());
-    for list in lists {
-        ids.extend(list.into_iter().map(|id| (id, 0)));
-    }
-
-    Ok(ids)
+    let mut lists: Vec<_> = ids_rx.iter().collect();
+    lists.push(snap_ids);
+    Ok(UsedIdMap::from_lists(lists))
 }
 
 #[cfg(test)]
@@ -1755,5 +1827,21 @@ mod used_id_hash_tests {
         ids.sort_unstable();
         ids.dedup();
         assert_eq!(ids, vec![a, b, c]);
+    }
+
+    #[test]
+    fn from_lists_merges_across_loaders_and_shards() {
+        let a = UsedId(blob(ID_A));
+        let b = UsedId(blob(ID_B));
+        let c = UsedId(blob(ID_C));
+        let map = UsedIdMap::from_lists(vec![vec![a, a, c], vec![c, b]]);
+        assert_eq!(map.get(&a).copied(), Some(0));
+        assert_eq!(map.get(&b).copied(), Some(0));
+        assert_eq!(map.get(&c).copied(), Some(0));
+        assert_eq!(map.iter().count(), 3);
+        let mut map = map;
+        assert_eq!(map.remove(&b), Some(0));
+        assert!(map.get(&b).is_none());
+        assert_eq!(map.iter().count(), 2);
     }
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -1803,14 +1803,14 @@ mod used_id_hash_tests {
         let a = UsedId(blob(ID_A));
         let b = UsedId(blob(ID_B));
         let c = UsedId(blob(ID_C));
-        assert_eq!(hasher.hash_one(&a), a.0.as_u64());
+        assert_eq!(hasher.hash_one(a), a.0.as_u64());
         assert_eq!(
-            hasher.hash_one(&a),
+            hasher.hash_one(a),
             u64::from_le_bytes([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
         );
-        assert_eq!(hasher.hash_one(&a), hasher.hash_one(&b));
+        assert_eq!(hasher.hash_one(a), hasher.hash_one(b));
         assert_ne!(a, b);
-        assert_ne!(hasher.hash_one(&a), hasher.hash_one(&c));
+        assert_ne!(hasher.hash_one(a), hasher.hash_one(c));
 
         let mut map = UsedIdMap::default();
         assert!(map.insert(a, 0).is_none());

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -6,7 +6,7 @@ use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
     str::FromStr,
-    sync::{Arc, Mutex},
+    sync::mpsc::{self, Sender},
 };
 
 use bytesize::ByteSize;
@@ -27,7 +27,7 @@ use crate::{
     blob::{
         BlobId, BlobLocations, BlobType, BlobTypeMap, Initialize,
         packer::{BlobCopier, CopyPackBlobs, PackSizer},
-        tree::{TreeStreamer, UsedBlobsTree},
+        tree::{OnTreeLoad, TreeStreamer, UsedBlobsTree},
     },
     error::{ErrorKind, RusticError, RusticResult},
     index::{
@@ -1584,44 +1584,24 @@ impl PackInfo {
     }
 }
 
-const USED_ID_SHARDS: usize = 16;
-
-/// Used blob ids filled from tree-loader threads.
-///
-/// A single `HashMap` on the streamer consumer serialized prune's used-blob
-/// walk. Shard so loaders insert without that bottleneck.
-struct ShardedUsedIds {
-    shards: [Mutex<HashMap<BlobId, u8>>; USED_ID_SHARDS],
+/// Per-loader used-id map. Inserts take no lock; maps are merged after the walk.
+struct UsedIdAcc {
+    map: HashMap<BlobId, u8>,
+    tx: Sender<HashMap<BlobId, u8>>,
 }
 
-impl ShardedUsedIds {
-    fn new() -> Self {
-        Self {
-            shards: std::array::from_fn(|_| Mutex::new(HashMap::new())),
+impl OnTreeLoad<UsedBlobsTree> for UsedIdAcc {
+    fn on_load(&mut self, tree: &UsedBlobsTree) {
+        for id in &tree.file_blobs {
+            _ = self.map.insert(BlobId::from(*id), 0);
+        }
+        for id in &tree.dir_trees {
+            _ = self.map.insert(BlobId::from(*id), 0);
         }
     }
 
-    fn insert(&self, id: BlobId) {
-        let i = (id.as_u32() as usize) & (USED_ID_SHARDS - 1);
-        _ = self.shards[i]
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(id, 0);
-    }
-
-    fn take_hashmap(&self) -> HashMap<BlobId, u8> {
-        let mut out = HashMap::new();
-        for shard in &self.shards {
-            let mut map = shard
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if out.is_empty() {
-                out = std::mem::take(&mut *map);
-            } else {
-                out.extend(std::mem::take(&mut *map));
-            }
-        }
-        out
+    fn finish(self) {
+        _ = self.tx.send(self.map);
     }
 }
 
@@ -1658,25 +1638,28 @@ fn find_used_blobs<S>(
         .try_collect()?;
     p.finish();
 
-    let ids = Arc::new(ShardedUsedIds::new());
-    for id in &snap_trees {
-        ids.insert(BlobId::from(**id));
-    }
+    let mut ids: HashMap<_, _> = snap_trees
+        .iter()
+        .map(|id| (BlobId::from(**id), 0))
+        .collect();
     let p = repo.progress_counter("finding used blobs...");
-    let ids_loader = Arc::clone(&ids);
-
+    let (maps_tx, maps_rx) = mpsc::channel();
     let mut tree_streamer =
-        TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, move |used| {
-            for id in &used.file_blobs {
-                ids_loader.insert(BlobId::from(*id));
-            }
-            for id in &used.dir_trees {
-                ids_loader.insert(BlobId::from(*id));
+        TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, {
+            let maps_tx = maps_tx.clone();
+            move || UsedIdAcc {
+                map: HashMap::new(),
+                tx: maps_tx.clone(),
             }
         })?;
+    drop(maps_tx);
     while let Some(item) = tree_streamer.next().transpose()? {
         let _ = item;
     }
+    drop(tree_streamer);
+    while let Ok(map) = maps_rx.recv() {
+        ids.extend(map);
+    }
 
-    Ok(ids.take_hashmap())
+    Ok(ids)
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -4,7 +4,7 @@
 /// accessors along with logging macros. Customize as you see fit.
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     str::FromStr,
     sync::mpsc::{self, Sender},
 };
@@ -17,6 +17,7 @@ use itertools::Itertools;
 use jiff::{Span, Timestamp, Zoned};
 use log::{info, warn};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -42,6 +43,8 @@ use crate::{
     },
     repository::{Open, Repository},
 };
+
+type UsedIdMap = FxHashMap<BlobId, u8>;
 
 pub(super) mod constants {
     /// Minimum size of an index file to be considered for pruning
@@ -584,7 +587,7 @@ pub struct PrunePlan {
     /// The time the plan was created
     time: Zoned,
     /// The ids of the blobs which are used
-    used_ids: HashMap<BlobId, u8>,
+    used_ids: UsedIdMap,
     /// The ids of the existing packs
     existing_packs: BTreeMap<PackId, u32>,
     /// The packs which should be repacked
@@ -604,7 +607,7 @@ impl PrunePlan {
     /// * `existing_packs` - The ids of the existing packs
     /// * `index_files` - The index files
     fn new(
-        used_ids: HashMap<BlobId, u8>,
+        used_ids: UsedIdMap,
         existing_packs: BTreeMap<PackId, u32>,
         index_files: Vec<(IndexId, IndexFile)>,
     ) -> Self {
@@ -1508,7 +1511,7 @@ impl PackInfo {
     ///
     /// * `pack` - The `PrunePack` to create the `PackInfo` from
     /// * `used_ids` - The map of used ids
-    fn from_pack(pack: &PrunePack, used_ids: &mut HashMap<BlobId, u8>) -> Self {
+    fn from_pack(pack: &PrunePack, used_ids: &mut UsedIdMap) -> Self {
         let mut pi = Self {
             blob_type: pack.blob_type,
             used_blobs: 0,
@@ -1586,8 +1589,8 @@ impl PackInfo {
 
 /// Per-loader used-id map. Inserts take no lock; maps are merged after the walk.
 struct UsedIdAcc {
-    map: HashMap<BlobId, u8>,
-    tx: Sender<HashMap<BlobId, u8>>,
+    map: UsedIdMap,
+    tx: Sender<UsedIdMap>,
 }
 
 impl OnTreeLoad<UsedBlobsTree> for UsedIdAcc {
@@ -1621,7 +1624,7 @@ fn find_used_blobs<S>(
     be: &impl DecryptReadBackend,
     index: &impl ReadGlobalIndex,
     ignore_snaps: &[SnapshotId],
-) -> RusticResult<HashMap<BlobId, u8>> {
+) -> RusticResult<UsedIdMap> {
     let ignore_snaps: BTreeSet<_> = ignore_snaps.iter().collect();
 
     let p = repo.progress_counter("reading snapshots...");
@@ -1638,7 +1641,7 @@ fn find_used_blobs<S>(
         .try_collect()?;
     p.finish();
 
-    let mut ids: HashMap<_, _> = snap_trees
+    let mut ids: UsedIdMap = snap_trees
         .iter()
         .map(|id| (BlobId::from(**id), 0))
         .collect();
@@ -1648,7 +1651,7 @@ fn find_used_blobs<S>(
         TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, {
             let maps_tx = maps_tx.clone();
             move || UsedIdAcc {
-                map: HashMap::new(),
+                map: UsedIdMap::default(),
                 tx: maps_tx.clone(),
             }
         })?;

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -62,7 +62,7 @@ impl Hasher for UsedIdHasher {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct UsedId(BlobId);
 
 impl Hash for UsedId {
@@ -77,8 +77,8 @@ type UsedIdMap = HashMap<UsedId, u8, BuildHasherDefault<UsedIdHasher>>;
 pub(super) mod constants {
     /// Minimum size of an index file to be considered for pruning
     pub(super) const MIN_INDEX_LEN: usize = 10_000;
-    /// Per-loader used-id map start size. Avoids grow/rehash during the walk.
-    pub(super) const USED_ID_MAP_CAP: usize = 1 << 21;
+    /// Per-loader used-id vec start size. Avoids grow during the walk.
+    pub(super) const USED_ID_VEC_CAP: usize = 1 << 21;
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -1617,24 +1617,35 @@ impl PackInfo {
     }
 }
 
-/// Per-loader used-id map. Inserts take no lock; maps are merged after the walk.
+/// Per-loader used-id list. Push during the walk; sort+dedup in `finish`.
 struct UsedIdAcc {
-    map: UsedIdMap,
-    tx: Sender<UsedIdMap>,
+    ids: Vec<UsedId>,
+    tx: Sender<Vec<UsedId>>,
 }
 
 impl OnTreeLoad<UsedBlobsTree> for UsedIdAcc {
     fn on_load(&mut self, tree: &UsedBlobsTree) {
-        for id in &tree.file_blobs {
-            _ = self.map.insert(UsedId(BlobId::from(*id)), 0);
-        }
-        for id in &tree.dir_trees {
-            _ = self.map.insert(UsedId(BlobId::from(*id)), 0);
-        }
+        self.ids
+            .reserve(tree.file_blobs.len() + tree.dir_trees.len());
+        self.ids.extend(
+            tree.file_blobs
+                .iter()
+                .copied()
+                .map(|id| UsedId(BlobId::from(id))),
+        );
+        self.ids.extend(
+            tree.dir_trees
+                .iter()
+                .copied()
+                .map(|id| UsedId(BlobId::from(id))),
+        );
     }
 
     fn finish(self) {
-        _ = self.tx.send(self.map);
+        let mut ids = self.ids;
+        ids.sort_unstable();
+        ids.dedup();
+        _ = self.tx.send(ids);
     }
 }
 
@@ -1676,27 +1687,24 @@ fn find_used_blobs<S>(
         .map(|id| (UsedId(BlobId::from(**id)), 0))
         .collect();
     let p = repo.progress_counter("finding used blobs...");
-    let (maps_tx, maps_rx) = mpsc::channel();
+    let (ids_tx, ids_rx) = mpsc::channel();
     let mut tree_streamer =
         TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, {
-            let maps_tx = maps_tx.clone();
+            let ids_tx = ids_tx.clone();
             move || UsedIdAcc {
-                map: UsedIdMap::with_capacity_and_hasher(
-                    constants::USED_ID_MAP_CAP,
-                    BuildHasherDefault::default(),
-                ),
-                tx: maps_tx.clone(),
+                ids: Vec::with_capacity(constants::USED_ID_VEC_CAP),
+                tx: ids_tx.clone(),
             }
         })?;
-    drop(maps_tx);
+    drop(ids_tx);
     while let Some(item) = tree_streamer.next().transpose()? {
         let _ = item;
     }
     drop(tree_streamer);
-    let maps: Vec<_> = maps_rx.iter().collect();
-    ids.reserve(maps.iter().map(HashMap::len).sum());
-    for map in maps {
-        ids.extend(map);
+    let lists: Vec<_> = ids_rx.iter().collect();
+    ids.reserve(lists.iter().map(Vec::len).sum());
+    for list in lists {
+        ids.extend(list.into_iter().map(|id| (id, 0)));
     }
 
     Ok(ids)
@@ -1736,5 +1744,16 @@ mod used_id_hash_tests {
         assert!(map.insert(b, 1).is_none());
         assert_eq!(map.get(&a).copied(), Some(0));
         assert_eq!(map.get(&b).copied(), Some(1));
+    }
+
+    #[test]
+    fn sort_dedup_keeps_unique_ids() {
+        let a = UsedId(blob(ID_A));
+        let b = UsedId(blob(ID_B));
+        let c = UsedId(blob(ID_C));
+        let mut ids = vec![c, a, a, b, c, a];
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids, vec![a, b, c]);
     }
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -91,9 +91,14 @@ impl Default for UsedIdMap {
 }
 
 impl UsedIdMap {
+    /// Shard by bits 28–31 of the id prefix. `UsedIdHasher` feeds the same
+    /// prefix to hashbrown, which takes bucket positions from the low bits and
+    /// the tag byte from the top 7, so sharding on either would leave every
+    /// key in a shard sharing those bits and cost extra probing.
     #[inline]
     fn shard(id: &UsedId) -> usize {
-        usize::try_from(id.0.as_u64() & (constants::USED_ID_SHARDS as u64 - 1)).unwrap_or(0)
+        usize::try_from((id.0.as_u64() >> 28) & (constants::USED_ID_SHARDS as u64 - 1))
+            .unwrap_or(0)
     }
 
     fn from_lists(lists: Vec<Vec<UsedId>>) -> Self {

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -22,12 +22,11 @@ use crate::{
     backend::{
         FileType, ReadBackend,
         decrypt::{DecryptReadBackend, DecryptWriteBackend},
-        node::NodeType,
     },
     blob::{
         BlobId, BlobLocations, BlobType, BlobTypeMap, Initialize,
         packer::{BlobCopier, CopyPackBlobs, PackSizer},
-        tree::TreeStreamerOnce,
+        tree::{TreeStreamer, UsedBlobsTree},
     },
     error::{ErrorKind, RusticError, RusticResult},
     index::{
@@ -1608,25 +1607,11 @@ fn find_used_blobs<S>(
         .collect();
     let p = repo.progress_counter("finding used blobs...");
 
-    let mut tree_streamer = TreeStreamerOnce::new(be, index, snap_trees, p)?;
+    let mut tree_streamer = TreeStreamer::<UsedBlobsTree>::new(be, index, snap_trees, p)?;
     while let Some(item) = tree_streamer.next().transpose()? {
-        let (_, tree) = item;
-        for node in tree.nodes {
-            match node.node_type {
-                NodeType::File => {
-                    ids.extend(
-                        node.content
-                            .iter()
-                            .flatten()
-                            .map(|id| (BlobId::from(**id), 0)),
-                    );
-                }
-                NodeType::Dir => {
-                    _ = ids.insert(BlobId::from(*node.subtree.unwrap()), 0);
-                }
-                _ => {} // nothing to do
-            }
-        }
+        let (_, used) = item;
+        ids.extend(used.file_blobs.into_iter().map(|id| (BlobId::from(id), 0)));
+        ids.extend(used.dir_trees.into_iter().map(|id| (BlobId::from(id), 0)));
     }
 
     Ok(ids)

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -97,8 +97,7 @@ impl UsedIdMap {
     /// key in a shard sharing those bits and cost extra probing.
     #[inline]
     fn shard(id: &UsedId) -> usize {
-        usize::try_from((id.0.as_u64() >> 28) & (constants::USED_ID_SHARDS as u64 - 1))
-            .unwrap_or(0)
+        usize::try_from((id.0.as_u64() >> 28) & (constants::USED_ID_SHARDS as u64 - 1)).unwrap_or(0)
     }
 
     fn from_lists(lists: Vec<Vec<UsedId>>) -> Self {
@@ -156,9 +155,6 @@ impl UsedIdMap {
 pub(super) mod constants {
     /// Minimum size of an index file to be considered for pruning
     pub(super) const MIN_INDEX_LEN: usize = 10_000;
-    /// Per-loader used-id vec start size. Avoids grow during the walk.
-    /// ~22M unique blobs / 8 loaders plus dups; 4M slots is 128 MiB/loader.
-    pub(super) const USED_ID_VEC_CAP: usize = 1 << 22;
     /// Parallel `HashMap` shards for the used-id merge. Power of two.
     pub(super) const USED_ID_SHARDS: usize = 16;
 }
@@ -1705,6 +1701,16 @@ struct UsedIdAcc {
     tx: Sender<Vec<UsedId>>,
 }
 
+impl UsedIdAcc {
+    fn new(tx: Sender<Vec<UsedId>>) -> Self {
+        // Allocate only for references actually encountered by this loader.
+        Self {
+            ids: Vec::new(),
+            tx,
+        }
+    }
+}
+
 impl OnTreeLoad<UsedBlobsTree> for UsedIdAcc {
     fn on_load(&mut self, tree: &UsedBlobsTree) {
         self.ids
@@ -1773,10 +1779,7 @@ fn find_used_blobs<S>(
     let mut tree_streamer =
         TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, {
             let ids_tx = ids_tx.clone();
-            move || UsedIdAcc {
-                ids: Vec::with_capacity(constants::USED_ID_VEC_CAP),
-                tx: ids_tx.clone(),
-            }
+            move || UsedIdAcc::new(ids_tx.clone())
         })?;
     drop(ids_tx);
     while let Some(item) = tree_streamer.next().transpose()? {
@@ -1800,6 +1803,23 @@ mod used_id_hash_tests {
 
     fn blob(s: &str) -> BlobId {
         BlobId::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn loader_allocates_for_actual_references_and_preserves_ids() {
+        let (tx, rx) = mpsc::channel();
+        let mut loader = UsedIdAcc::new(tx);
+        assert_eq!(loader.ids.capacity(), 0);
+        let tree = UsedBlobsTree {
+            file_blobs: vec![ID_A.parse().unwrap(); 3],
+            dir_trees: vec![ID_C.parse().unwrap()],
+        };
+        loader.on_load(&tree);
+        loader.on_load(&tree);
+        assert!(loader.ids.capacity() < 1024);
+        loader.finish();
+        let ids = rx.recv().unwrap();
+        assert_eq!(ids, vec![UsedId(blob(ID_A)), UsedId(blob(ID_C))]);
     }
 
     #[test]

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -4,7 +4,8 @@
 /// accessors along with logging macros. Customize as you see fit.
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
+    hash::{BuildHasherDefault, Hash, Hasher},
     str::FromStr,
     sync::mpsc::{self, Sender},
 };
@@ -17,7 +18,6 @@ use itertools::Itertools;
 use jiff::{Span, Timestamp, Zoned};
 use log::{info, warn};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -44,11 +44,41 @@ use crate::{
     repository::{Open, Repository},
 };
 
-type UsedIdMap = FxHashMap<BlobId, u8>;
+/// SHA-256 blob ids are already uniform; use the first 8 bytes as the hash.
+#[derive(Default)]
+struct UsedIdHasher(u64);
+
+impl Hasher for UsedIdHasher {
+    fn write(&mut self, _: &[u8]) {}
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct UsedId(BlobId);
+
+impl Hash for UsedId {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.0.as_u64());
+    }
+}
+
+type UsedIdMap = HashMap<UsedId, u8, BuildHasherDefault<UsedIdHasher>>;
 
 pub(super) mod constants {
     /// Minimum size of an index file to be considered for pruning
     pub(super) const MIN_INDEX_LEN: usize = 10_000;
+    /// Per-loader used-id map start size. Avoids grow/rehash during the walk.
+    pub(super) const USED_ID_MAP_CAP: usize = 1 << 21;
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -792,7 +822,7 @@ impl PrunePlan {
             .flat_map(|index| &index.packs)
             .flat_map(|pack| &pack.blobs)
         {
-            if let Some(count) = self.used_ids.get_mut(&blob.id) {
+            if let Some(count) = self.used_ids.get_mut(&UsedId(blob.id)) {
                 // note that duplicates are only counted up to 255. If there are more
                 // duplicates, the number is set to 255. This may imply that later on
                 // not the "best" pack is chosen to have that blob marked as used.
@@ -813,7 +843,7 @@ impl PrunePlan {
                     ErrorKind::Internal,
                     "Blob ID `{blob_id}` is missing in index files.",
                 )
-                .attach_context("blob_id", id.to_string())
+                .attach_context("blob_id", id.0.to_string())
                 .ask_report());
             }
         }
@@ -1109,7 +1139,7 @@ impl PrunePlan {
                 }
                 PackToDo::Keep | PackToDo::Recover => {
                     for blob in &pack.blobs {
-                        _ = self.used_ids.remove(&blob.id);
+                        _ = self.used_ids.remove(&UsedId(blob.id));
                     }
                     check_size()?;
                 }
@@ -1336,7 +1366,7 @@ pub(crate) fn prune_repository<S: Open>(
                         indexer.add_remove(pack)?;
                     }
                     pack.blobs
-                        .retain(|blob| used_ids.remove(&blob.id).is_some()); // don't save duplicate blobs
+                        .retain(|blob| used_ids.remove(&UsedId(blob.id)).is_some()); // don't save duplicate blobs
                     // sort blobs to later allow coalescing
                     pack.blobs.sort_unstable();
                     repack_packs.push(pack);
@@ -1528,7 +1558,7 @@ impl PackInfo {
         // If we found a needed blob, we stop and process the information that the pack is actually needed.
         let first_needed = pack.blobs.iter().position(|blob| {
             let length = blob.location.length;
-            match used_ids.get_mut(&blob.id) {
+            match used_ids.get_mut(&UsedId(blob.id)) {
                 None | Some(0) => {
                     pi.unused_size += length;
                     pi.unused_blobs += 1;
@@ -1554,7 +1584,7 @@ impl PackInfo {
             // The pack is actually needed.
             // We reprocess the blobs up to the first needed one and mark all blobs which are generally needed as used.
             for blob in &pack.blobs[..first_needed] {
-                match used_ids.get_mut(&blob.id) {
+                match used_ids.get_mut(&UsedId(blob.id)) {
                     None | Some(0) => {} // already correctly marked
                     Some(count) => {
                         // remark blob as used
@@ -1568,7 +1598,7 @@ impl PackInfo {
             }
             // Then we process the remaining blobs and mark all blobs which are generally needed as used in this blob
             for blob in &pack.blobs[first_needed + 1..] {
-                match used_ids.get_mut(&blob.id) {
+                match used_ids.get_mut(&UsedId(blob.id)) {
                     None | Some(0) => {
                         pi.unused_size += blob.location.length;
                         pi.unused_blobs += 1;
@@ -1596,10 +1626,10 @@ struct UsedIdAcc {
 impl OnTreeLoad<UsedBlobsTree> for UsedIdAcc {
     fn on_load(&mut self, tree: &UsedBlobsTree) {
         for id in &tree.file_blobs {
-            _ = self.map.insert(BlobId::from(*id), 0);
+            _ = self.map.insert(UsedId(BlobId::from(*id)), 0);
         }
         for id in &tree.dir_trees {
-            _ = self.map.insert(BlobId::from(*id), 0);
+            _ = self.map.insert(UsedId(BlobId::from(*id)), 0);
         }
     }
 
@@ -1643,7 +1673,7 @@ fn find_used_blobs<S>(
 
     let mut ids: UsedIdMap = snap_trees
         .iter()
-        .map(|id| (BlobId::from(**id), 0))
+        .map(|id| (UsedId(BlobId::from(**id)), 0))
         .collect();
     let p = repo.progress_counter("finding used blobs...");
     let (maps_tx, maps_rx) = mpsc::channel();
@@ -1651,7 +1681,10 @@ fn find_used_blobs<S>(
         TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, {
             let maps_tx = maps_tx.clone();
             move || UsedIdAcc {
-                map: UsedIdMap::default(),
+                map: UsedIdMap::with_capacity_and_hasher(
+                    constants::USED_ID_MAP_CAP,
+                    BuildHasherDefault::default(),
+                ),
                 tx: maps_tx.clone(),
             }
         })?;
@@ -1660,9 +1693,48 @@ fn find_used_blobs<S>(
         let _ = item;
     }
     drop(tree_streamer);
-    while let Ok(map) = maps_rx.recv() {
+    let maps: Vec<_> = maps_rx.iter().collect();
+    ids.reserve(maps.iter().map(HashMap::len).sum());
+    for map in maps {
         ids.extend(map);
     }
 
     Ok(ids)
+}
+
+#[cfg(test)]
+mod used_id_hash_tests {
+    use super::*;
+    use std::hash::BuildHasher;
+    use std::str::FromStr;
+
+    const ID_A: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const ID_B: &str = "0123456789abcdefffffffffffffffffffffffffffffffffffffffffffffffff";
+    const ID_C: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    fn blob(s: &str) -> BlobId {
+        BlobId::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn hash_is_first_eight_bytes_and_collides_only_on_prefix() {
+        let hasher = BuildHasherDefault::<UsedIdHasher>::default();
+        let a = UsedId(blob(ID_A));
+        let b = UsedId(blob(ID_B));
+        let c = UsedId(blob(ID_C));
+        assert_eq!(hasher.hash_one(&a), a.0.as_u64());
+        assert_eq!(
+            hasher.hash_one(&a),
+            u64::from_le_bytes([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+        );
+        assert_eq!(hasher.hash_one(&a), hasher.hash_one(&b));
+        assert_ne!(a, b);
+        assert_ne!(hasher.hash_one(&a), hasher.hash_one(&c));
+
+        let mut map = UsedIdMap::default();
+        assert!(map.insert(a, 0).is_none());
+        assert!(map.insert(b, 1).is_none());
+        assert_eq!(map.get(&a).copied(), Some(0));
+        assert_eq!(map.get(&b).copied(), Some(1));
+    }
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -6,6 +6,7 @@ use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
     str::FromStr,
+    sync::{Arc, Mutex},
 };
 
 use bytesize::ByteSize;
@@ -1583,6 +1584,47 @@ impl PackInfo {
     }
 }
 
+const USED_ID_SHARDS: usize = 16;
+
+/// Used blob ids filled from tree-loader threads.
+///
+/// A single `HashMap` on the streamer consumer serialized prune's used-blob
+/// walk. Shard so loaders insert without that bottleneck.
+struct ShardedUsedIds {
+    shards: [Mutex<HashMap<BlobId, u8>>; USED_ID_SHARDS],
+}
+
+impl ShardedUsedIds {
+    fn new() -> Self {
+        Self {
+            shards: std::array::from_fn(|_| Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn insert(&self, id: BlobId) {
+        let i = (id.as_u32() as usize) & (USED_ID_SHARDS - 1);
+        _ = self.shards[i]
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(id, 0);
+    }
+
+    fn take_hashmap(&self) -> HashMap<BlobId, u8> {
+        let mut out = HashMap::new();
+        for shard in &self.shards {
+            let mut map = shard
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if out.is_empty() {
+                out = std::mem::take(&mut *map);
+            } else {
+                out.extend(std::mem::take(&mut *map));
+            }
+        }
+        out
+    }
+}
+
 /// Find used blobs in repo and return a map of used ids.
 ///
 /// # Arguments
@@ -1616,18 +1658,25 @@ fn find_used_blobs<S>(
         .try_collect()?;
     p.finish();
 
-    let mut ids: HashMap<_, _> = snap_trees
-        .iter()
-        .map(|id| (BlobId::from(**id), 0))
-        .collect();
+    let ids = Arc::new(ShardedUsedIds::new());
+    for id in &snap_trees {
+        ids.insert(BlobId::from(**id));
+    }
     let p = repo.progress_counter("finding used blobs...");
+    let ids_loader = Arc::clone(&ids);
 
-    let mut tree_streamer = TreeStreamer::<UsedBlobsTree>::new(be, index, snap_trees, p)?;
+    let mut tree_streamer =
+        TreeStreamer::<UsedBlobsTree>::new_with_on_load(be, index, snap_trees, p, move |used| {
+            for id in &used.file_blobs {
+                ids_loader.insert(BlobId::from(*id));
+            }
+            for id in &used.dir_trees {
+                ids_loader.insert(BlobId::from(*id));
+            }
+        })?;
     while let Some(item) = tree_streamer.next().transpose()? {
-        let (_, used) = item;
-        ids.extend(used.file_blobs.into_iter().map(|id| (BlobId::from(id), 0)));
-        ids.extend(used.dir_trees.into_iter().map(|id| (BlobId::from(id), 0)));
+        let _ = item;
     }
 
-    Ok(ids)
+    Ok(ids.take_hashmap())
 }

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -703,6 +703,13 @@ impl PrunePlan {
 
         let mut index_files = Vec::new();
 
+        // Pack listing is a full B2 prefix walk and does not depend on the
+        // index or used-blob set. Run it while we read the index and trees.
+        let pack_list = {
+            let be = be.clone();
+            std::thread::spawn(move || be.list_with_size(FileType::Pack))
+        };
+
         let p = repo.progress_counter("reading index...");
         let mut index_collector = IndexCollector::new(IndexType::OnlyTrees);
 
@@ -724,13 +731,20 @@ impl PrunePlan {
             (used_ids, total_size)
         };
 
-        // list existing pack files
+        // list existing pack files (started before index/tree work)
         let p = repo.progress_spinner("getting packs from repository...");
-        let existing_packs: BTreeMap<_, _> = be
-            .list_with_size(FileType::Pack)?
-            .into_iter()
-            .map(|(id, size)| (PackId::from(id), size))
-            .collect();
+        let existing_packs: BTreeMap<_, _> = match pack_list.join() {
+            Ok(listed) => listed?
+                .into_iter()
+                .map(|(id, size)| (PackId::from(id), size))
+                .collect(),
+            Err(_) => {
+                return Err(RusticError::new(
+                    ErrorKind::Internal,
+                    "Pack listing thread panicked.",
+                ));
+            }
+        };
         p.finish();
 
         let mut pruner = Self::new(used_ids, existing_packs, index_files);

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -703,13 +703,6 @@ impl PrunePlan {
 
         let mut index_files = Vec::new();
 
-        // Pack listing is a full B2 prefix walk and does not depend on the
-        // index or used-blob set. Run it while we read the index and trees.
-        let pack_list = {
-            let be = be.clone();
-            std::thread::spawn(move || be.list_with_size(FileType::Pack))
-        };
-
         let p = repo.progress_counter("reading index...");
         let mut index_collector = IndexCollector::new(IndexType::OnlyTrees);
 
@@ -724,6 +717,14 @@ impl PrunePlan {
         }
         p.finish();
 
+        // Pack listing does not need the used-blob set. Start it after the
+        // index so it does not steal B2 from index GETs, and overlap it with
+        // the tree walk instead.
+        let pack_list = {
+            let be = be.clone();
+            std::thread::spawn(move || be.list_with_size(FileType::Pack))
+        };
+
         let (used_ids, total_size) = {
             let index = GlobalIndex::new_from_index(index_collector.into_index());
             let total_size = BlobTypeMap::init(|blob_type| index.total_size(blob_type));
@@ -731,7 +732,7 @@ impl PrunePlan {
             (used_ids, total_size)
         };
 
-        // list existing pack files (started before index/tree work)
+        // list existing pack files (started before the tree walk)
         let p = repo.progress_spinner("getting packs from repository...");
         let existing_packs: BTreeMap<_, _> = match pack_list.join() {
             Ok(listed) => listed?

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -1416,14 +1416,15 @@ pub(crate) fn prune_repository<S: Open>(
                     })
                     .collect();
 
-                // TODO: repack in parallel
-                for blobs in blob_chunks {
+                // Range-GETs for holes in the same pack run in parallel. The
+                // packer already serializes writes via its channel / lock.
+                blob_chunks.into_par_iter().try_for_each(|blobs| {
                     if opts.fast_repack {
-                        repacker.copy_fast(blobs, &p)?;
+                        repacker.copy_fast(blobs, &p)
                     } else {
-                        repacker.copy(blobs, &p)?;
+                        repacker.copy(blobs, &p)
                     }
-                }
+                })?;
                 Ok(())
             })?;
         _ = tree_repacker.finalize()?;

--- a/crates/core/src/commands/prune.rs
+++ b/crates/core/src/commands/prune.rs
@@ -4,7 +4,7 @@
 /// accessors along with logging macros. Customize as you see fit.
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     str::FromStr,
 };
 
@@ -584,7 +584,7 @@ pub struct PrunePlan {
     /// The time the plan was created
     time: Zoned,
     /// The ids of the blobs which are used
-    used_ids: BTreeMap<BlobId, u8>,
+    used_ids: HashMap<BlobId, u8>,
     /// The ids of the existing packs
     existing_packs: BTreeMap<PackId, u32>,
     /// The packs which should be repacked
@@ -604,7 +604,7 @@ impl PrunePlan {
     /// * `existing_packs` - The ids of the existing packs
     /// * `index_files` - The index files
     fn new(
-        used_ids: BTreeMap<BlobId, u8>,
+        used_ids: HashMap<BlobId, u8>,
         existing_packs: BTreeMap<PackId, u32>,
         index_files: Vec<(IndexId, IndexFile)>,
     ) -> Self {
@@ -1492,8 +1492,8 @@ impl PackInfo {
     /// # Arguments
     ///
     /// * `pack` - The `PrunePack` to create the `PackInfo` from
-    /// * `used_ids` - The `BTreeMap` of used ids
-    fn from_pack(pack: &PrunePack, used_ids: &mut BTreeMap<BlobId, u8>) -> Self {
+    /// * `used_ids` - The map of used ids
+    fn from_pack(pack: &PrunePack, used_ids: &mut HashMap<BlobId, u8>) -> Self {
         let mut pi = Self {
             blob_type: pack.blob_type,
             used_blobs: 0,
@@ -1585,7 +1585,7 @@ fn find_used_blobs<S>(
     be: &impl DecryptReadBackend,
     index: &impl ReadGlobalIndex,
     ignore_snaps: &[SnapshotId],
-) -> RusticResult<BTreeMap<BlobId, u8>> {
+) -> RusticResult<HashMap<BlobId, u8>> {
     let ignore_snaps: BTreeSet<_> = ignore_snaps.iter().collect();
 
     let p = repo.progress_counter("reading snapshots...");
@@ -1602,7 +1602,7 @@ fn find_used_blobs<S>(
         .try_collect()?;
     p.finish();
 
-    let mut ids: BTreeMap<_, _> = snap_trees
+    let mut ids: HashMap<_, _> = snap_trees
         .iter()
         .map(|id| (BlobId::from(**id), 0))
         .collect();

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -209,6 +209,18 @@ impl Id {
         u32::from_le_bytes([self.0[0], self.0[1], self.0[2], self.0[3]])
     }
 
+    /// Returns the first 8 bytes as `u64` (little endian).
+    ///
+    /// SHA-256 ids are uniform, so this is enough to bucket a used-blob map
+    /// without hashing all 32 bytes. Equality is still the full id.
+    #[inline]
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        u64::from_le_bytes([
+            self.0[0], self.0[1], self.0[2], self.0[3], self.0[4], self.0[5], self.0[6], self.0[7],
+        ])
+    }
+
     /// Finds the [`Id`]s starting with the given strings from an iterator over [`Id`]s.
     /// # Type Parameters
     ///

--- a/crates/core/src/index.rs
+++ b/crates/core/src/index.rs
@@ -65,6 +65,25 @@ impl IndexEntry {
         Ok(data)
     }
 
+    /// Decrypt and decompress this blob, then run `f` on the plaintext.
+    ///
+    /// Prune tree walking uses this so zstd output can stay in a thread-local
+    /// buffer instead of a new `Vec`/`Bytes` per tree.
+    pub fn with_decoded<B, R, F>(&self, be: &B, f: F) -> RusticResult<R>
+    where
+        B: DecryptReadBackend,
+        F: FnOnce(&[u8]) -> RusticResult<R>,
+    {
+        let cipher = be.read_partial(
+            FileType::Pack,
+            &self.pack,
+            self.blob_type.is_cacheable(),
+            self.location.offset,
+            self.location.length,
+        )?;
+        be.with_decoded_from_partial(&cipher, self.location.uncompressed_length, f)
+    }
+
     /// Get the length of the data described by the [`IndexEntry`]
     #[must_use]
     pub const fn data_length(&self) -> u32 {

--- a/crates/core/src/index/binarysorted.rs
+++ b/crates/core/src/index/binarysorted.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use rayon::prelude::*;
 
 use crate::{
@@ -20,6 +22,77 @@ pub(crate) struct SortedEntry {
     location: BlobLocation,
 }
 
+/// Max entries in one collector chunk.
+///
+/// Growing a single `Vec` of blob ids doubles it. On a large repo that request
+/// is hundreds of MiB while the old buffer is still live, and musl aborts:
+/// `memory allocation of N bytes failed`. Chunks cap each allocation.
+const ENTRY_CHUNK_LEN: usize = if cfg!(test) { 4 } else { 1 << 20 };
+
+/// Append-only vec of bounded chunks. Lookups binary-search every chunk.
+#[derive(Debug)]
+pub(crate) struct Chunked<T> {
+    chunks: Vec<Vec<T>>,
+}
+
+impl<T> Default for Chunked<T> {
+    fn default() -> Self {
+        Self { chunks: Vec::new() }
+    }
+}
+
+impl<T> Chunked<T> {
+    fn push(&mut self, item: T) {
+        if self
+            .chunks
+            .last()
+            .is_none_or(|chunk| chunk.len() >= ENTRY_CHUNK_LEN)
+        {
+            self.chunks.push(Vec::with_capacity(ENTRY_CHUNK_LEN));
+        }
+        self.chunks
+            .last_mut()
+            .expect("chunk is created above")
+            .push(item);
+    }
+
+    fn shrink_last(&mut self) {
+        if let Some(last) = self.chunks.last_mut() {
+            last.shrink_to_fit();
+        }
+    }
+
+    fn par_sort_unstable(&mut self)
+    where
+        T: Ord + Send,
+    {
+        self.chunks.par_iter_mut().for_each(|chunk| {
+            chunk.sort_unstable();
+        });
+    }
+
+    fn par_sort_unstable_by<F>(&mut self, compare: F)
+    where
+        T: Send,
+        F: Fn(&T, &T) -> Ordering + Sync,
+    {
+        self.chunks.par_iter_mut().for_each(|chunk| {
+            chunk.sort_unstable_by(&compare);
+        });
+    }
+
+    fn par_sort_unstable_by_key<K, F>(&mut self, f: F)
+    where
+        T: Send,
+        K: Ord,
+        F: Fn(&T) -> K + Sync,
+    {
+        self.chunks.par_iter_mut().for_each(|chunk| {
+            chunk.sort_unstable_by_key(&f);
+        });
+    }
+}
+
 /// `IndexType` determines which information is stored in the index.
 #[derive(Debug, Clone, Copy)]
 pub enum IndexType {
@@ -36,8 +109,8 @@ pub enum IndexType {
 pub(crate) enum EntriesVariants {
     #[default]
     None,
-    Ids(Vec<BlobId>),
-    FullEntries(Vec<SortedEntry>),
+    Ids(Chunked<BlobId>),
+    FullEntries(Chunked<SortedEntry>),
 }
 
 #[derive(Default, Debug)]
@@ -54,7 +127,8 @@ pub struct IndexCollector(BlobTypeMap<TypeIndexCollector>);
 pub struct PackIndexes {
     c: Index,
     tpe: BlobType,
-    idx: BlobTypeMap<(u32, usize)>,
+    pack_idx: BlobTypeMap<u32>,
+    cursors: BlobTypeMap<Vec<usize>>,
 }
 
 #[derive(Debug)]
@@ -89,11 +163,11 @@ impl IndexCollector {
     pub fn new(tpe: IndexType) -> Self {
         let mut collector = Self::default();
 
-        collector.0[BlobType::Tree].entries = EntriesVariants::FullEntries(Vec::new());
+        collector.0[BlobType::Tree].entries = EntriesVariants::FullEntries(Chunked::default());
         collector.0[BlobType::Data].entries = match tpe {
             IndexType::OnlyTrees => EntriesVariants::None,
-            IndexType::DataIds => EntriesVariants::Ids(Vec::new()),
-            IndexType::Full => EntriesVariants::FullEntries(Vec::new()),
+            IndexType::DataIds => EntriesVariants::Ids(Chunked::default()),
+            IndexType::Full => EntriesVariants::FullEntries(Chunked::default()),
         };
 
         collector
@@ -110,8 +184,14 @@ impl IndexCollector {
         Index(self.0.map(|_, mut tc| {
             match &mut tc.entries {
                 EntriesVariants::None => {}
-                EntriesVariants::Ids(ids) => ids.par_sort_unstable(),
-                EntriesVariants::FullEntries(entries) => entries.par_sort_unstable_by_key(|e| e.id),
+                EntriesVariants::Ids(ids) => {
+                    ids.shrink_last();
+                    ids.par_sort_unstable();
+                }
+                EntriesVariants::FullEntries(entries) => {
+                    entries.shrink_last();
+                    entries.par_sort_unstable_by_key(|e| e.id);
+                }
             }
 
             let packs = tc.packs.into_iter().map(|(id, _)| id).collect();
@@ -130,7 +210,6 @@ impl Extend<IndexPack> for IndexCollector {
         T: IntoIterator<Item = IndexPack>,
     {
         for p in iter {
-            let len = p.blobs.len();
             let blob_type = p.blob_type();
             let size = p.pack_size();
 
@@ -139,12 +218,6 @@ impl Extend<IndexPack> for IndexCollector {
             self.0[blob_type].packs.push((p.id, size));
 
             self.0[blob_type].total_size += u64::from(size);
-
-            match &mut self.0[blob_type].entries {
-                EntriesVariants::None => {}
-                EntriesVariants::Ids(idents) => idents.reserve(len),
-                EntriesVariants::FullEntries(entries) => entries.reserve(len),
-            }
 
             for blob in &p.blobs {
                 let be = SortedEntry {
@@ -166,39 +239,45 @@ impl Iterator for PackIndexes {
     type Item = IndexPack;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (pack_idx, idx) = loop {
-            let (pack_idx, idx) = &mut self.idx[self.tpe];
-            let pack_count = u32::try_from(self.c.0[self.tpe].packs.len())
-                .expect("pack count should fit into u32");
-            if *pack_idx >= pack_count {
-                if self.tpe == BlobType::Data {
+        loop {
+            let tpe = self.tpe;
+            let pack_count =
+                u32::try_from(self.c.0[tpe].packs.len()).expect("pack count should fit into u32");
+            if self.pack_idx[tpe] >= pack_count {
+                if tpe == BlobType::Data {
                     return None;
                 }
                 self.tpe = BlobType::Data;
-            } else {
-                break (pack_idx, idx);
+                continue;
             }
-        };
 
-        let mut pack = IndexPack {
-            id: self.c.0[self.tpe].packs[*pack_idx as usize],
-            ..Default::default()
-        };
+            let pack_idx = self.pack_idx[tpe];
+            let mut pack = IndexPack {
+                id: self.c.0[tpe].packs[pack_idx as usize],
+                ..Default::default()
+            };
 
-        if let EntriesVariants::FullEntries(entries) = &self.c.0[self.tpe].entries {
-            while *idx < entries.len() && entries[*idx].pack_idx == *pack_idx {
-                let entry = &entries[*idx];
-                pack.blobs.push(IndexBlob {
-                    id: entry.id,
-                    tpe: self.tpe,
-                    location: entry.location,
-                });
-                *idx += 1;
+            if let EntriesVariants::FullEntries(entries) = &self.c.0[tpe].entries {
+                let cursors = &mut self.cursors[tpe];
+                if cursors.len() != entries.chunks.len() {
+                    cursors.resize(entries.chunks.len(), 0);
+                }
+                for (chunk, cursor) in entries.chunks.iter().zip(cursors.iter_mut()) {
+                    while *cursor < chunk.len() && chunk[*cursor].pack_idx == pack_idx {
+                        let entry = &chunk[*cursor];
+                        pack.blobs.push(IndexBlob {
+                            id: entry.id,
+                            tpe,
+                            location: entry.location,
+                        });
+                        *cursor += 1;
+                    }
+                }
             }
+
+            self.pack_idx[tpe] += 1;
+            return Some(pack);
         }
-        *pack_idx += 1;
-
-        Some(pack)
     }
 }
 
@@ -214,34 +293,32 @@ impl IntoIterator for Index {
             }
         }
         PackIndexes {
-            c: Self(self.0.map(|_, mut tc| {
-                if let EntriesVariants::FullEntries(entries) = &mut tc.entries {
-                    entries.par_sort_unstable_by(|e1, e2| e1.pack_idx.cmp(&e2.pack_idx));
-                }
-
-                tc
-            })),
+            c: self,
             tpe: BlobType::Tree,
-            idx: BlobTypeMap::default(),
+            pack_idx: BlobTypeMap::default(),
+            cursors: BlobTypeMap::default(),
         }
     }
 }
 
 impl ReadIndex for Index {
     fn get_id(&self, blob_type: BlobType, id: &BlobId) -> Option<IndexEntry> {
-        let EntriesVariants::FullEntries(vec) = &self.0[blob_type].entries else {
+        let EntriesVariants::FullEntries(entries) = &self.0[blob_type].entries else {
             // get_id() only gives results if index contains full entries
             return None;
         };
 
-        vec.binary_search_by_key(id, |e| e.id).ok().map(|index| {
-            let be = &vec[index];
-            IndexEntry::new(
-                blob_type,
-                self.0[blob_type].packs[be.pack_idx as usize],
-                be.location,
-            )
-        })
+        for chunk in &entries.chunks {
+            if let Ok(index) = chunk.binary_search_by_key(id, |e| e.id) {
+                let be = &chunk[index];
+                return Some(IndexEntry::new(
+                    blob_type,
+                    self.0[blob_type].packs[be.pack_idx as usize],
+                    be.location,
+                ));
+            }
+        }
+        None
     }
 
     fn total_size(&self, blob_type: BlobType) -> u64 {
@@ -250,10 +327,14 @@ impl ReadIndex for Index {
 
     fn has(&self, blob_type: BlobType, id: &BlobId) -> bool {
         match &self.0[blob_type].entries {
-            EntriesVariants::FullEntries(entries) => {
-                entries.binary_search_by_key(id, |e| e.id).is_ok()
-            }
-            EntriesVariants::Ids(ids) => ids.binary_search(id).is_ok(),
+            EntriesVariants::FullEntries(entries) => entries
+                .chunks
+                .iter()
+                .any(|chunk| chunk.binary_search_by_key(id, |e| e.id).is_ok()),
+            EntriesVariants::Ids(ids) => ids
+                .chunks
+                .iter()
+                .any(|chunk| chunk.binary_search(id).is_ok()),
             // has() only gives results if index contains full entries or ids
             EntriesVariants::None => false,
         }
@@ -439,6 +520,53 @@ mod tests {
         );
         assert!(!index.has(BlobType::Tree, &id));
         assert!(index.get_id(BlobType::Tree, &id).is_none());
+
+        // This id is in the second test-sized chunk (ENTRY_CHUNK_LEN is 4 under cfg(test)).
+        let id = "ee67585c7c53324e74537ab7aa44f889c0767c1b67e7e336fae6204aef2d4c73".parse()?;
+        assert!(index.has(BlobType::Data, &id));
+        assert_eq!(
+            index.get_id(BlobType::Data, &id),
+            Some(IndexEntry {
+                blob_type: BlobType::Data,
+                pack: "3b25ec6d16401c31099c259311562160b1b5efbcf70bd69d0463104d3b8148fc".parse()?,
+                location: BlobLocation {
+                    offset: 7737,
+                    length: 7686,
+                    uncompressed_length: Some(NonZeroU32::new(29928).unwrap()),
+                }
+            }),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn into_iter_groups_blobs_by_pack() -> RusticResult<()> {
+        let packs: Vec<_> = index(IndexType::Full).into_iter().collect();
+        assert_eq!(packs.len(), 3);
+        assert_eq!(
+            packs[0].id,
+            "8431a27d38dd7d192dc37abd43a85d6dc4298de72fc8f583c5d7cdd09fa47274".parse()?
+        );
+        assert_eq!(packs[0].blobs.len(), 2);
+        assert_eq!(
+            packs[1].id,
+            "217f145b63fbc10267f5a686186689ea3389bed0d6a54b50ffc84d71f99eb7fa".parse()?
+        );
+        assert_eq!(packs[1].blobs.len(), 3);
+        assert_eq!(
+            packs[2].id,
+            "3b25ec6d16401c31099c259311562160b1b5efbcf70bd69d0463104d3b8148fc".parse()?
+        );
+        assert_eq!(packs[2].blobs.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn data_ids_has_across_chunks() -> RusticResult<()> {
+        let index = index(IndexType::DataIds);
+        let id = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2".parse()?;
+        assert!(index.has(BlobType::Data, &id));
+        assert!(index.get_id(BlobType::Data, &id).is_none());
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #564.

Stacked on https://github.com/rustic-rs/rustic_core/pull/568. Review the unique range:

https://github.com/BradKollmyer/rustic_core/compare/perf/prune-used-ids...perf/prune-zstd-buffer

Last core PR in the stack: reuse a per-thread zstd output buffer when decoding prune trees.

Warm-cache dry-run vs `34483c9` (LTO off / 16 CGU, mimalloc):

| Host | used-blobs | wall |
|---|---|---|
| Darwin aarch64 | 1:17 → **0:16** | **60.4s** |
| x86_64 musl | 12:40 → **0:33** | 14:41 → **92.9s** |

CLI follow-up (mimalloc + aarch64 AES cfgs) is a separate PR on `rustic-rs/rustic`.